### PR TITLE
ASAN fix for test_malloc_regression

### DIFF
--- a/test/common/config.h
+++ b/test/common/config.h
@@ -74,4 +74,16 @@ const unsigned MByte = 1024*1024;
 #define __TBB_TEST_SKIP_AFFINITY 1
 #endif
 
+#ifdef __has_feature
+	#define __TBB_HAS_FEATURE(x) __has_feature(x)
+#else
+	#define __TBB_HAS_FEATURE(x) 0
+#endif
+
+#ifdef __SANITIZE_ADDRESS__
+	#define __TBB_TEST_USE_ADDRESS_SANITIZER 1
+#else
+	#define __TBB_TEST_USE_ADDRESS_SANITIZER __TBB_HAS_FEATURE(address_sanitizer)
+#endif
+
 #endif /* __TBB_test_common_config_H */

--- a/test/common/config.h
+++ b/test/common/config.h
@@ -74,16 +74,12 @@ const unsigned MByte = 1024*1024;
 #define __TBB_TEST_SKIP_AFFINITY 1
 #endif
 
-#ifdef __has_feature
-	#define __TBB_HAS_FEATURE(x) __has_feature(x)
-#else
-	#define __TBB_HAS_FEATURE(x) 0
-#endif
-
 #ifdef __SANITIZE_ADDRESS__
 	#define __TBB_TEST_USE_ADDRESS_SANITIZER 1
-#else
-	#define __TBB_TEST_USE_ADDRESS_SANITIZER __TBB_HAS_FEATURE(address_sanitizer)
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer)
+      #define __TBB_TEST_USE_ADDRESS_SANITIZER 1
+#endif
 #endif
 
 #endif /* __TBB_test_common_config_H */

--- a/test/common/memory_usage.h
+++ b/test/common/memory_usage.h
@@ -26,6 +26,10 @@
 #include "utils.h"
 #include "utils_assert.h"
 
+#if __TBB_TEST_USE_ADDRESS_SANITIZER
+#include <sanitizer/allocator_interface.h>
+#endif
+
 #if __linux__ || __sun
 #include <sys/resource.h>
 #include <unistd.h>
@@ -86,7 +90,10 @@ namespace utils {
     /* Returns 0 if not implemented on platform. */
     std::size_t GetMemoryUsage(MemoryStatType stat = currentUsage) {
         utils::suppress_unused_warning(stat);
-#if __TBB_WIN8UI_SUPPORT || defined(WINAPI_FAMILY)
+#if __TBB_TEST_USE_ADDRESS_SANITIZER
+        // Under ASAN generic memory usage functions provide information with ASAN overhead.
+        return __sanitizer_get_current_allocated_bytes();
+#elif __TBB_WIN8UI_SUPPORT || defined(WINAPI_FAMILY)
         return 0;
 #elif _WIN32
         PROCESS_MEMORY_COUNTERS mem;


### PR DESCRIPTION
Malloc regression test checks memory leaks by comparing allocated memory before and after the test.
ASAN allocator never releases memory to OS, instead of it just marks those memory as "freed".
Generic OS functions for getting currently allocated memory aren't working correctly under ASAN.
Have to use __sanitizer_get_current_allocated_bytes function in this case.