### PR TITLE
Uses __copy__ in proxy.hpp for aliases when available

### DIFF
--- a/src/tbbmalloc/proxy.cpp
+++ b/src/tbbmalloc/proxy.cpp
@@ -292,7 +292,7 @@ struct mallinfo mallinfo() __THROW
 // Android doesn't have malloc_usable_size, provide it to be compatible
 // with Linux, in addition overload dlmalloc_usable_size() that presented
 // under Android.
-size_t dlmalloc_usable_size(const void *ptr) __TBB_ALIAS_ATTR_COPY(malloc_usable_size)
+size_t dlmalloc_usable_size(const void *ptr) __TBB_ALIAS_ATTR_COPY(malloc_usable_size);
 #else // __ANDROID__
 // C11 function, supported starting GLIBC 2.16
 void *aligned_alloc(size_t alignment, size_t size) __TBB_ALIAS_ATTR_COPY(memalign);


### PR DESCRIPTION
I was compiling oneTBB 2020 v2 with gcc > 9 and getting warnings like the following

```bash
../../src/tbbmalloc/proxy.cpp:215:7: warning: ‘void* __libc_calloc(size_t, size_t)’ specifies less restrictive attributes than its target ‘void* calloc(size_t, size_t)’: ‘alloc_size’, ‘leaf’, ‘malloc’, ‘nothrow’ [-Wmissing-attributes]
  215 | void *__libc_calloc(size_t num, size_t size) __attribute__ ((alias ("calloc")));
      |       ^~~~~~~~~~~~~
../../src/tbbmalloc/proxy.cpp:123:14: note: ‘void* __libc_calloc(size_t, size_t)’ target declared here
  123 | void *PREFIX(calloc)(ZONE_ARG size_t num, size_t size) __THROW
      |              ^~~~~~
../../src/tbbmalloc/proxy.cpp:84:22: note: in definition of macro ‘PREFIX’
   84 | #define PREFIX(name) name
```

I saw you had a pragma to ignore those, but I think you can just use `__copy__` instead

This does the same thing as [#1637](https://github.com/jemalloc/jemalloc/pull/1637/files#diff-d2be2656d37670b0c7f5f4320c0670ce) in jemalloc with a little check to make sure the copy attribute exists.