### PR TITLE
Fix build on musl

### DIFF
--- a/src/tbbmalloc/proxy.cpp
+++ b/src/tbbmalloc/proxy.cpp
@@ -275,6 +275,7 @@ int mallopt(int /*param*/, int /*value*/) __THROW
     return 1;
 }
 
+#ifdef __GLIBC__
 struct mallinfo mallinfo() __THROW
 {
     struct mallinfo m;
@@ -282,6 +283,7 @@ struct mallinfo mallinfo() __THROW
 
     return m;
 }
+#endif
 
 #if __ANDROID__
 // Android doesn't have malloc_usable_size, provide it to be compatible

--- a/src/tbbmalloc/proxy.cpp
+++ b/src/tbbmalloc/proxy.cpp
@@ -24,7 +24,8 @@
 // of aligned_alloc as required by new C++ standard, this makes it hard to
 // redefine aligned_alloc here. However, running on systems with new libc
 // version, it still needs it to be redefined, thus tricking system headers
-#if defined(__GLIBC_PREREQ) && !__GLIBC_PREREQ(2, 16) && _GLIBCXX_HAVE_ALIGNED_ALLOC
+#if defined(__GLIBC_PREREQ)
+#if !__GLIBC_PREREQ(2, 16) && _GLIBCXX_HAVE_ALIGNED_ALLOC
 // tell <cstdlib> that there is no aligned_alloc
 #undef _GLIBCXX_HAVE_ALIGNED_ALLOC
 // trick <stdlib.h> to define another symbol instead
@@ -32,7 +33,8 @@
 // Fix the state and undefine the trick
 #include <cstdlib>
 #undef aligned_alloc
-#endif // defined(__GLIBC_PREREQ)&&!__GLIBC_PREREQ(2, 16)&&_GLIBCXX_HAVE_ALIGNED_ALLOC
+#endif // !__GLIBC_PREREQ(2, 16)&&_GLIBCXX_HAVE_ALIGNED_ALLOC
+#endif // defined(__GLIBC_PREREQ)
 #endif // __linux__ && !__ANDROID__
 
 #include "proxy.h"


### PR DESCRIPTION
This Pull Request adds two commits to fix build on musl:
-  first commit ensures that `__GLIBC_PREREQ` is not called if it is not defined otherwise build will
fail on musl on:
```
../../src/tbbmalloc/proxy.cpp:27:47: error: missing binary operator before token "("
 #if defined(__GLIBC_PREREQ) && !__GLIBC_PREREQ(2, 16) && _GLIBCXX_HAVE_ALIGNED_ALLOC
                                               ^
```
 - second commit ensures that `mallinfo` is not called as it is not defined on musl. This commit was retrieved from openembedded (https://github.com/openembedded/meta-openembedded/blob/master/meta-oe/recipes-support/tbb/tbb/0001-mallinfo-is-glibc-specific-API-mark-it-so.patch). Without it, build fails on:
```
../../src/tbbmalloc/proxy.cpp: In function ‘mallinfo mallinfo()’:
../../src/tbbmalloc/proxy.cpp:278:26: error: return type ‘struct mallinfo’ is incomplete
 struct mallinfo mallinfo() __THROW
                          ^
../../src/tbbmalloc/proxy.cpp:280:21: error: aggregate ‘mallinfo m’ has incomplete type and cannot be defined
     struct mallinfo m;
                     ^
../../src/tbbmalloc/proxy.cpp:281:41: error: invalid application of ‘sizeof’ to incomplete type ‘mallinfo’
     memset(&m, 0, sizeof(struct mallinfo));
                                         ^
```

Both patches are needed to fix build of latest tbb release on buildroot (openembedded does not need first patch as they support an old version of tbb (20170412) that does not include 4cebdd9a1c9f0c56c4ddcbbb400447ab2a11fad4.