### PR TITLE
Fix leaking proxy task objects

### DIFF
--- a/src/tbb/mailbox.h
+++ b/src/tbb/mailbox.h
@@ -191,7 +191,7 @@ public:
         // No fences here because other threads have already quit.
         for( ; task_proxy* t = my_first; ++k ) {
             my_first.store(t->next_in_mailbox, std::memory_order_relaxed);
-            // cache_aligned_deallocate((char*)t - task_prefix_reservation_size);
+            t->allocator.delete_object(t);
         }
         return k;
     }

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -1687,7 +1687,7 @@ void StressTestMixFunctionality() {
                     });
 
                     break;
-                }               
+                }
                 case enqueue_task :
                 {
                     tbb::spin_rw_mutex::scoped_lock lock{};

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -1687,34 +1687,7 @@ void StressTestMixFunctionality() {
                     });
 
                     break;
-                }
-                {
-                    tbb::spin_rw_mutex::scoped_lock lock{};
-                    auto curr_arena = arenas_pool.begin();
-                    for (; curr_arena != arenas_pool.end(); ++curr_arena) {
-                        if (lock.try_acquire(curr_arena->arena_in_use, /*writer*/ false)) {
-                            if (curr_arena->status == arena_handler::alive) {
-                                break;
-                            }
-                            else {
-                                lock.release();
-                            }
-                        }
-                    }
-
-                    if (curr_arena == arenas_pool.end()) break;
-
-                    curr_arena->arena->execute([]() {
-                        static tbb::affinity_partitioner aff;
-                        tbb::parallel_for(tbb::blocked_range<std::size_t>(0, 10000), [](tbb::blocked_range<std::size_t>&) {
-                            std::atomic<int> sum{};
-                            // Make some work
-                            for (; sum < 10; ++sum);
-                        }, aff);
-                    });
-
-                    break;
-                }
+                }               
                 case enqueue_task :
                 {
                     tbb::spin_rw_mutex::scoped_lock lock{};


### PR DESCRIPTION
It seems during revamp we forget to add clean up logic for proxy task when destroying arena.

Signed-off-by: Alexei Katranov <alexei.katranov@intel.com>