### PR TITLE
Fix build with gcc11+glibc-2.34

### DIFF
--- a/src/tbb/parallel_pipeline.cpp
+++ b/src/tbb/parallel_pipeline.cpp
@@ -243,7 +243,8 @@ public:
         return end_of_input_tls.get() != 0;
     }
     void set_my_tls_end_of_input() {
-        end_of_input_tls.set(1);
+	// Use an arbitrary but valid pointer as value.
+        end_of_input_tls.set(array_size);
     }
 };
 


### PR DESCRIPTION
Pass a valid pointer to pthread_setspecific to avoid GCC 11 warning.
Fixes

src/tbb/tls.h:44:46: error: 'int pthread_setspecific(pthread_key_t, const void*)' expecting 1 byte in a region of size 0 [-Werror=stringop-overread]
|    44 |     void set( T value ) { pthread_setspecific(my_key, (void*)value); }
|       |                           ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
| compilation terminated due to -Wfatal-errors.

Signed-off-by: Khem Raj <raj.khem@gmail.com>