### PR TITLE
ASAN: disable test_eh_thread

### DIFF
--- a/test/tbb/test_eh_thread.cpp
+++ b/test/tbb/test_eh_thread.cpp
@@ -33,7 +33,9 @@
 
 // On Windows there is no real thread number limit beside available memory.
 // Therefore, the test for thread limit is unreasonable.
-#if TBB_USE_EXCEPTIONS && !_WIN32 && !__ANDROID__
+//
+// Under ASAN current approach is not viable as it breaks the ASAN itself as well
+#if TBB_USE_EXCEPTIONS && !_WIN32 && !__ANDROID__ && !__TBB_TEST_USE_ADDRESS_SANITIZER
 
 static bool g_exception_caught = false;
 static std::mutex m;

--- a/test/tbbmalloc/test_malloc_new_handler.cpp
+++ b/test/tbbmalloc/test_malloc_new_handler.cpp
@@ -24,7 +24,8 @@
 
 #include "common/allocator_overload.h"
 
-#if !HARNESS_SKIP_TEST && TBB_USE_EXCEPTIONS
+// Under ASAN current approach is not viable as it breaks the ASAN itself as well
+#if !HARNESS_SKIP_TEST && TBB_USE_EXCEPTIONS && !__TBB_TEST_USE_ADDRESS_SANITIZER
 
 #if _MSC_VER
 #pragma warning (push)


### PR DESCRIPTION
Current approach of the test seems to push ASAN beyond it's limit. So do not run the test under ASAN