### PR TITLE
[fix] Uses __copy__ in proxy.hpp for aliases when complier has it

### DIFF
--- a/src/tbbmalloc_proxy/proxy.cpp
+++ b/src/tbbmalloc_proxy/proxy.cpp
@@ -59,6 +59,13 @@
 // Use MallocMutex implementation
 typedef MallocMutex ProxyMutex;
 
+// Adds aliasing and copy attributes to function if available
+#if __has_attribute(__copy__)
+  #define __TBB_ALIAS_ATTR_COPY(name) __attribute__((alias (#name), __copy__(name)))
+#else
+  #define __TBB_ALIAS_ATTR_COPY(name) __attribute__((alias (#name)))
+#endif
+
 // In case there is no std::get_new_handler function
 // which provides synchronized access to std::new_handler
 #if !__TBB_CPP11_GET_NEW_HANDLER_PRESENT
@@ -123,10 +130,7 @@ static inline void initPageSize()
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wmissing-attributes"
 #endif
-extern "C" void *__TBB_malloc_proxy(size_t) __attribute__ ((alias ("malloc")));
-#if __GNUC__ == 9
-    #pragma GCC diagnostic pop
-#endif
+extern "C" void *__TBB_malloc_proxy(size_t) __TBB_ALIAS_ATTR_COPY(malloc);
 
 static void *orig_msize;
 
@@ -265,28 +269,23 @@ struct mallinfo mallinfo() __THROW
 // Android doesn't have malloc_usable_size, provide it to be compatible
 // with Linux, in addition overload dlmalloc_usable_size() that presented
 // under Android.
-size_t dlmalloc_usable_size(const void *ptr) __attribute__ ((alias ("malloc_usable_size")));
+size_t dlmalloc_usable_size(const void *ptr) __TBB_ALIAS_ATTR_COPY(malloc_usable_size);
 #else // __ANDROID__
 // C11 function, supported starting GLIBC 2.16
-void *aligned_alloc(size_t alignment, size_t size) __attribute__ ((alias ("memalign")));
+void *aligned_alloc(size_t alignment, size_t size) __TBB_ALIAS_ATTR_COPY(memalign);
 // Those non-standard functions are exported by GLIBC, and might be used
 // in conjunction with standard malloc/free, so we must ovberload them.
 // Bionic doesn't have them. Not removing from the linker scripts,
 // as absent entry points are ignored by the linker.
 
-// Starting from GCC 9, the -Wmissing-attributes warning was extended for aliases below
-#if __GNUC__ >= 9
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wmissing-attributes"
-#endif
-void *__libc_malloc(size_t size) __attribute__ ((alias ("malloc")));
-void *__libc_calloc(size_t num, size_t size) __attribute__ ((alias ("calloc")));
-void *__libc_memalign(size_t alignment, size_t size) __attribute__ ((alias ("memalign")));
-void *__libc_pvalloc(size_t size) __attribute__ ((alias ("pvalloc")));
-void *__libc_valloc(size_t size) __attribute__ ((alias ("valloc")));
-#if __GNUC__ == 9
-    #pragma GCC diagnostic pop
-#endif
+void *__libc_malloc(size_t size) __TBB_ALIAS_ATTR_COPY(malloc);
+void *__libc_calloc(size_t num, size_t size) __TBB_ALIAS_ATTR_COPY(calloc);
+void *__libc_memalign(size_t alignment, size_t size) __TBB_ALIAS_ATTR_COPY(memalign);
+void *__libc_pvalloc(size_t size) __TBB_ALIAS_ATTR_COPY(pvalloc);
+void *__libc_valloc(size_t size) __TBB_ALIAS_ATTR_COPY(valloc);
+
+// Last place tbb alias attr copy is used
+#undef __TBB_ALIAS_ATTR_COPY
 
 // call original __libc_* to support naive replacement of free via __libc_free etc
 void __libc_free(void *ptr)


### PR DESCRIPTION
@alexey-katranov This is just #276 but updated to master. I let that PR linger for too long and the rebase was v difficult for such a small change so I just opened up a new PR.

I was compiling oneTBB 2020 v2 with gcc > 9 and getting warnings like the following

```bash
../../src/tbbmalloc/proxy.cpp:215:7: warning: ‘void* __libc_calloc(size_t, size_t)’ specifies less restrictive attributes than its target ‘void* calloc(size_t, size_t)’: ‘alloc_size’, ‘leaf’, ‘malloc’, ‘nothrow’ [-Wmissing-attributes]
  215 | void *__libc_calloc(size_t num, size_t size) __attribute__ ((alias ("calloc")));
      |       ^~~~~~~~~~~~~
../../src/tbbmalloc/proxy.cpp:123:14: note: ‘void* __libc_calloc(size_t, size_t)’ target declared here
  123 | void *PREFIX(calloc)(ZONE_ARG size_t num, size_t size) __THROW
      |              ^~~~~~
../../src/tbbmalloc/proxy.cpp:84:22: note: in definition of macro ‘PREFIX’
   84 | #define PREFIX(name) name
```

I saw you had a pragma to ignore those, but I think you can just use `__copy__` instead

This does the same thing as [#1637](https://github.com/jemalloc/jemalloc/pull/1637/files#diff-d2be2656d37670b0c7f5f4320c0670ce) in jemalloc with a little check to make sure the copy attribute exists.