### PR TITLE
Optimize x86 atomic_fence

### DIFF
--- a/include/oneapi/tbb/detail/_machine.h
+++ b/include/oneapi/tbb/detail/_machine.h
@@ -76,22 +76,15 @@ using std::this_thread::yield;
 #endif
 
 //--------------------------------------------------------------------------------------------------
-// atomic_fence implementation
+// atomic_fence_seq_cst implementation
 //--------------------------------------------------------------------------------------------------
 
-static inline void atomic_fence(std::memory_order order) {
+static inline void atomic_fence_seq_cst() {
 #if (__TBB_x86_64 || __TBB_x86_32) && defined(__GNUC__) && __GNUC__ < 11
-    if (order == std::memory_order_seq_cst)
-    {
-        unsigned char dummy = 0u;
-        __asm__ __volatile__ ("lock; notb %0" : "+m" (dummy) :: "memory");
-    }
-    else if (order != std::memory_order_relaxed)
-    {
-        __asm__ __volatile__ ("" ::: "memory");
-    }
+    unsigned char dummy = 0u;
+    __asm__ __volatile__ ("lock; notb %0" : "+m" (dummy) :: "memory");
 #else
-    std::atomic_thread_fence(order);
+    std::atomic_thread_fence(std::memory_order_seq_cst);
 #endif
 }
 

--- a/include/oneapi/tbb/detail/_machine.h
+++ b/include/oneapi/tbb/detail/_machine.h
@@ -84,6 +84,17 @@ using std::this_thread::yield;
 #endif
 
 static inline void atomic_fence(std::memory_order order) {
+#if (__TBB_x86_64 || __TBB_x86_32) && defined(__GNUC__) && __GNUC__ < 11
+    if (order == std::memory_order_seq_cst)
+    {
+        unsigned char dummy = 0u;
+        __asm__ __volatile__ ("lock; notb %0" : "+m" (dummy) :: "memory");
+    }
+    else if (order != std::memory_order_relaxed)
+    {
+        __asm__ __volatile__ ("" ::: "memory");
+    }
+#else
 #if _MSC_VER && (__TBB_x86_64 || __TBB_x86_32)
     if (order == std::memory_order_seq_cst ||
         order == std::memory_order_acq_rel ||
@@ -95,6 +106,7 @@ static inline void atomic_fence(std::memory_order order) {
     }
 #endif /*_MSC_VER && (__TBB_x86_64 || __TBB_x86_32)*/
     std::atomic_thread_fence(order);
+#endif
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/include/oneapi/tbb/detail/_machine.h
+++ b/include/oneapi/tbb/detail/_machine.h
@@ -79,10 +79,6 @@ using std::this_thread::yield;
 // atomic_fence implementation
 //--------------------------------------------------------------------------------------------------
 
-#if _MSC_VER && (__TBB_x86_64 || __TBB_x86_32)
-#pragma intrinsic(_mm_mfence)
-#endif
-
 static inline void atomic_fence(std::memory_order order) {
 #if (__TBB_x86_64 || __TBB_x86_32) && defined(__GNUC__) && __GNUC__ < 11
     if (order == std::memory_order_seq_cst)
@@ -95,16 +91,6 @@ static inline void atomic_fence(std::memory_order order) {
         __asm__ __volatile__ ("" ::: "memory");
     }
 #else
-#if _MSC_VER && (__TBB_x86_64 || __TBB_x86_32)
-    if (order == std::memory_order_seq_cst ||
-        order == std::memory_order_acq_rel ||
-        order == std::memory_order_acquire ||
-        order == std::memory_order_release )
-    {
-        _mm_mfence();
-        return;
-    }
-#endif /*_MSC_VER && (__TBB_x86_64 || __TBB_x86_32)*/
     std::atomic_thread_fence(order);
 #endif
 }

--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -494,7 +494,7 @@ void arena::advertise_new_work() {
     };
 
     if( work_type == work_enqueued ) {
-        atomic_fence(std::memory_order_seq_cst);
+        atomic_fence_seq_cst();
 #if __TBB_ENQUEUE_ENFORCED_CONCURRENCY
         if ( my_market->my_num_workers_soft_limit.load(std::memory_order_acquire) == 0 &&
             my_global_concurrency_mode.load(std::memory_order_acquire) == false )
@@ -508,7 +508,7 @@ void arena::advertise_new_work() {
         // Starvation resistant tasks require concurrency, so missed wakeups are unacceptable.
     }
     else if( work_type == wakeup ) {
-        atomic_fence(std::memory_order_seq_cst);
+        atomic_fence_seq_cst();
     }
 
     // Double-check idiom that, in case of spawning, is deliberately sloppy about memory fences.

--- a/src/tbb/concurrent_monitor.h
+++ b/src/tbb/concurrent_monitor.h
@@ -220,7 +220,7 @@ public:
 
         // Prepare wait guarantees Write Read memory barrier.
         // In C++ only full fence covers this type of barrier.
-        atomic_fence(std::memory_order_seq_cst);
+        atomic_fence_seq_cst();
     }
 
     //! Commit wait if event count has not changed; otherwise, cancel wait.
@@ -272,7 +272,7 @@ public:
 
     //! Notify one thread about the event
     void notify_one() {
-        atomic_fence(std::memory_order_seq_cst);
+        atomic_fence_seq_cst();
         notify_one_relaxed();
     }
 
@@ -301,7 +301,7 @@ public:
 
     //! Notify all waiting threads of the event
     void notify_all() {
-        atomic_fence(std::memory_order_seq_cst);
+        atomic_fence_seq_cst();
         notify_all_relaxed();
     }
 
@@ -337,7 +337,7 @@ public:
     //! Notify waiting threads of the event that satisfies the given predicate
     template <typename P>
     void notify( const P& predicate ) {
-        atomic_fence(std::memory_order_seq_cst);
+        atomic_fence_seq_cst();
         notify_relaxed( predicate );
     }
 
@@ -409,7 +409,7 @@ public:
 
     //! Abort any sleeping threads at the time of the call
     void abort_all() {
-        atomic_fence( std::memory_order_seq_cst );
+        atomic_fence_seq_cst();
         abort_all_relaxed();
     }
 


### PR DESCRIPTION
The first commit provides an optimized `atomic_fence` implementation for x86 on gcc-compatible compilers.

On x86 (32 and 64-bit) any lock-prefixed instruction provides sequential consistency guarantees for atomic operations and is more efficient than mfence. You can see some tests in [this](https://shipilev.net/blog/2014/on-the-fence-with-dependencies/) article.
    
We are choosing a "lock not" on a dummy byte on the stack for the following reasons:

- The "not" instruction does not affect flags or clobber any registers. The memory operand is presumably accessible through esp/rsp.
- The dummy byte variable is at the top of the stack, which is likely hot in cache.
- The dummy variable does not alias any other data on the stack, which means the "lock not" instruction won't introduce any false data dependencies with prior or following instructions.

In order to avoid various sanitizers and valgrind complaining, we have to initialize the dummy variable to zero prior to the operation.
    
Additionally, for memory orders weaker than seq_cst there is no need for any special instructions, and we only need a compiler fence. For the relaxed memory order we don't need even that.

The second commit removes explicit mfence on Windows. The existing `std::atomic_thread_fence` already provides the necessary instructions to maintain memory order according to its argument.
