### PR TITLE
Fix tests compilation on FreeBSD

### DIFF
--- a/test/common/utils_concurrency_limit.h
+++ b/test/common/utils_concurrency_limit.h
@@ -171,9 +171,15 @@ int limit_number_of_threads( int max_threads ) {
 #define OS_AFFINITY_SYSCALL_PRESENT ((__linux__ && !__ANDROID__) || (__FreeBSD_version >= 701000))
 
 #if OS_AFFINITY_SYSCALL_PRESENT
+
+#if __FreeBSD__
+using mask_t = cpuset_t;
+#else
+using mask_t = cpu_set_t;
+#endif
 void get_thread_affinity_mask(std::size_t& ncpus, std::vector<int>& free_indexes) {
-    cpu_set_t* mask = nullptr;
-    ncpus = sizeof(cpu_set_t) * CHAR_BIT;
+    mask_t* mask = nullptr;
+    ncpus = sizeof(mask_t) * CHAR_BIT;
     do {
         mask = CPU_ALLOC(ncpus);
         if (!mask) break;
@@ -206,7 +212,7 @@ void pin_thread_imp(std::size_t ncpus, std::vector<int>& free_indexes, std::atom
     ASSERT(free_indexes.size() > 0, nullptr);
     int mapped_idx = free_indexes[curr_idx++ % free_indexes.size()];
 
-    cpu_set_t *target_mask = CPU_ALLOC(ncpus);
+    mask_t *target_mask = CPU_ALLOC(ncpus);
     ASSERT(target_mask, nullptr);
     CPU_ZERO_S(size, target_mask);
     CPU_SET_S(mapped_idx, size, target_mask);

--- a/test/common/utils_concurrency_limit.h
+++ b/test/common/utils_concurrency_limit.h
@@ -168,18 +168,13 @@ int limit_number_of_threads( int max_threads ) {
 
 #endif // __TBB_TEST_SKIP_AFFINITY
 
-#define OS_AFFINITY_SYSCALL_PRESENT ((__linux__ && !__ANDROID__) || (__FreeBSD_version >= 701000))
+#define OS_AFFINITY_SYSCALL_PRESENT (__linux__ && !__ANDROID__)
 
 #if OS_AFFINITY_SYSCALL_PRESENT
 
-#if __FreeBSD__
-using mask_t = cpuset_t;
-#else
-using mask_t = cpu_set_t;
-#endif
 void get_thread_affinity_mask(std::size_t& ncpus, std::vector<int>& free_indexes) {
-    mask_t* mask = nullptr;
-    ncpus = sizeof(mask_t) * CHAR_BIT;
+    cpu_set_t* mask = nullptr;
+    ncpus = sizeof(cpu_set_t) * CHAR_BIT;
     do {
         mask = CPU_ALLOC(ncpus);
         if (!mask) break;
@@ -212,7 +207,7 @@ void pin_thread_imp(std::size_t ncpus, std::vector<int>& free_indexes, std::atom
     ASSERT(free_indexes.size() > 0, nullptr);
     int mapped_idx = free_indexes[curr_idx++ % free_indexes.size()];
 
-    mask_t *target_mask = CPU_ALLOC(ncpus);
+    cpu_set_t *target_mask = CPU_ALLOC(ncpus);
     ASSERT(target_mask, nullptr);
     CPU_ZERO_S(size, target_mask);
     CPU_SET_S(mapped_idx, size, target_mask);

--- a/test/common/utils_concurrency_limit.h
+++ b/test/common/utils_concurrency_limit.h
@@ -168,10 +168,10 @@ int limit_number_of_threads( int max_threads ) {
 
 #endif // __TBB_TEST_SKIP_AFFINITY
 
+// TODO: consider using cpuset_setaffinity/sched_getaffinity on FreeBSD to enable the functionality
 #define OS_AFFINITY_SYSCALL_PRESENT (__linux__ && !__ANDROID__)
 
 #if OS_AFFINITY_SYSCALL_PRESENT
-
 void get_thread_affinity_mask(std::size_t& ncpus, std::vector<int>& free_indexes) {
     cpu_set_t* mask = nullptr;
     ncpus = sizeof(cpu_set_t) * CHAR_BIT;

--- a/test/tbbmalloc/test_malloc_compliance.cpp
+++ b/test/tbbmalloc/test_malloc_compliance.cpp
@@ -91,7 +91,7 @@ void limitMem( size_t limit )
     }
     if (rlim.rlim_max==(rlim_t)RLIM_INFINITY)
         rlim.rlim_cur = (limit > 0) ? limit*MByte : rlim.rlim_max;
-    else rlim.rlim_cur = (limit > 0 && limit<rlim.rlim_max) ? limit*MByte : rlim.rlim_max;
+    else rlim.rlim_cur = (limit > 0 && static_cast<rlim_t>(limit)<rlim.rlim_max) ? limit*MByte : rlim.rlim_max;
     ret = setrlimit(RLIMIT_AS,&rlim);
     if (0 != ret) {
         REPORT("Can't set limits: errno %d\n", errno);


### PR DESCRIPTION
There are several issues during the compilation and linking oneTBB library on the FreeBSD OS. This patch fixes it.

One of the issues is related to the TBBbind compilation (and linking with the HWLOC library), so this patch also actualizes the TBBbind related CMake documentation and adds a new option for disabling the TBBBind library build.