### PR TITLE
Fix shellcheck scan errors and warnings

### DIFF
--- a/integration/linux/env/vars.sh
+++ b/integration/linux/env/vars.sh
@@ -141,7 +141,7 @@ TBBROOT=$(get_script_path "${vars_script_name:-}")/..
 TBB_TARGET_ARCH="intel64"
 
 if [ -n "${SETVARS_ARGS:-}" ]; then
-  tbb_arg_ia32="$(expr "${SETVARS_ARGS:-}" : '^.*[:space:]*\(ia32\)[:space:]*')"
+  tbb_arg_ia32="$(expr "${SETVARS_ARGS:-}" : '^.*\(ia32\)')"
   if [ -n "${tbb_arg_ia32:-}" ]; then
     TBB_TARGET_ARCH="ia32"
   fi

--- a/integration/linux/env/vars.sh
+++ b/integration/linux/env/vars.sh
@@ -140,32 +140,11 @@ TBBROOT=$(get_script_path "${vars_script_name:-}")/..
 
 TBB_TARGET_ARCH="intel64"
 
-if [ -n "${ZSH_VERSION:-}" ]; then
-    setopt sh_word_split
-fi
-
-# shellcheck disable=2154
-if [ -n "$SETVARS_ARGS" ] && [ "$SETVARS_CALL" = "1" ]; then
-    for arg in $SETVARS_ARGS; do
-        case "$arg" in
-        (intel64|ia32)
-            TBB_TARGET_ARCH="${arg}"
-            ;;
-        (*) ;;
-        esac
-    done
-elif [ -n "$SETVARS_ARGS" ]; then
-        for arg in $SETVARS_ARGS; do
-        case "$arg" in
-            (intel64|ia32)
-            TBB_TARGET_ARCH="${arg}"
-            ;;
-            (*)
-            >&2 echo "ERROR: Unknown argument $arg"
-            return 255 2>/dev/null || exit 255
-            ;;
-        esac
-    done
+if [ -n "${SETVARS_ARGS:-}" ]; then
+  arg_ia32="$(expr "${SETVARS_ARGS:-}" : '^.*[:space:]*\(ia32\)[:space:]*')"
+  if [ -n "${arg_ia32:-}" ]; then
+    TBB_TARGET_ARCH="ia32"
+  fi
 else
     for arg do
         case "$arg" in
@@ -175,10 +154,6 @@ else
         (*) ;;
         esac
     done
-fi
-
-if [ -n "${ZSH_VERSION:-}" ]; then
-    unsetopt sh_word_split
 fi
 
 TBB_LIB_NAME="libtbb.so.12"

--- a/integration/linux/env/vars.sh
+++ b/integration/linux/env/vars.sh
@@ -140,9 +140,12 @@ TBBROOT=$(get_script_path "${vars_script_name:-}")/..
 
 TBB_TARGET_ARCH="intel64"
 
-# shellcheck disable=2236
+if [ -n "${ZSH_VERSION:-}" ]; then
+    setopt sh_word_split
+fi
+
 # shellcheck disable=2154
-if [ ! -z "$SETVARS_ARGS" ] && [ "$SETVARS_CALL" "=" "1" ]; then
+if [ -n "$SETVARS_ARGS" ] && [ "$SETVARS_CALL" = "1" ]; then
     for arg in $SETVARS_ARGS; do
         case "$arg" in
         (intel64|ia32)
@@ -151,7 +154,7 @@ if [ ! -z "$SETVARS_ARGS" ] && [ "$SETVARS_CALL" "=" "1" ]; then
         (*) ;;
         esac
     done
-elif [ ! -z "$SETVARS_ARGS" ]; then
+elif [ -n "$SETVARS_ARGS" ]; then
         for arg in $SETVARS_ARGS; do
         case "$arg" in
             (intel64|ia32)
@@ -172,6 +175,10 @@ else
         (*) ;;
         esac
     done
+fi
+
+if [ -n "${ZSH_VERSION:-}" ]; then
+    unsetopt sh_word_split
 fi
 
 TBB_LIB_NAME="libtbb.so.12"

--- a/integration/linux/env/vars.sh
+++ b/integration/linux/env/vars.sh
@@ -140,8 +140,10 @@ TBBROOT=$(get_script_path "${vars_script_name:-}")/..
 
 TBB_TARGET_ARCH="intel64"
 
-if [ ! -z "$SETVARS_ARGS" ] && [ "$SETVARS_CALL" "==" "1" ]; then
-    for arg in "$SETVARS_ARGS"; do
+# shellcheck disable=2236
+# shellcheck disable=2154
+if [ ! -z "$SETVARS_ARGS" ] && [ "$SETVARS_CALL" "=" "1" ]; then
+    for arg in $SETVARS_ARGS; do
         case "$arg" in
         (intel64|ia32)
             TBB_TARGET_ARCH="${arg}"
@@ -150,7 +152,7 @@ if [ ! -z "$SETVARS_ARGS" ] && [ "$SETVARS_CALL" "==" "1" ]; then
         esac
     done
 elif [ ! -z "$SETVARS_ARGS" ]; then
