### PR TITLE
Allow explicitly specifying the make tool name for tbb_build.

### DIFF
--- a/cmake/README.rst
+++ b/cmake/README.rst
@@ -333,7 +333,7 @@ TBBBuild
 Module for building TBB library from the source code.
 
 Provides the following functions:
- ``tbb_build(TBB_ROOT <tbb_root> CONFIG_DIR <variable> [MAKE_ARGS <custom_make_arguments>])``
+ ``tbb_build(TBB_ROOT <tbb_root> CONFIG_DIR <variable> [MAKE_ARGS <custom_make_arguments>] [MAKE_TOOL_NAME <tool_name>])``
   builds TBB from source code using the ``Makefile``, creates and provides the location of the CMake configuration files (TBBConfig.cmake and TBBConfigVersion.cmake) .
 
   =====================================  ====================================
@@ -351,6 +351,9 @@ Provides the following functions:
                                            - ``tbb_build_dir=<tbb_build_dir>``
                                            - ``tbb_build_prefix=<tbb_build_prefix>``
                                            - ``-j<n>``
+  ``MAKE_TOOL_NAME <tool_name>``         the name of the ``make`` tool used to compile TBB
+
+                                         If not set the name is guessed based on `CMAKE_SYSTEM_NAME <https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_NAME.html>`_.
   =====================================  ====================================
 
 

--- a/cmake/TBBBuild.cmake
+++ b/cmake/TBBBuild.cmake
@@ -137,7 +137,7 @@ function(tbb_build)
     # -------------------- #
     # Function entry point #
     # -------------------- #
-    set(oneValueArgs TBB_ROOT CONFIG_DIR)
+    set(oneValueArgs TBB_ROOT CONFIG_DIR MAKE_TOOL_NAME)
     set(multiValueArgs MAKE_ARGS)
     cmake_parse_arguments(tbb_build "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -147,11 +147,15 @@ function(tbb_build)
         return()
     endif()
 
-    set(make_tool_name make)
-    if (CMAKE_SYSTEM_NAME MATCHES "Windows")
-        set(make_tool_name gmake)
-    elseif (CMAKE_SYSTEM_NAME MATCHES "Android")
-        set(make_tool_name ndk-build)
+    if (tbb_build_MAKE_TOOL_NAME STREQUAL "")
+        set(make_tool_name make)
+        if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+            set(make_tool_name gmake)
+        elseif (CMAKE_SYSTEM_NAME MATCHES "Android")
+            set(make_tool_name ndk-build)
+        endif()
+    else()
+        set(make_tool_name "${tbb_build_MAKE_TOOL_NAME}")
     endif()
 
     find_program(TBB_MAKE_TOOL ${make_tool_name} DOC "Make-tool to build Intel TBB.")


### PR DESCRIPTION
Problem:
While trying the source package integration using cmake TBBBuild.cmake/tbb_build automatically chooses the make_tool_name based on CMAKE_SYSTEM_NAME. When GNU Make is e.g. installed from [Chocolatey](https://chocolatey.org/packages/make) or [gnuwin32](http://gnuwin32.sourceforge.net/packages/make.htm) the binary is called 'make' and the build fails.

Solution:
This patch adds the option to explicitly set the make_tool_name when calling tbb_build through an additional one-value-argument called MAKE_TOOL_NAME.