### PR TITLE
exception.cpp: visual stidio 2015 build fix

### DIFF
--- a/src/tbb/exception.cpp
+++ b/src/tbb/exception.cpp
@@ -110,7 +110,7 @@ void handle_perror( int error_code, const char* what ) {
     }
     __TBB_ASSERT(buf_len <= BUF_SIZE && buf[buf_len] == 0, nullptr);
 #if TBB_USE_EXCEPTIONS
-    do_throw([buf] { throw std::runtime_error(buf); });
+    do_throw([&buf] { throw std::runtime_error(buf); });
 #else
     PRINT_ERROR_AND_ABORT( "runtime_error", buf);
 #endif /* !TBB_USE_EXCEPTIONS */


### PR DESCRIPTION
Error	C2075	'tbb::detail::r1::handle_perror::<lambda_4bd345ce870bcb6a9dba57dde6595eaf>::buf': array initialization requires a brace-enclosed initializer list	tbb (thirdparty\tbb\src\tbb\tbb)	...\thirdparty\tbb\src\tbb\exception.cpp	113