### PR TITLE
Do not capture build kernel version

### DIFF
--- a/build/linux.inc
+++ b/build/linux.inc
@@ -60,11 +60,9 @@ endif
 
 ifndef runtime
         export gcc_version:=$(shell gcc -dumpversion)
-        os_version:=$(shell uname -r)
-        os_kernel_version:=$(shell uname -r | sed -e 's/-.*$$//')
         export os_glibc_version_full:=$(shell getconf GNU_LIBC_VERSION | grep glibc | sed -e 's/^glibc //')
         os_glibc_version:=$(shell echo "$(os_glibc_version_full)" | sed -e '2,$$d' -e 's/-.*$$//')
-        export runtime:=cc$(gcc_version)_libc$(os_glibc_version)_kernel$(os_kernel_version)
+        export runtime:=cc$(gcc_version)_libc$(os_glibc_version)
 endif
 
 native_compiler := gcc


### PR DESCRIPTION
Do not capture build kernel version
so that it does not influence build results.
See https://reproducible-builds.org/ for why this is good.

Also os_version was unused and thus dropped.