### PR TITLE
TBBBuild.cmake: don't unset result var if MAKE_ARGS are empty

### DIFF
--- a/cmake/TBBBuild.cmake
+++ b/cmake/TBBBuild.cmake
@@ -54,7 +54,7 @@ function(tbb_build)
         set(multiValueArgs USER_DEFINED_ARGS)
         cmake_parse_arguments(tbb_GMA "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-        set(result ${tbb_GMA_USER_DEFINED_ARGS})
+        set(result "${tbb_GMA_USER_DEFINED_ARGS}")
 
         if (NOT tbb_GMA_USER_DEFINED_ARGS MATCHES "compiler=")
             # TODO: add other supported compilers.


### PR DESCRIPTION
See https://gitlab.kitware.com/cmake/cmake/-/issues/20508

### Problem

If the `MAKE_ARGS` argument to the [`tbb_build`](https://github.com/oneapi-src/oneTBB/tree/tbb_2020/cmake#tbbbuild) CMake function is empty, the line `set(result ${tbb_GMA_USER_DEFINED_ARGS})` evaluates to `set(result)`, which unsets the `result` variable, causing CMake to fall back to the `result` cache entry instead of setting a local variable `result` to an empty string.  
This causes the build to fail.

### Solution

By adding quotes around `${tbb_GMA_USER_DEFINED_ARGS}`, it evaluates to `set(result "")` if no arguments are provided, which has the desired effect of creating an empty result variable.  
This doesn't change the functionality, and using `MAKE_ARGS` still works as before.

Merge request [!4528](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/4528) for CMake fixes a problem where CMake's `CheckIPOSupported` function would set a cache entry `result` which conflicted with TBB.

I think it's best to address this problem in TBB as well, in order to support older versions of CMake, and because a generic name like `result` may conflict with other libraries or user code as well.

***

### Steps to reproduce the problem

Create a `CMakeLists.txt` file with the following contents:
```cmake
cmake_minimum_required(VERSION 3.12)
project(TEST)

set(TBB_ROOT "${CMAKE_CURRENT_LIST_DIR}/oneTBB")
include(${TBB_ROOT}/cmake/TBBBuild.cmake)
tbb_build(TBB_ROOT ${TBB_ROOT} CONFIG_DIR TBB_DIR)
find_package(TBB REQUIRED)

include(CheckIPOSupported)
check_ipo_supported(RESULT LTO_SUPPORTED)
```
Then run these commands:
```sh
git clone https://github.com/oneapi-src/oneTBB
mkdir build && cd build
cmake .. # first configure works without problems (not cached yet)
cmake .. # second configure fails
```
Output:
```
-- Building Intel TBB: /usr/bin/make -j8 tbb_build_prefix=tbb_cmake_build_subdir tbb_build_dir=/tmp/CMake/TBB-set-issue/build/tbb_cmake_build compiler=gcc TRUE
-- Building is unsuccessful (2): make: *** No rule to make target 'TRUE'.  Stop.

-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/CMake/TBB-set-issue/build
```