### PR TITLE
POC: Extend tbb::task_group to support new use cases

### DIFF
--- a/include/oneapi/tbb/detail/_task.h
+++ b/include/oneapi/tbb/detail/_task.h
@@ -30,6 +30,7 @@
 #include <utility>
 #include <atomic>
 #include <mutex>
+#include <functional>
 
 namespace tbb {
 namespace detail {
@@ -229,6 +230,9 @@ private:
     friend struct r1::task_accessor;
 };
 static_assert(sizeof(task) == task_alignment, "task size is broken");
+
+
+using task_handle = std::unique_ptr<task, std::function<void(task*)>>;
 
 } // namespace d1
 } // namespace detail

--- a/test/common/utils.h
+++ b/test/common/utils.h
@@ -42,6 +42,8 @@ namespace utils {
 
 #define utils_fallthrough __TBB_fallthrough
 
+using tbb::detail::try_call;
+
 template<typename It>
 typename std::iterator_traits<It>::value_type median(It first, It last) {
     std::sort(first, last);


### PR DESCRIPTION
The use cases include:
- Instantiation of the tbb::task_group with arbitrary tbb::task_group_context.
- Bypassing a functor using tbb::task_group interfaces.
- Deferring a task to be run later as part of the current tbb::task_group execution.