### PR TITLE
Use mallinfo2 API where possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ unset(_tbb_ver_minor)
 include(CheckCXXCompilerFlag)
 include(GNUInstallDirs)
 
+include(CheckSymbolExists)
+
 # ---------------------------------------------------------------------------------------------------------
 # Handle C++ standard version.
 if (NOT MSVC)  # no need to cover MSVC as it uses C++14 by default.
@@ -228,6 +230,13 @@ else()
             DESTINATION ${CMAKE_INSTALL_DOCDIR}
             COMPONENT devel)
     # -------------------------------------------------------------------
+endif()
+
+check_symbol_exists(mallinfo2 "malloc.h" HAVE_MALLINFO2)
+
+# Add compile definitions if we have mallinfo ( glibc >= 2.33 )
+if (HAVE_MALLINFO2)
+    set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -DHAVE_MALLINFO2)
 endif()
 
 if (TBB_TEST)

--- a/src/tbbmalloc_proxy/CMakeLists.txt
+++ b/src/tbbmalloc_proxy/CMakeLists.txt
@@ -35,6 +35,10 @@ if (NOT APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
                              $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},5.0>>:-Wno-sized-deallocation>)
 endif()
 
+if (HAVE_MALLINFO2)
+    set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -DHAVE_MALLINFO2)
+endif()
+
 target_compile_options(tbbmalloc_proxy
     PRIVATE
     ${TBB_CXX_STD_FLAG} # TODO: consider making it PUBLIC.

--- a/src/tbbmalloc_proxy/def/lin32-proxy.def
+++ b/src/tbbmalloc_proxy/def/lin32-proxy.def
@@ -26,6 +26,7 @@ aligned_alloc;
 valloc;
 pvalloc;
 mallinfo;
+mallinfo2;
 mallopt;
 malloc_usable_size;
 __libc_malloc;

--- a/src/tbbmalloc_proxy/def/lin64-proxy.def
+++ b/src/tbbmalloc_proxy/def/lin64-proxy.def
@@ -26,6 +26,7 @@ aligned_alloc;
 valloc;
 pvalloc;
 mallinfo;
+mallinfo2;
 mallopt;
 malloc_usable_size;
 __libc_malloc;

--- a/src/tbbmalloc_proxy/proxy.cpp
+++ b/src/tbbmalloc_proxy/proxy.cpp
@@ -256,10 +256,16 @@ int mallopt(int /*param*/, int /*value*/) __THROW
     return 1;
 }
 
-struct mallinfo mallinfo() __THROW
+#ifdef HAVE_MALLINFO2
+#define MALLINFO mallinfo2
+#else
+#define MALLINFO mallinfo
+#endif
+
+struct MALLINFO MALLINFO() __THROW
 {
-    struct mallinfo m;
-    memset(&m, 0, sizeof(struct mallinfo));
+    struct MALLINFO m;
+    memset(&m, 0, sizeof(struct MALLINFO));
 
     return m;
 }

--- a/test/tbbmalloc/test_malloc_overload.cpp
+++ b/test/tbbmalloc/test_malloc_overload.cpp
@@ -448,7 +448,11 @@ TEST_CASE("Main set of tests") {
     CheckMemalignFuncOverload(aligned_alloc, free);
 #endif
 
+#ifdef HAVE_MALLINFO2
+    struct mallinfo2 info = mallinfo2();
+#else
     struct mallinfo info = mallinfo();
+#endif
     // right now mallinfo initialized by zero
     REQUIRE((!info.arena && !info.ordblks && !info.smblks && !info.hblks
            && !info.hblkhd && !info.usmblks && !info.fsmblks


### PR DESCRIPTION
glibc 2.33+ has introduced this API and actively deprecated the old
mallinfo API, therefore it will be prudent to enquire the platform for
what it can support and conditionalize the code accordingly with
preference to use mallinfo2 if available.

Signed-off-by: Khem Raj <raj.khem@gmail.com>