### PR TITLE
Use arm specific definitions when compiling for Apple Silicon/iOS

### DIFF
--- a/include/tbb/tbb_machine.h
+++ b/include/tbb/tbb_machine.h
@@ -254,6 +254,8 @@ template<> struct atomic_selector<8> {
         #include "machine/linux_intel64.h"
     #elif __POWERPC__
         #include "machine/mac_ppc.h"
+    #elif __aarch64__
+        #include "machine/gcc_arm.h"
     #endif
     #include "machine/macos_common.h"
 


### PR DESCRIPTION
Use gcc_arm (intrinsics) for Apple Silicon and iOS devices.
This prevents a fallback to the faulty generic implementation (see issue https://github.com/oneapi-src/oneTBB/issues/293)