### PR TITLE
ASAN: skip test_malloc_atexit under ASAN

### DIFF
--- a/test/tbbmalloc/test_malloc_atexit.cpp
+++ b/test/tbbmalloc/test_malloc_atexit.cpp
@@ -82,7 +82,7 @@ void *realloc(void *ptr, size_t size)
 
 // Even when the test is skipped, dll source must not be empty to generate .lib to link with.
 
-#ifndef _PGO_INSTRUMENT
+#if !defined(_PGO_INSTRUMENT) && !__TBB_TEST_USE_ADDRESS_SANITIZER
 void dummyFunction() {}
 
 // TODO: enable the check under Android
@@ -132,7 +132,7 @@ public:
 };
 
 static Foo f;
-#endif
+#endif // !defined(_PGO_INSTRUMENT) && !__TBB_TEST_USE_ADDRESS_SANITIZER
 
 int main() {}
 
@@ -149,6 +149,9 @@ bool dll_isMallocOverloaded();
 #ifdef _PGO_INSTRUMENT
 //! \brief \ref error_guessing
 TEST_CASE("Known issue: test_malloc_atexit hangs if compiled with -prof-genx\n" * doctest::skip(true)) {}
+#elif __TBB_TEST_USE_ADDRESS_SANITIZER
+//! \brief \ref error_guessing
+TEST_CASE("Known issue: test_malloc_atexit is not applicable under ASAN\n" * doctest::skip(true)) {}
 #else
 // Check common/allocator_overload.h for skip cases
 #if !HARNESS_SKIP_TEST


### PR DESCRIPTION
During test_malloc_atexit memory is allocated bypass the ASAN and it causes ASAN bad-malloc_usable_size issue.
"Attempting to call malloc_usable_size() for pointer which is not owned"
Skip test_malloc_atexit since it not applicable under ASAN.
