### PR TITLE
Use nanosleep on Linux in atomic_backoff when spinning for a long time (oneTBB)

### DIFF
--- a/include/oneapi/tbb/detail/_machine.h
+++ b/include/oneapi/tbb/detail/_machine.h
@@ -20,6 +20,7 @@
 #include "_config.h"
 #include "_assert.h"
 
+#include <time.h>
 #include <atomic>
 #include <climits>
 #include <cstdint>
@@ -58,6 +59,15 @@ static inline void yield() {
 #else
 using std::this_thread::yield;
 #endif
+
+static inline void long_yield() {
+#if defined(__linux__)
+    struct ::timespec ts = {};
+    ::nanosleep(&ts, 0);
+#else
+    yield();
+#endif
+}
 
 //--------------------------------------------------------------------------------------------------
 // atomic_fence implementation

--- a/include/oneapi/tbb/detail/_utils.h
+++ b/include/oneapi/tbb/detail/_utils.h
@@ -44,6 +44,8 @@ class atomic_backoff {
     /** Should be equal to approximately the number of "pause" instructions
       that take the same time as an context switch. Must be a power of two.*/
     static constexpr std::int32_t LOOPS_BEFORE_YIELD = 16;
+    //! The number of time slice yields before switching to a long yield
+    static constexpr std::int32_t LOOPS_BEFORE_LONG_YIELD = LOOPS_BEFORE_YIELD + 4;
     std::int32_t count;
 
 public:
@@ -64,9 +66,12 @@ public:
             machine_pause(count);
             // Pause twice as long the next time.
             count *= 2;
-        } else {
+        } else if (count <= LOOPS_BEFORE_LONG_YIELD) {
             // Pause is so long that we might as well yield CPU to scheduler.
             yield();
+            ++count;
+        } else {
+            long_yield();
         }
     }
 


### PR DESCRIPTION
This is an updated version of https://github.com/oneapi-src/oneTBB/pull/106, which is rebased on top of oneTBB 2021.1.1 code base.

This allows to significantly reduce CPU system time while spinning, as `nanosleep` deschedules the thread and allows other threads to progress. Unlike `sched_yield`, `nanosleep` allows the thread to migrate to other CPUs, as well as other threads to migrate to the current CPU, which is what allows for more total progress.

See https://github.com/oneapi-src/oneTBB/issues/105. On the test presented
there, this patch offers to reduce CPU system time by 25-30%. On a real world
application that test is based on this patch offers ~10% improvement.
