### PR TITLE
arena: Remove dead code

### DIFF
--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -232,14 +232,13 @@ void arena::free_arena () {
     __TBB_ASSERT( !my_global_concurrency_mode, NULL );
 #endif
     poison_value( my_guard );
-    std::intptr_t drained = 0;
     for ( unsigned i = 0; i < my_num_slots; ++i ) {
         // __TBB_ASSERT( !my_slots[i].my_scheduler, "arena slot is not empty" );
         // TODO: understand the assertion and modify
         // __TBB_ASSERT( my_slots[i].task_pool == EmptyTaskPool, NULL );
         __TBB_ASSERT( my_slots[i].head == my_slots[i].tail, NULL ); // TODO: replace by is_quiescent_local_task_pool_empty
         my_slots[i].free_task_pool();
-        drained += mailbox(i).drain();
+        mailbox(i).drain();
         my_slots[i].my_default_task_dispatcher->~task_dispatcher();
     }
     __TBB_ASSERT(my_fifo_task_stream.empty(), "Not all enqueued tasks were executed");
@@ -776,4 +775,3 @@ void isolate_within_arena(d1::delegate_base& d, std::intptr_t isolation) {
 } // namespace r1
 } // namespace detail
 } // namespace tbb
-

--- a/src/tbb/mailbox.h
+++ b/src/tbb/mailbox.h
@@ -186,14 +186,12 @@ public:
     }
 
     //! Drain the mailbox
-    intptr_t drain() {
-        intptr_t k = 0;
+    void drain() {
         // No fences here because other threads have already quit.
-        for( ; task_proxy* t = my_first; ++k ) {
+        for( ; task_proxy* t = my_first; ) {
             my_first.store(t->next_in_mailbox, std::memory_order_relaxed);
             // cache_aligned_deallocate((char*)t - task_prefix_reservation_size);
         }
-        return k;
     }
 
     //! True if thread that owns this mailbox is looking for work.


### PR DESCRIPTION
Fixes clang warning
arena.cpp:226:19: error: variable 'drained' set b
ut not used [-Werror,-Wunused-but-set-variable]
|     std::intptr_t drained = 0;
|                   ^

Signed-off-by: Khem Raj <raj.khem@gmail.com>