### PR TITLE
Remove the same test cases to fix MIPS compilation

### DIFF
--- a/test/tbb/test_join_node_msg_key_matching.cpp
+++ b/test/tbb/test_join_node_msg_key_matching.cpp
@@ -87,7 +87,7 @@ using T10 = make_tuple < T9, MyMessageKeyWithBrokenKey<std::string, size_t>>;
 // the compiler might generate huge object file in debug (>64M)
 #define TEST_CASE_TEMPLATE_N_ARGS(dec) TEST_CASE_TEMPLATE(dec, T, T2, T3, T4, T5, T6, T7, T8, T9, T10)
 #else
-#define TEST_CASE_TEMPLATE_N_ARGS(dec) TEST_CASE_TEMPLATE(dec, T, T2, T5)
+#define TEST_CASE_TEMPLATE_N_ARGS(dec) TEST_CASE_TEMPLATE(dec, T, T2, T10)
 #endif
 
 //! Serial test with different tuple sizes

--- a/test/tbb/test_join_node_msg_key_matching.cpp
+++ b/test/tbb/test_join_node_msg_key_matching.cpp
@@ -70,13 +70,6 @@ void test_deduction_guides() {
 }
 #endif
 
-//! Serial test with matching policies
-//! \brief \ref error_guessing
-TEST_CASE("Serial test") {
-    generate_test<serial_test, std::tuple<MyMessageKeyWithBrokenKey<int, double>, MyMessageKeyWithoutKey<int, float> >, message_based_key_matching<int> >::do_test();
-    generate_test<serial_test, std::tuple<MyMessageKeyWithoutKeyMethod<std::string, double>, MyMessageKeyWithBrokenKey<std::string, float> >, message_based_key_matching<std::string> >::do_test();
-}
-
 template <typename T1, typename T2>
 using make_tuple = decltype(std::tuple_cat(T1(), std::tuple<T2>()));
 using T1 = std::tuple<MyMessageKeyWithoutKeyMethod<std::string, double>>;
@@ -94,7 +87,7 @@ using T10 = make_tuple < T9, MyMessageKeyWithBrokenKey<std::string, size_t>>;
 // the compiler might generate huge object file in debug (>64M)
 #define TEST_CASE_TEMPLATE_N_ARGS(dec) TEST_CASE_TEMPLATE(dec, T, T2, T3, T4, T5, T6, T7, T8, T9, T10)
 #else
-#define TEST_CASE_TEMPLATE_N_ARGS(dec) TEST_CASE_TEMPLATE(dec, T, T2, T5, T8, T10)
+#define TEST_CASE_TEMPLATE_N_ARGS(dec) TEST_CASE_TEMPLATE(dec, T, T2, T5)
 #endif
 
 //! Serial test with different tuple sizes
@@ -107,6 +100,13 @@ TEST_CASE_TEMPLATE_N_ARGS("Serial N tests") {
 //! \brief \ref error_guessing
 TEST_CASE_TEMPLATE_N_ARGS("Parallel N tests") {
     generate_test<parallel_test, T, message_based_key_matching<std::string&> >::do_test();
+}
+
+//! Serial test with matching policies
+//! \brief \ref error_guessing
+TEST_CASE("Serial test") {
+    generate_test<serial_test, std::tuple<MyMessageKeyWithBrokenKey<int, double>, MyMessageKeyWithoutKey<int, float> >, message_based_key_matching<int> >::do_test();
+    generate_test<serial_test, std::tuple<MyMessageKeyWithoutKeyMethod<std::string, double>, MyMessageKeyWithBrokenKey<std::string, float> >, message_based_key_matching<std::string> >::do_test();
 }
 
 //! Parallel test with special key types
@@ -124,10 +124,3 @@ TEST_CASE("Deduction guides test"){
     test_deduction_guides();
 }
 #endif
-
-//! Serial test with special key types
-//! \brief \ref error_guessing
-TEST_CASE("Serial test"){
-    generate_test<serial_test, std::tuple<MyMessageKeyWithBrokenKey<int, double>, MyMessageKeyWithoutKey<int, float> >, message_based_key_matching<int> >::do_test();
-    generate_test<serial_test, std::tuple<MyMessageKeyWithoutKeyMethod<std::string, double>, MyMessageKeyWithBrokenKey<std::string, float> >, message_based_key_matching<std::string> >::do_test();
-}


### PR DESCRIPTION
The `relocation truncated to fit: R_MIPS_GOT_PAGE against` issue occurred during the MIPS debug compilation when GOT taking more than 64Kb. Now, this issue appeared during the `test_join_node_msg_key_matching` compilation. There are two same test cases in this test, so removing one of them reduces the size of GOT fixes the issue.

The possible more general solution is to split too complex tests into several exe files on MIPS to reduce the size of GOT and get rid of the problem.