### PR TITLE
COMP: failure during build of TBB with clang

### DIFF
--- a/include/tbb/tbb_config.h
+++ b/include/tbb/tbb_config.h
@@ -494,7 +494,7 @@ There are four cases that are supported:
         #define TBB_USE_CAPTURED_EXCEPTION 1
     #endif
 #else /* defined TBB_USE_CAPTURED_EXCEPTION */
-    #if !TBB_USE_CAPTURED_EXCEPTION && !__TBB_EXCEPTION_PTR_PRESENT
+    #if !TBB_USE_CAPTURED_EXCEPTION && !__TBB_EXCEPTION_PTR_PRESENT && !defined(__TBB_SYMBOL)
         #error Current runtime does not support std::exception_ptr. Set TBB_USE_CAPTURED_EXCEPTION and make sure that your code is ready to catch tbb::captured_exception.
     #endif
 #endif /* defined TBB_USE_CAPTURED_EXCEPTION */


### PR DESCRIPTION
TBB_USE_CAPTURED_EXCEPTION=0 is desired for C++11 build.

When `__TBB_SYMBOL` is defined, then
  `#include <cstddef>`  is not included
  which means that `_LIBCPP_VERSION` is not defined
  so that `__TBB_EXCEPTION_PTR_PRESENT` is defined as 0 (not present)
  which results in a compiler error during creation of 'tbb.def'

```
In file included from ../../src/tbb/mac64-tbb-export.def:18:
In file included from ../../src/tbb/mac64-tbb-export.lst:17:
../../include/tbb/tbb_config.h:498:10: error: Current runtime does not support std::exception_ptr. Set TBB_USE_CAPTURED_EXCEPTION and make sure that your code is ready to catch
      tbb::captured_exception.
        #error Current runtime does not support std::exception_ptr. Set TBB_USE_CAPTURED_EXCEPTION and make sure that your code is ready to catch tbb::captured_exception.
         ^
1 error generated.
make[1]: *** [tbb.def] Error 1
make[1]: *** Deleting file `tbb.def'
make: *** [tbb] Error 2
```