### PR TITLE
Make test_thread_monitor more reliable.

### DIFF
--- a/src/rml/test/test_thread_monitor.cpp
+++ b/src/rml/test/test_thread_monitor.cpp
@@ -33,21 +33,21 @@ public:
     }
     typedef rml::internal::thread_monitor thread_monitor;
     thread_monitor monitor;
-    volatile int request;
-    volatile int ack;
-    volatile unsigned clock;
-    volatile unsigned stamp;
+    tbb::atomic<int> request;
+    tbb::atomic<int> ack;
+    tbb::atomic<unsigned> clock;
+    unsigned stamp;
     ThreadState() : request(-1), ack(-1), clock(0) {}
 };
 
 void ThreadState::loop() {
     for(;;) {
-        ++clock;
         if( ack==request ) {
             thread_monitor::cookie c;
             monitor.prepare_wait(c);
             if( ack==request ) {
                 REMARK("%p: request=%d ack=%d\n", this, request, ack );
+                ++clock;
                 monitor.commit_wait(c);
             } else
                 monitor.cancel_wait();
@@ -60,7 +60,7 @@ void ThreadState::loop() {
                     rml::internal::thread_monitor::yield();
             }
             int r = request;
-            ack = request;
+            ack = r;
             if( !r ) return;
         }
     }
@@ -89,7 +89,7 @@ int TestMain () {
                                 REPORT("Warning: thread %d not waiting\n",i);
                                 break;
                             }
-                        } while( t[i].stamp!=t[i].clock );
+                        } while( t[i].stamp==0 || t[i].stamp!=t[i].clock );
                     }
                 }
                 REMARK("notifying threads\n");


### PR DESCRIPTION
This is a fix for issue 160.  Multiple problems are addressed.

First, the volatile keyword is not sufficient on architectures with weak memory ordering, such as ppc64le.  The request, ack, and clock fields of ThreadState should be atomic so that accesses to them by multiple threads are done with the necessary memory barriers.  The stamp field does not need to be either volatile or atomic, as it is accessed by the main thread only.

The main thread can decide that a child thread is waiting in the monitor before the child thread even  starts; hence the change to line 92.

There is no need to fetch request from memory twice in a row on lines 62 and 63; just fetch it once and use it twice.

Finally, the increment of clock was done too often.  Two threads, the main thread and a child thread, can get into an endless cycle of changing the clock value and trying to read the same clock value twice in a row.  The tick of the clock value is only needed to signal that a child thread is going to sleep in the monitor ... so only increment if the child thread really is about to go to sleep in the monitor.

With these changes, the test completes reliably on ppc64le.