### PR TITLE
Fix clang-cl support by avoiding TSX

### DIFF
--- a/include/tbb/tbb_config.h
+++ b/include/tbb/tbb_config.h
@@ -107,7 +107,7 @@
 #define __TBB_DEFINE_MIC 1
 #endif
 
-#define __TBB_TSX_AVAILABLE  ((__TBB_x86_32 || __TBB_x86_64) && !__TBB_DEFINE_MIC)
+#define __TBB_TSX_AVAILABLE  ((__TBB_x86_32 || __TBB_x86_64) && !__TBB_DEFINE_MIC && !(defined(__clang__) && defined(_WIN32)))
 
 /** Presence of compiler features **/
 


### PR DESCRIPTION
We see linker errors with clang-cl as Transactional Synchronization Extensions instructions are not supported, so set TSX_AVAILABLE to off with clang-cl.

We (@fnabulsi, @bmcdb, myself) have only tested with clang-cl 8.0.0, but at the same time I haven't seen any indication that this would change in clang-cl 9.x

This seems to be different from the clang-cl C++11 issue tackled in #198.