### PR TITLE
Fix some gcc11 warnings

### DIFF
--- a/include/oneapi/tbb/detail/_flow_graph_types_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_types_impl.h
@@ -169,7 +169,7 @@ private:
     // default-initialized and then copied to in some fashion, resulting in two
     // constructions and one destruction per element.  If the type is char[ ], we
     // placement new into each element, resulting in one construction per element.
-    static const size_t space_size = sizeof(ArrayType) / sizeof(char);
+    static const size_t space_size = sizeof(ArrayType);
     char value_space[space_size];
 
 

--- a/test/tbbmalloc/test_malloc_overload.cpp
+++ b/test/tbbmalloc/test_malloc_overload.cpp
@@ -448,7 +448,10 @@ TEST_CASE("Main set of tests") {
     CheckMemalignFuncOverload(aligned_alloc, free);
 #endif
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     struct mallinfo info = mallinfo();
+#pragma GCC diagnostic pop
     // right now mallinfo initialized by zero
     REQUIRE((!info.arena && !info.ordblks && !info.smblks && !info.hblks
            && !info.hblkhd && !info.usmblks && !info.fsmblks


### PR DESCRIPTION
Fix two warnings with gcc 11:
1. `mallinfo` deprectaion warning in `test_malloc_overload`. In theory we need to extend `tbbmalloc_proxy` with `mallinfo2` but it will bring dependency on libc 2.33, so release notes should be updated.
2. `expression does not compute the number of elements in this array` (`-Wsizeof-array-div]`) in flow graph tests.

Signed-off-by: Alexei Katranov <alexei.katranov@intel.com>