### PR TITLE
fix for #60 linker warning on iOS/MacOS using clang

### DIFF
--- a/build/macos.clang.inc
+++ b/build/macos.clang.inc
@@ -91,8 +91,8 @@ endif
 
 ifdef SDKROOT
     CPLUS_FLAGS += -isysroot $(SDKROOT)
-    LINK_FLAGS += -L$(SDKROOT)/usr/lib/system -L$(SDKROOT)/usr/lib/
-    LIB_LINK_FLAGS += -L$(SDKROOT)/usr/lib/system -L$(SDKROOT)/usr/lib/
+    LINK_FLAGS += -L$(SDKROOT)/usr/include -L$(SDKROOT)/usr/lib/
+    LIB_LINK_FLAGS += -L$(SDKROOT)/usr/include -L$(SDKROOT)/usr/lib/
 endif
 
 ifeq (ios,$(target))


### PR DESCRIPTION
solves #60  because $(SDKROOT)/usr/lib/system doesn't exist anymore in apple SDK's