-        for arg in "$SETVARS_ARGS"; do
+        for arg in $SETVARS_ARGS; do
         case "$arg" in
             (intel64|ia32)
             TBB_TARGET_ARCH="${arg}"
@@ -178,7 +180,7 @@ TBB_LIB_DIR="$TBB_TARGET_ARCH/gcc4.8"
 if [ -e "$TBBROOT/lib/$TBB_LIB_DIR/$TBB_LIB_NAME" ]; then
     export TBBROOT
 
-    LIBRARY_PATH=$(prepend_path "${TBBROOT}/lib"/$TBB_LIB_DIR "${LIBRARY_PATH:-}") ; export LIBRARY_PATH
+    LIBRARY_PATH=$(prepend_path "${TBBROOT}/lib/$TBB_LIB_DIR" "${LIBRARY_PATH:-}") ; export LIBRARY_PATH
     LD_LIBRARY_PATH=$(prepend_path "${TBBROOT}/lib/$TBB_LIB_DIR" "${LD_LIBRARY_PATH:-}") ; export LD_LIBRARY_PATH
     CPATH=$(prepend_path "${TBBROOT}/include" "${CPATH:-}") ; export CPATH
     CMAKE_PREFIX_PATH=$(prepend_path "${TBBROOT}" "${CMAKE_PREFIX_PATH:-}") ; export CMAKE_PREFIX_PATH

--- a/integration/linux/env/vars.sh
+++ b/integration/linux/env/vars.sh
@@ -141,8 +141,8 @@ TBBROOT=$(get_script_path "${vars_script_name:-}")/..
 TBB_TARGET_ARCH="intel64"
 
 if [ -n "${SETVARS_ARGS:-}" ]; then
-  arg_ia32="$(expr "${SETVARS_ARGS:-}" : '^.*[:space:]*\(ia32\)[:space:]*')"
-  if [ -n "${arg_ia32:-}" ]; then
+  tbb_arg_ia32="$(expr "${SETVARS_ARGS:-}" : '^.*[:space:]*\(ia32\)[:space:]*')"
+  if [ -n "${tbb_arg_ia32:-}" ]; then
     TBB_TARGET_ARCH="ia32"
   fi
 else

--- a/integration/linux/env/vars.sh
+++ b/integration/linux/env/vars.sh
@@ -146,27 +146,27 @@ if [ -n "${SETVARS_ARGS:-}" ]; then
     TBB_TARGET_ARCH="ia32"
   fi
 else
-    for arg do
-        case "$arg" in
-        (intel64|ia32)
-            TBB_TARGET_ARCH="${arg}"
-            ;;
-        (*) ;;
-        esac
-    done
+  for arg do
+    case "$arg" in
+    (intel64|ia32)
+      TBB_TARGET_ARCH="${arg}"
+      ;;
+    (*) ;;
+    esac
+  done
 fi
 
 TBB_LIB_NAME="libtbb.so.12"
 TBB_LIB_DIR="$TBB_TARGET_ARCH/gcc4.8"
 
 if [ -e "$TBBROOT/lib/$TBB_LIB_DIR/$TBB_LIB_NAME" ]; then
-    export TBBROOT
+  export TBBROOT
 
-    LIBRARY_PATH=$(prepend_path "${TBBROOT}/lib/$TBB_LIB_DIR" "${LIBRARY_PATH:-}") ; export LIBRARY_PATH
-    LD_LIBRARY_PATH=$(prepend_path "${TBBROOT}/lib/$TBB_LIB_DIR" "${LD_LIBRARY_PATH:-}") ; export LD_LIBRARY_PATH
-    CPATH=$(prepend_path "${TBBROOT}/include" "${CPATH:-}") ; export CPATH
-    CMAKE_PREFIX_PATH=$(prepend_path "${TBBROOT}" "${CMAKE_PREFIX_PATH:-}") ; export CMAKE_PREFIX_PATH
+  LIBRARY_PATH=$(prepend_path "${TBBROOT}/lib/$TBB_LIB_DIR" "${LIBRARY_PATH:-}") ; export LIBRARY_PATH
+  LD_LIBRARY_PATH=$(prepend_path "${TBBROOT}/lib/$TBB_LIB_DIR" "${LD_LIBRARY_PATH:-}") ; export LD_LIBRARY_PATH
+  CPATH=$(prepend_path "${TBBROOT}/include" "${CPATH:-}") ; export CPATH
+  CMAKE_PREFIX_PATH=$(prepend_path "${TBBROOT}" "${CMAKE_PREFIX_PATH:-}") ; export CMAKE_PREFIX_PATH
 else
-    >&2 echo "ERROR: $TBB_LIB_NAME library does not exist in $TBBROOT/lib/$TBB_LIB_DIR."
-    return 255 2>/dev/null || exit 255
+  >&2 echo "ERROR: $TBB_LIB_NAME library does not exist in $TBBROOT/lib/$TBB_LIB_DIR."
+  return 255 2>/dev/null || exit 255
 fi


### PR DESCRIPTION
`SETVARS_ARGS` variable is not parsed properly, if it contains more than one argument. There are also `shellcheck` scan error and warnings fixes in this PR.