### PR TITLE
Remove superfluous semicolons to satisfy -pedantic.

### DIFF
--- a/include/tbb/machine/gcc_generic.h
+++ b/include/tbb/machine/gcc_generic.h
@@ -216,9 +216,9 @@ struct machine_load_store_seq_cst {
 
 // __builtin_clz counts the number of leading zeroes
 namespace tbb{ namespace internal { namespace gcc_builtins {
-    inline int clz(unsigned int x){ return __builtin_clz(x); };
-    inline int clz(unsigned long int x){ return __builtin_clzl(x); };
-    inline int clz(unsigned long long int x){ return __builtin_clzll(x); };
+    inline int clz(unsigned int x){ return __builtin_clz(x); }
+    inline int clz(unsigned long int x){ return __builtin_clzl(x); }
+    inline int clz(unsigned long long int x){ return __builtin_clzll(x); }
 }}}
 // logarithm is the index of the most significant non-zero bit
 static inline intptr_t __TBB_machine_lg( uintptr_t x ) {


### PR DESCRIPTION
Compiling user code with `-pedantic` causes warnings which are turned into errors if the user also has `-Werror` activated.