### PR TITLE
Fix TBB vars.sh for zsh in Linux

### DIFF
--- a/integration/linux/env/vars.sh
+++ b/integration/linux/env/vars.sh
@@ -19,10 +19,7 @@
 #   intel64|ia32 - architecture, intel64 is default.
 
 if [ -n "$ZSH_EVAL_CONTEXT" ]; then
-    case "$0" in
-    (/*) TBBROOT="$(dirname $0)"/.. ;;
-    (*) TBBROOT="$(dirname "$(command pwd)/$0")"/.. ;;
-    esac
+    TBBROOT="$(cd "$(dirname "${(%):-%x}")" && pwd -P)"/..
 elif [ -n "$KSH_VERSION" ]; then
     TBBROOT="${.sh.file%/*}/.."
 else


### PR DESCRIPTION
Solution for [this issue](https://community.intel.com/t5/Intel-oneAPI-HPC-Toolkit/setvars-sh-failing-on-macOS-Catalina-using-zsh-works-for-bash/m-p/1199001), marked as Solved, but the solution proposed in the post is just a workaround, and initiates other subshell.

Here, we replicate the Bash line for Zsh, but using "${(%):-%x}" instead of $BASH_SOURCE (more info: [https://stackoverflow.com/a/28336473](https://stackoverflow.com/a/28336473))

I think that the same fix could be applied to the Mac version, but I cannot test it.