### PR TITLE
Solve the issue with different incompatible HWLOC library versions in one executable

### DIFF
--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -408,10 +408,10 @@ namespace r1 {
     #endif /* __TBB_DYNAMIC_LOAD_ENABLED */
     }
 
-    dynamic_link_handle dynamic_load( const char* library, const dynamic_link_descriptor descriptors[], std::size_t required ) {
+    dynamic_link_handle dynamic_load( const char* library, const dynamic_link_descriptor descriptors[], std::size_t required, bool is_local ) {
         ::tbb::detail::suppress_unused_warning( library, descriptors, required );
 #if __TBB_DYNAMIC_LOAD_ENABLED
-
+        auto flags = is_local ? (RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND) : (RTLD_NOW | RTLD_GLOBAL);
         std::size_t const len = PATH_MAX + 1;
         char path[ len ];
         std::size_t rc = abs_path( library, path, len );
@@ -421,7 +421,7 @@ namespace r1 {
             // (e.g. because of MS runtime problems - one of those crazy manifest related ones)
             UINT prev_mode = SetErrorMode (SEM_FAILCRITICALERRORS);
 #endif /* _WIN32 */
-            dynamic_link_handle library_handle = dlopen( path, RTLD_NOW | RTLD_GLOBAL );
+            dynamic_link_handle library_handle = dlopen( path, flags );
 #if _WIN32
             SetErrorMode (prev_mode);
 #endif /* _WIN32 */
@@ -448,8 +448,8 @@ namespace r1 {
         // TODO: May global_symbols_link find weak symbols?
         dynamic_link_handle library_handle = ( flags & DYNAMIC_LINK_GLOBAL ) ? global_symbols_link( library, descriptors, required ) : 0;
 
-        if ( !library_handle && ( flags & DYNAMIC_LINK_LOAD ) )
-            library_handle = dynamic_load( library, descriptors, required );
+        if ( !library_handle && ( ( flags & DYNAMIC_LINK_LOAD ) || ( flags & DYNAMIC_LINK_LOCAL_SCOPE ) ) )
+            library_handle = dynamic_load( library, descriptors, required, ( flags & DYNAMIC_LINK_LOCAL_SCOPE ) );
 
         if ( !library_handle && ( flags & DYNAMIC_LINK_WEAK ) )
             return weak_symbol_link( descriptors, required );

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -408,10 +408,9 @@ namespace r1 {
     #endif /* __TBB_DYNAMIC_LOAD_ENABLED */
     }
 
-    int define_flags(bool is_local) {
-        int flags = 0;
 #if !_WIN32
-        flags = flags | RTLD_NOW;
+    int define_flags(bool is_local) {
+        int flags = RTLD_NOW;
         if (is_local) {
             flags = flags | RTLD_LOCAL;
 #if !__APPLE__
@@ -420,9 +419,11 @@ namespace r1 {
         } else {
             flags = flags | RTLD_GLOBAL;
         }
-#endif /*!_WIN32*/
         return flags;
     }
+#else /*_WIN32*/
+    int define_flags(bool) { return 0; }
+#endif /*_WIN32*/
 
     dynamic_link_handle dynamic_load( const char* library, const dynamic_link_descriptor descriptors[], std::size_t required, bool is_local ) {
         ::tbb::detail::suppress_unused_warning( library, descriptors, required );

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -426,7 +426,7 @@ namespace r1 {
 #endif /*_WIN32*/
 
     dynamic_link_handle dynamic_load( const char* library, const dynamic_link_descriptor descriptors[], std::size_t required, bool is_local ) {
-        ::tbb::detail::suppress_unused_warning( library, descriptors, required );
+        ::tbb::detail::suppress_unused_warning( library, descriptors, required, is_local );
 #if __TBB_DYNAMIC_LOAD_ENABLED
         std::size_t const len = PATH_MAX + 1;
         char path[ len ];

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -413,9 +413,9 @@ namespace r1 {
         int flags = RTLD_NOW;
         if (is_local) {
             flags = flags | RTLD_LOCAL;
-#if !__APPLE__
+#if __linux__ && !__ANDROID__
             flags = flags | RTLD_DEEPBIND;
-#endif /*!__APPLE__*/
+#endif /*__linux__ && !__ANDROID__*/
         } else {
             flags = flags | RTLD_GLOBAL;
         }

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -411,7 +411,6 @@ namespace r1 {
     dynamic_link_handle dynamic_load( const char* library, const dynamic_link_descriptor descriptors[], std::size_t required, bool is_local ) {
         ::tbb::detail::suppress_unused_warning( library, descriptors, required );
 #if __TBB_DYNAMIC_LOAD_ENABLED
-        auto flags = is_local ? (RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND) : (RTLD_NOW | RTLD_GLOBAL);
         std::size_t const len = PATH_MAX + 1;
         char path[ len ];
         std::size_t rc = abs_path( library, path, len );
@@ -421,6 +420,15 @@ namespace r1 {
             // (e.g. because of MS runtime problems - one of those crazy manifest related ones)
             UINT prev_mode = SetErrorMode (SEM_FAILCRITICALERRORS);
 #endif /* _WIN32 */
+            auto flags = RTLD_NOW;
+            if (is_local) {
+                flags = flags | RTLD_LOCAL;
+#if !__APPLE__
+                flags = flags | RTLD_DEEPBIND;
+#endif
+            } else {
+                flags = flags | RTLD_GLOBAL;
+            }
             dynamic_link_handle library_handle = dlopen( path, flags );
 #if _WIN32
             SetErrorMode (prev_mode);

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -464,9 +464,17 @@ namespace r1 {
         // TODO: May global_symbols_link find weak symbols?
         dynamic_link_handle library_handle = ( flags & DYNAMIC_LINK_GLOBAL ) ? global_symbols_link( library, descriptors, required ) : 0;
 
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+#pragma warning (push)
+// MSVC 2015 warning: 'int': forcing value to bool 'true' or 'false'
+#pragma warning (disable: 4800)
+#endif
         if ( !library_handle && ( flags & DYNAMIC_LINK_LOAD ) )
-            library_handle = dynamic_load( library, descriptors, required, ( flags & DYNAMIC_LINK_LOCAL_BINDING ) );
+            library_handle = dynamic_load( library, descriptors, required, flags & DYNAMIC_LINK_LOCAL_BINDING );
 
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+#pragma warning (pop)
+#endif
         if ( !library_handle && ( flags & DYNAMIC_LINK_WEAK ) )
             return weak_symbol_link( descriptors, required );
 

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -464,7 +464,7 @@ namespace r1 {
         // TODO: May global_symbols_link find weak symbols?
         dynamic_link_handle library_handle = ( flags & DYNAMIC_LINK_GLOBAL ) ? global_symbols_link( library, descriptors, required ) : 0;
 
-        if ( !library_handle && ( ( flags & DYNAMIC_LINK_LOAD ) || ( flags & DYNAMIC_LINK_LOCAL_BINDING ) ) )
+        if ( !library_handle && ( flags & DYNAMIC_LINK_LOAD ) )
             library_handle = dynamic_load( library, descriptors, required, ( flags & DYNAMIC_LINK_LOCAL_BINDING ) );
 
         if ( !library_handle && ( flags & DYNAMIC_LINK_WEAK ) )

--- a/src/tbb/dynamic_link.h
+++ b/src/tbb/dynamic_link.h
@@ -71,7 +71,7 @@ using dynamic_link_handle = void*;
 const int DYNAMIC_LINK_GLOBAL        = 0x01;
 const int DYNAMIC_LINK_LOAD          = 0x02;
 const int DYNAMIC_LINK_WEAK          = 0x04;
-const int DYNAMIC_LINK_LOCAL_SCOPE   = 0x08;
+const int DYNAMIC_LINK_LOCAL_BINDING = 0x08;
 const int DYNAMIC_LINK_DEFAULT       = DYNAMIC_LINK_GLOBAL | DYNAMIC_LINK_LOAD | DYNAMIC_LINK_WEAK;
 
 //! Fill in dynamically linked handlers.

--- a/src/tbb/dynamic_link.h
+++ b/src/tbb/dynamic_link.h
@@ -68,10 +68,11 @@ using dynamic_link_handle = HMODULE;
 using dynamic_link_handle = void*;
 #endif /* _WIN32 */
 
-const int DYNAMIC_LINK_GLOBAL = 0x01;
-const int DYNAMIC_LINK_LOAD   = 0x02;
-const int DYNAMIC_LINK_WEAK   = 0x04;
-const int DYNAMIC_LINK_ALL    = DYNAMIC_LINK_GLOBAL | DYNAMIC_LINK_LOAD | DYNAMIC_LINK_WEAK;
+const int DYNAMIC_LINK_GLOBAL        = 0x01;
+const int DYNAMIC_LINK_LOAD          = 0x02;
+const int DYNAMIC_LINK_WEAK          = 0x04;
+const int DYNAMIC_LINK_LOCAL_SCOPE   = 0x08;
+const int DYNAMIC_LINK_DEFAULT       = DYNAMIC_LINK_GLOBAL | DYNAMIC_LINK_LOAD | DYNAMIC_LINK_WEAK;
 
 //! Fill in dynamically linked handlers.
 /** 'library' is the name of the requested library. It should not contain a full
@@ -93,7 +94,7 @@ bool dynamic_link( const char* library,
                    const dynamic_link_descriptor descriptors[],
                    std::size_t required,
                    dynamic_link_handle* handle = 0,
-                   int flags = DYNAMIC_LINK_ALL );
+                   int flags = DYNAMIC_LINK_DEFAULT );
 
 void dynamic_unlink( dynamic_link_handle handle );
 

--- a/src/tbb/dynamic_link.h
+++ b/src/tbb/dynamic_link.h
@@ -71,7 +71,8 @@ using dynamic_link_handle = void*;
 const int DYNAMIC_LINK_GLOBAL        = 0x01;
 const int DYNAMIC_LINK_LOAD          = 0x02;
 const int DYNAMIC_LINK_WEAK          = 0x04;
-const int DYNAMIC_LINK_LOCAL_BINDING = 0x08;
+
+const int DYNAMIC_LINK_LOCAL_BINDING = 0x08 | DYNAMIC_LINK_LOAD;
 const int DYNAMIC_LINK_DEFAULT       = DYNAMIC_LINK_GLOBAL | DYNAMIC_LINK_LOAD | DYNAMIC_LINK_WEAK;
 
 //! Fill in dynamically linked handlers.

--- a/src/tbb/governor.cpp
+++ b/src/tbb/governor.cpp
@@ -390,7 +390,7 @@ const char* load_tbbbind_shared_object() {
     if (si.dwNumberOfProcessors > 32) return nullptr;
 #endif /* _WIN32 && !_WIN64 */
     for (const auto& tbbbind_version : {TBBBIND_2_4_NAME, TBBBIND_2_0_NAME, TBBBIND_NAME}) {
-        if (dynamic_link(tbbbind_version, TbbBindLinkTable, LinkTableSize, nullptr, DYNAMIC_LINK_LOCAL_SCOPE)) {
+        if (dynamic_link(tbbbind_version, TbbBindLinkTable, LinkTableSize, nullptr, DYNAMIC_LINK_LOCAL_BINDING)) {
             return tbbbind_version;
         }
     }

--- a/src/tbb/governor.cpp
+++ b/src/tbb/governor.cpp
@@ -390,7 +390,7 @@ const char* load_tbbbind_shared_object() {
     if (si.dwNumberOfProcessors > 32) return nullptr;
 #endif /* _WIN32 && !_WIN64 */
     for (const auto& tbbbind_version : {TBBBIND_2_4_NAME, TBBBIND_2_0_NAME, TBBBIND_NAME}) {
-        if (dynamic_link(tbbbind_version, TbbBindLinkTable, LinkTableSize)) {
+        if (dynamic_link(tbbbind_version, TbbBindLinkTable, LinkTableSize, nullptr, DYNAMIC_LINK_LOCAL_SCOPE)) {
             return tbbbind_version;
         }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -204,12 +204,12 @@ function(tbb_configure_hwloc_dependent_test)
         return()
     endif()
 
-    list(GET _hwloc_test_HWLOC_REQUIRED_VERSION_LIST 0 HWLOC_MAXIMAL_VERSION)
+    list(GET _hwloc_test_HWLOC_REQUIRED_VERSION_LIST 0 TEST_HWLOC_VERSION)
     tbb_add_test(
         SUBDIR ${_hwloc_test_SUBDIR}
         NAME ${_hwloc_test_NAME}
         SUFFIX ${_hwloc_test_SUFFIX}
-        DEPENDENCIES TBB::tbb HWLOC::${HWLOC_MAXIMAL_VERSION}
+        DEPENDENCIES TBB::tbb HWLOC::${TEST_HWLOC_VERSION}
     )
 
     _tbb_get_hwloc_runtime_vars(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -298,6 +298,8 @@ function(tbb_add_tbbbind_test)
         hwloc_2_4_hwloc_1_11
         hwloc_2_hwloc_1_11
         hwloc_2_4_hwloc_2_hwloc_1_11
+        incompatible_hwlocs_1_11_vs_2_4
+        incompatible_hwlocs_1_11_vs_2
     )
 
     list(APPEND HWLOC_TEST_CASE_0_VARS tbbbind_2_4 "hwloc_2_4")
@@ -307,6 +309,8 @@ function(tbb_add_tbbbind_test)
     list(APPEND HWLOC_TEST_CASE_4_VARS tbbbind_2_4 "hwloc_2_4,hwloc_1_11")
     list(APPEND HWLOC_TEST_CASE_5_VARS tbbbind_2   "hwloc_2,hwloc_1_11")
     list(APPEND HWLOC_TEST_CASE_6_VARS tbbbind_2_4 "hwloc_2_4,hwloc_2,hwloc_1_11")
+    list(APPEND HWLOC_TEST_CASE_7_VARS tbbbind_2_4 "hwloc_1_11,hwloc_2_4")
+    list(APPEND HWLOC_TEST_CASE_8_VARS tbbbind_2   "hwloc_1_11,hwloc_2")
 
     foreach(TEST_CASE ${HWLOC_TEST_CASES})
         list(FIND HWLOC_TEST_CASES ${TEST_CASE} TEST_CASE_INDEX)


### PR DESCRIPTION
HWLOC library has two incompatible versions: 1.x and 2.x. But the part of C-style entry points in both of these versions have the same names which cause the following issue: If the application links with one HWLOC version and oneTBB loads the incompatible HWLOC library version using `dlopen()`, then the HWLOC shared object that was shared later will use some entry points from the already loaded version. That's because oneTBB loads the HWLOC shared object with the `RTLD_GLOBAL`  flag.

This patch fixes this issue by loading the HWLOC with the right flags (`RTLD_LOCAL` and `RTLD_DEEPBIND`) which places the symbols into the local scope and use only loaded symbols.

Signed-off-by: Kochin Ivan <kochin.ivan@intel.com>