### PR TITLE
Fix the logic that depends on optional copy elision

### DIFF
--- a/cmake/compilers/Clang.cmake
+++ b/cmake/compilers/Clang.cmake
@@ -48,5 +48,7 @@ if (ANDROID_PLATFORM)
     set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} $<$<NOT:$<CONFIG:Debug>>:-D_FORTIFY_SOURCE=2>)
 endif()
 
+set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -fno-elide-constructors)
+
 # TBB malloc settings
 set(TBBMALLOC_LIB_COMPILE_FLAGS -fno-rtti -fno-exceptions)

--- a/cmake/compilers/Clang.cmake
+++ b/cmake/compilers/Clang.cmake
@@ -48,7 +48,5 @@ if (ANDROID_PLATFORM)
     set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} $<$<NOT:$<CONFIG:Debug>>:-D_FORTIFY_SOURCE=2>)
 endif()
 
-set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -fno-elide-constructors)
-
 # TBB malloc settings
 set(TBBMALLOC_LIB_COMPILE_FLAGS -fno-rtti -fno-exceptions)

--- a/include/oneapi/tbb/detail/_template_helpers.h
+++ b/include/oneapi/tbb/detail/_template_helpers.h
@@ -184,12 +184,7 @@ class raii_guard {
 public:
     raii_guard( Func f ) : my_func(f), is_active(true) {}
 
-    raii_guard (raii_guard&& g) : my_func(g.my_func), is_active(g.is_active) {
-        g.is_active = false;
-    }
-    raii_guard& operator=(raii_guard&& g) {
-        my_func = std::move(g.my_func);
-        is_active = g.is_active;
+    raii_guard (raii_guard&& g) : my_func(std::move(g.my_func)), is_active(g.is_active) {
         g.is_active = false;
     }
 

--- a/include/oneapi/tbb/detail/_template_helpers.h
+++ b/include/oneapi/tbb/detail/_template_helpers.h
@@ -22,7 +22,7 @@
 
 #include <cstddef>
 #include <cstdint>
-
+#include <utility>
 #include <type_traits>
 #include <memory>
 #include <iterator>
@@ -182,9 +182,15 @@ using pack_element_t = typename pack_element<N, Args...>::type;
 template <typename Func>
 class raii_guard {
 public:
-    raii_guard( Func f ) : my_func(f), is_active(true) {}
+    static_assert(
+        std::is_nothrow_copy_constructible<Func>::value &&
+        std::is_nothrow_move_constructible<Func>::value,
+        "Throwing an exception during the Func copy or move construction cause an unexpected behavior."
+    );
 
-    raii_guard (raii_guard&& g) : my_func(std::move(g.my_func)), is_active(g.is_active) {
+    raii_guard( Func f ) noexcept : my_func(f), is_active(true) {}
+
+    raii_guard( raii_guard&& g ) noexcept : my_func(std::move(g.my_func)), is_active(g.is_active) {
         g.is_active = false;
     }
 

--- a/include/oneapi/tbb/detail/_template_helpers.h
+++ b/include/oneapi/tbb/detail/_template_helpers.h
@@ -184,6 +184,15 @@ class raii_guard {
 public:
     raii_guard( Func f ) : my_func(f), is_active(true) {}
 
+    raii_guard (raii_guard&& g) : my_func(g.my_func), is_active(g.is_active) {
+        g.is_active = false;
+    }
+    raii_guard& operator=(raii_guard&& g) {
+        my_func = std::move(g.my_func);
+        is_active = g.is_active;
+        g.is_active = false;
+    }
+
     ~raii_guard() {
         if (is_active) {
             my_func();

--- a/test/common/doctest.h
+++ b/test/common/doctest.h
@@ -1522,7 +1522,7 @@ namespace detail {
     public:
         explicit ContextScope(const L &lambda) : ContextScopeBase(), lambda_(lambda) {}
 
-        ContextScope(ContextScope &&other) : ContextScopeBase(), lambda_(std::move(other.lambda_)) {}
+        ContextScope(ContextScope &&other) : ContextScopeBase(), lambda_(other.lambda_) {}
 
         void stringify(std::ostream* s) const override { lambda_(s); }
 

--- a/test/common/doctest.h
+++ b/test/common/doctest.h
@@ -1524,6 +1524,7 @@ namespace detail {
     public:
         explicit ContextScope(const L &lambda) : ContextScopeBase(), lambda_(lambda) {}
 
+        // std::move cannot be applied here since there is no utility header included in this place (by some reason all headers are included later)
         ContextScope(ContextScope &&other) : ContextScopeBase(static_cast<ContextScopeBase&&>(other)), lambda_(other.lambda_) {}
 
         void stringify(std::ostream* s) const override { lambda_(s); }

--- a/test/common/doctest.h
+++ b/test/common/doctest.h
@@ -1972,7 +1972,7 @@ int registerReporter(const char* name, int priority, bool isReporter) {
         mb_name << expression;                                                                     \
     };                                                                                             \
     DOCTEST_MSVC_SUPPRESS_WARNING_POP                                                              \
-    auto DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope(lambda_name)
+    doctest::detail::ContextScope<decltype(lambda_name)> DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_){lambda_name}
 
 #define DOCTEST_CAPTURE(x) DOCTEST_INFO(#x " := " << x)
 

--- a/test/conformance/conformance_task_arena.cpp
+++ b/test/conformance/conformance_task_arena.cpp
@@ -41,7 +41,7 @@ TEST_CASE("Arena interfaces") {
         //! oneapi::tbb::this_task_arena interfaces
         CHECK(oneapi::tbb::this_task_arena::current_thread_index() >= 0);
         //! Attach interface
-        oneapi::tbb::task_arena attached_arena = oneapi::tbb::task_arena(oneapi::tbb::task_arena::attach());
+        oneapi::tbb::task_arena attached_arena{oneapi::tbb::task_arena::attach()};
         CHECK(attached_arena.is_active());
     });
     while (!done) {

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -596,7 +596,7 @@ struct TestAttachBody : utils::NoAssign {
 
         int default_threads = tbb::this_task_arena::max_concurrency();
 
-        tbb::task_arena arena = tbb::task_arena( tbb::task_arena::attach() );
+        tbb::task_arena arena{tbb::task_arena::attach()};
         ValidateAttachedArena( arena, false, -1, -1 ); // Nothing yet to attach to
 
         arena.terminate();
@@ -605,7 +605,7 @@ struct TestAttachBody : utils::NoAssign {
         // attach to an auto-initialized arena
         tbb::parallel_for(0, 1, [](int) {});
 
-        tbb::task_arena arena2 = tbb::task_arena( tbb::task_arena::attach() );
+        tbb::task_arena arena2{tbb::task_arena::attach()};
         ValidateAttachedArena( arena2, true, default_threads, 1 );
 
         // attach to another task_arena
@@ -615,14 +615,14 @@ struct TestAttachBody : utils::NoAssign {
 
     // The functor body for task_arena::execute above
     void operator()() const {
-        tbb::task_arena arena2 = tbb::task_arena( tbb::task_arena::attach() );
+        tbb::task_arena arena2{tbb::task_arena::attach()};
         ValidateAttachedArena( arena2, true, maxthread, std::min(maxthread,my_idx) );
     }
 
     // The functor body for tbb::parallel_for
     void operator()( const Range& r ) const {
         for( int i = r.begin(); i<r.end(); ++i ) {
-            tbb::task_arena arena2 = tbb::task_arena( tbb::task_arena::attach() );
+            tbb::task_arena arena2{tbb::task_arena::attach()};
             ValidateAttachedArena( arena2, true, tbb::this_task_arena::max_concurrency(), 1 );
         }
     }
@@ -944,7 +944,7 @@ namespace TestIsolatedExecuteNS {
     void TestEnqueue() {
         tbb::enumerable_thread_specific<bool> executed(false);
         std::atomic<int> completed;
-        tbb::task_arena arena = tbb::task_arena(tbb::task_arena::attach());
+        tbb::task_arena arena{tbb::task_arena::attach()};
 
         // Check that the main thread can process enqueued tasks.
         completed = 0;
@@ -1218,9 +1218,14 @@ namespace TestReturnValueNS {
             std::size_t copied = cnts[StateTrackableBase::CopyInitialized];
             std::size_t moved = cnts[StateTrackableBase::MoveInitialized];
             REQUIRE(cnts[StateTrackableBase::Destroyed] == copied + moved);
-            // The number of copies/moves should not exceed 3: function return, store to an internal storage,
-            // acquire internal storage.
-            REQUIRE((copied == 0 && moved <=3));
+            // The number of copies/moves should not exceed 3 if copy elision takes a place:
+            // function return, store to an internal storage, acquire internal storage.
+            // For compilation, without copy elision, this number may be grown up to 7.
+            REQUIRE((copied == 0 && moved <=7));
+            WARN_MESSAGE(moved <= 3,
+                "Waring: The number of copies/moves should not exceed 3 if copy elision takes a place."
+                "Take an attention to this warning only if copy elision is enabled."
+            );
         }
     };
 
@@ -1250,27 +1255,27 @@ namespace TestReturnValueNS {
     template <typename F>
     void TestExecute(F &f) {
         StateTrackableCounters::reset();
-        ReturnType r = arena().execute(f);
+        ReturnType r{arena().execute(f)};
         r.check();
     }
 
     template <typename F>
     void TestExecute(const F &f) {
         StateTrackableCounters::reset();
-        ReturnType r = arena().execute(f);
+        ReturnType r{arena().execute(f)};
         r.check();
     }
     template <typename F>
     void TestIsolate(F &f) {
         StateTrackableCounters::reset();
-        ReturnType r = tbb::this_task_arena::isolate(f);
+        ReturnType r{tbb::this_task_arena::isolate(f)};
         r.check();
     }
 
     template <typename F>
     void TestIsolate(const F &f) {
         StateTrackableCounters::reset();
-        ReturnType r = tbb::this_task_arena::isolate(f);
+        ReturnType r{tbb::this_task_arena::isolate(f)};
         r.check();
     }
 

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -1223,7 +1223,7 @@ namespace TestReturnValueNS {
             // For compilation, without copy elision, this number may be grown up to 7.
             REQUIRE((copied == 0 && moved <= 7));
             WARN_MESSAGE(moved <= 3,
-                "Waring: The number of copies/moves should not exceed 3 if copy elision takes a place."
+                "Warning: The number of copies/moves should not exceed 3 if copy elision takes a place."
                 "Take an attention to this warning only if copy elision is enabled."
             );
         }

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -1221,7 +1221,7 @@ namespace TestReturnValueNS {
             // The number of copies/moves should not exceed 3 if copy elision takes a place:
             // function return, store to an internal storage, acquire internal storage.
             // For compilation, without copy elision, this number may be grown up to 7.
-            REQUIRE((copied == 0 && moved <=7));
+            REQUIRE((copied == 0 && moved <= 7));
             WARN_MESSAGE(moved <= 3,
                 "Waring: The number of copies/moves should not exceed 3 if copy elision takes a place."
                 "Take an attention to this warning only if copy elision is enabled."


### PR DESCRIPTION
Disabling the [copy elision](https://en.cppreference.com/w/cpp/language/copy_elision) optimization causes unexpected behavior in several tests and interfaces. The patch gets rid of the dependency on this optional optimization.

### Common fixed cases:
#### raii_guard
Without explicitly defined move semantic and with disabled optional copy elision the interface `make_raii_guard()` causes the additional temporary object that will just be moved out and then destroyed. But during the temporary object destruction, this object will contain `true` in the `is_active` field which will cause the calling of the `on_exception()` without any exception.
#### attached arena construction
The execution of the code
```c++
oneapi::tbb::task_arena attached_arena = oneapi::tbb::task_arena(oneapi::tbb::task_arena::attach());
```
with disabled optional copy elision optimization causes the construction of additional temporary object which will be attached, but after it, this temporary object will be copy-constructed to the `attached_arena` variable using copy constructor which is not expected at corresponding test cases.
#### doctest internal fix
The code
```c++
auto DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope(lambda_name)
```
with disabled optional copy elision optimization causes the construction of additional temporary which causes the segmentation fault during `WARN_MESSSAGE()` message printing. The change that was applied in this patch fixes the problem.