### PR TITLE
Allow to disable tbbmalloc, use posix_memalign (oneTBB)

### DIFF
--- a/src/tbb/allocator.cpp
+++ b/src/tbb/allocator.cpp
@@ -31,6 +31,20 @@
 #include <dlfcn.h>
 #endif /* _WIN32||_WIN64 */
 
+#if (!_WIN32 && !_WIN64) || defined(__CYGWIN__)
+#include <stdlib.h> // posix_memalign, free
+// With glibc it is safe to use memalign(), as the allocated memory can be freed with free()
+#if defined(__GLIBC__)
+#include <malloc.h> // memalign
+#define __TBB_USE_MEMALIGN
+#else
+#define __TBB_USE_POSIX_MEMALIGN
+#endif
+#elif defined(_MSC_VER) || defined(__MINGW32__)
+#include <malloc.h> // _aligned_malloc, _aligned_free
+#define __TBB_USE_MSVC_ALIGNED_MALLOC
+#endif
+
 #if __TBB_WEAK_SYMBOLS_PRESENT
 
 #pragma weak scalable_malloc
@@ -63,11 +77,15 @@ static void  (*deallocate_handler)(void* pointer) = nullptr;
 //! Initialization routine used for first indirect call via cache_aligned_allocate_handler.
 static void* initialize_cache_aligned_allocate_handler(std::size_t n, std::size_t alignment);
 
+#if !defined(__TBB_USE_MSVC_ALIGNED_MALLOC)
 //! Allocates memory using standard malloc. It is used when scalable_allocator is not available
 static void* std_cache_aligned_allocate(std::size_t n, std::size_t alignment);
+#endif
 
+#if !defined(__TBB_USE_POSIX_MEMALIGN) && !defined(__TBB_USE_MEMALIGN) && !defined(__TBB_USE_MSVC_ALIGNED_MALLOC)
 //! Allocates memory using standard free. It is used when scalable_allocator is not available
 static void  std_cache_aligned_deallocate(void* p);
+#endif
 
 //! Handler for padded memory allocation
 static void* (*cache_aligned_allocate_handler)(std::size_t n, std::size_t alignment) = &initialize_cache_aligned_allocate_handler;
@@ -117,8 +135,16 @@ void initialize_handler_pointers() {
         // which forces them to wait.
         allocate_handler = &std::malloc;
         deallocate_handler = &std::free;
+#if defined(__TBB_USE_POSIX_MEMALIGN) || defined(__TBB_USE_MEMALIGN)
+        cache_aligned_allocate_handler = &std_cache_aligned_allocate;
+        cache_aligned_deallocate_handler = &::free;
+#elif defined(__TBB_USE_MSVC_ALIGNED_MALLOC)
+        cache_aligned_allocate_handler = &::_aligned_malloc;
+        cache_aligned_deallocate_handler = &::_aligned_free;
+#else
         cache_aligned_allocate_handler = &std_cache_aligned_allocate;
         cache_aligned_deallocate_handler = &std_cache_aligned_deallocate;
+#endif
     }
 
     PrintExtraVersionInfo( "ALLOCATOR", success?"scalable_malloc":"malloc" );
@@ -175,7 +201,17 @@ void __TBB_EXPORTED_FUNC cache_aligned_deallocate(void* p) {
     (*cache_aligned_deallocate_handler)(p);
 }
 
+#if !defined(__TBB_USE_MSVC_ALIGNED_MALLOC)
 static void* std_cache_aligned_allocate(std::size_t bytes, std::size_t alignment) {
+#if defined(__TBB_USE_MEMALIGN)
+    return memalign(alignment, bytes);
+#elif defined(__TBB_USE_POSIX_MEMALIGN)
+    void* p = nullptr;
+    int res = posix_memalign(&p, alignment, bytes);
+    if (res != 0)
+        p = nullptr;
+    return p;
+#else
     // TODO: make it common with cache_aligned_resource
     std::size_t space = alignment + bytes;
     std::uintptr_t base = reinterpret_cast<std::uintptr_t>(std::malloc(space));
@@ -190,8 +226,11 @@ static void* std_cache_aligned_allocate(std::size_t bytes, std::size_t alignment
     // Record where block actually starts.
     (reinterpret_cast<std::uintptr_t*>(result))[-1] = base;
     return reinterpret_cast<void*>(result);
+#endif
 }
+#endif // !defined(__TBB_USE_MSVC_ALIGNED_MALLOC)
 
+#if !defined(__TBB_USE_POSIX_MEMALIGN) && !defined(__TBB_USE_MEMALIGN) && !defined(__TBB_USE_MSVC_ALIGNED_MALLOC)
 static void std_cache_aligned_deallocate(void* p) {
     if (p) {
         __TBB_ASSERT(reinterpret_cast<std::uintptr_t>(p) >= 0x4096, "attempt to free block not obtained from cache_aligned_allocator");
@@ -201,6 +240,7 @@ static void std_cache_aligned_deallocate(void* p) {
         std::free(reinterpret_cast<void*>(base));
     }
 }
+#endif // !defined(__TBB_USE_POSIX_MEMALIGN) && !defined(__TBB_USE_MEMALIGN) && !defined(__TBB_USE_MSVC_ALIGNED_MALLOC)
 
 void* __TBB_EXPORTED_FUNC allocate_memory(std::size_t size) {
     void* result = (*allocate_handler)(size);

--- a/src/tbb/allocator.cpp
+++ b/src/tbb/allocator.cpp
@@ -20,6 +20,7 @@
 #include "oneapi/tbb/detail/_assert.h"
 #include "oneapi/tbb/detail/_utils.h"
 
+#include "environment.h"
 #include "dynamic_link.h"
 #include "misc.h"
 
@@ -127,7 +128,9 @@ static const dynamic_link_descriptor MallocLinkTable[] = {
     If that allocator is not found, it links to malloc and free. */
 void initialize_handler_pointers() {
     __TBB_ASSERT(allocate_handler == &initialize_allocate_handler, NULL);
-    bool success = dynamic_link(MALLOCLIB_NAME, MallocLinkTable, 4);
+    bool success = false;
+    if (!GetBoolEnvironmentVariable("TBB_USE_MALLOC"))
+        success = dynamic_link(MALLOCLIB_NAME, MallocLinkTable, 4);
     if(!success) {
         // If unsuccessful, set the handlers to the default routines.
         // This must be done now, and not before FillDynamicLinks runs, because if other


### PR DESCRIPTION
This is an updated version of https://github.com/oneapi-src/oneTBB/pull/149 which targets the reworked code base of oneTBB 2021.1.1.

The first commit enables `posix_memalign` and `memalign` on UNIX-like systems. This API is universally supported nowdays, so there's no need to use the hand-rolled implementation on top of `malloc`.

The second one adds `TBB_USE_MALLOC` environment variable to force using system allocator.

By setting `TBB_USE_MALLOC` environment variable to 1 the user can disable scalable allocator from tbbmalloc and use system allocator through `malloc`/`posix_memalign`/`free` API. There are other, more performant memory allocators, like tcmalloc for example, which the user might want to use instead of tbbmalloc. Also, using the system allocator can be useful with memory debugging and profiling tools, like valgrind. Such tools usually provide their own implementations of memory allocation functions, and we want those functions to be used by TBB.

The original PR https://github.com/oneapi-src/oneTBB/pull/149 contains some benchmarks and rationale as to why we prefer an environment variable as a way to disable tbbmalloc.
