### PR TITLE
Fix dlopen flags for loading tbbmalloc and rml

### DIFF
--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -28,6 +28,10 @@
 /* Check which standard library we use. */
 #include <cstddef>
 
+#if !defined(__has_feature)
+#define __has_feature(feature) 0
+#endif
+
 #if _MSC_VER
     #define __TBB_EXPORTED_FUNC   __cdecl
     #define __TBB_EXPORTED_METHOD __thiscall
@@ -204,6 +208,11 @@
     #define __TBB_USE_OPTIONAL_RTTI 1
 #else
     #define __TBB_USE_OPTIONAL_RTTI (__GXX_RTTI || __RTTI || __INTEL_RTTI__)
+#endif
+
+/** Address sanitizer detection **/
+#if __SANITIZE_ADDRESS__ || (__clang__ && __has_feature(address_sanitizer))
+#define __TBB_SANITIZE_ADDRESS 1
 #endif
 
 /** Library features presence macros **/

--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -28,10 +28,6 @@
 /* Check which standard library we use. */
 #include <cstddef>
 
-#if !defined(__has_feature)
-#define __has_feature(feature) 0
-#endif
-
 #if _MSC_VER
     #define __TBB_EXPORTED_FUNC   __cdecl
     #define __TBB_EXPORTED_METHOD __thiscall
@@ -211,8 +207,12 @@
 #endif
 
 /** Address sanitizer detection **/
-#if __SANITIZE_ADDRESS__ || (__clang__ && __has_feature(address_sanitizer))
-#define __TBB_SANITIZE_ADDRESS 1
+#ifdef __SANITIZE_ADDRESS__
+    #define __TBB_USE_ADDRESS_SANITIZER 1
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer)
+    #define __TBB_USE_ADDRESS_SANITIZER 1
+#endif
 #endif
 
 /** Library features presence macros **/

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -413,9 +413,9 @@ namespace r1 {
         int flags = RTLD_NOW;
         if (local_binding) {
             flags = flags | RTLD_LOCAL;
-#if __linux__ && !__ANDROID__ && !__TBB_SANITIZE_ADDRESS
+#if __linux__ && !__ANDROID__ && !__TBB_USE_ADDRESS_SANITIZER
             flags = flags | RTLD_DEEPBIND;
-#endif /*__linux__ && !__ANDROID__ && !__TBB_SANITIZE_ADDRESS*/
+#endif /*__linux__ && !__ANDROID__ && !__TBB_USE_ADDRESS_SANITIZER*/
         } else {
             flags = flags | RTLD_GLOBAL;
         }

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -413,9 +413,9 @@ namespace r1 {
         int flags = RTLD_NOW;
         if (local_binding) {
             flags = flags | RTLD_LOCAL;
-#if __linux__ && !__ANDROID__
+#if __linux__ && !__ANDROID__ && !__TBB_SANITIZE_ADDRESS
             flags = flags | RTLD_DEEPBIND;
-#endif /*__linux__ && !__ANDROID__*/
+#endif /*__linux__ && !__ANDROID__ && !__TBB_SANITIZE_ADDRESS*/
         } else {
             flags = flags | RTLD_GLOBAL;
         }
@@ -470,7 +470,7 @@ namespace r1 {
 #pragma warning (disable: 4800)
 #endif
         if ( !library_handle && ( flags & DYNAMIC_LINK_LOAD ) )
-            library_handle = dynamic_load( library, descriptors, required, flags & DYNAMIC_LINK_LOCAL_BINDING );
+            library_handle = dynamic_load( library, descriptors, required, flags & DYNAMIC_LINK_LOCAL );
 
 #if defined(_MSC_VER) && _MSC_VER <= 1900
 #pragma warning (pop)

--- a/src/tbb/dynamic_link.h
+++ b/src/tbb/dynamic_link.h
@@ -71,8 +71,9 @@ using dynamic_link_handle = void*;
 const int DYNAMIC_LINK_GLOBAL        = 0x01;
 const int DYNAMIC_LINK_LOAD          = 0x02;
 const int DYNAMIC_LINK_WEAK          = 0x04;
+const int DYNAMIC_LINK_LOCAL         = 0x08;
 
-const int DYNAMIC_LINK_LOCAL_BINDING = 0x08 | DYNAMIC_LINK_LOAD;
+const int DYNAMIC_LINK_LOCAL_BINDING = DYNAMIC_LINK_LOCAL | DYNAMIC_LINK_LOAD;
 const int DYNAMIC_LINK_DEFAULT       = DYNAMIC_LINK_GLOBAL | DYNAMIC_LINK_LOAD | DYNAMIC_LINK_WEAK;
 
 //! Fill in dynamically linked handlers.

--- a/test/common/config.h
+++ b/test/common/config.h
@@ -85,12 +85,4 @@ const unsigned MByte = 1024*1024;
 #define __TBB_TEST_SKIP_AFFINITY 1
 #endif
 
-#ifdef __SANITIZE_ADDRESS__
-	#define __TBB_TEST_USE_ADDRESS_SANITIZER 1
-#elif defined(__has_feature)
-#if __has_feature(address_sanitizer)
-      #define __TBB_TEST_USE_ADDRESS_SANITIZER 1
-#endif
-#endif
-
 #endif /* __TBB_test_common_config_H */

--- a/test/common/memory_usage.h
+++ b/test/common/memory_usage.h
@@ -26,7 +26,7 @@
 #include "utils.h"
 #include "utils_assert.h"
 
-#if __TBB_TEST_USE_ADDRESS_SANITIZER
+#if __TBB_USE_ADDRESS_SANITIZER
 #include <sanitizer/allocator_interface.h>
 #endif
 
@@ -90,7 +90,7 @@ namespace utils {
     /* Returns 0 if not implemented on platform. */
     std::size_t GetMemoryUsage(MemoryStatType stat = currentUsage) {
         utils::suppress_unused_warning(stat);
-#if __TBB_TEST_USE_ADDRESS_SANITIZER
+#if __TBB_USE_ADDRESS_SANITIZER
         // Under ASAN generic memory usage functions provide information with ASAN overhead.
         return __sanitizer_get_current_allocated_bytes();
 #elif __TBB_WIN8UI_SUPPORT || defined(WINAPI_FAMILY)

--- a/test/tbb/test_eh_thread.cpp
+++ b/test/tbb/test_eh_thread.cpp
@@ -35,7 +35,7 @@
 // Therefore, the test for thread limit is unreasonable.
 //
 // Under ASAN current approach is not viable as it breaks the ASAN itself as well
-#if TBB_USE_EXCEPTIONS && !_WIN32 && !__ANDROID__ && !__TBB_TEST_USE_ADDRESS_SANITIZER
+#if TBB_USE_EXCEPTIONS && !_WIN32 && !__ANDROID__ && !__TBB_USE_ADDRESS_SANITIZER
 
 static bool g_exception_caught = false;
 static std::mutex m;

--- a/test/tbbmalloc/test_malloc_atexit.cpp
+++ b/test/tbbmalloc/test_malloc_atexit.cpp
@@ -82,7 +82,7 @@ void *realloc(void *ptr, size_t size)
 
 // Even when the test is skipped, dll source must not be empty to generate .lib to link with.
 
-#if !defined(_PGO_INSTRUMENT) && !__TBB_TEST_USE_ADDRESS_SANITIZER
+#if !defined(_PGO_INSTRUMENT) && !__TBB_USE_ADDRESS_SANITIZER
 void dummyFunction() {}
 
 // TODO: enable the check under Android
@@ -132,7 +132,7 @@ public:
 };
 
 static Foo f;
-#endif // !defined(_PGO_INSTRUMENT) && !__TBB_TEST_USE_ADDRESS_SANITIZER
+#endif // !defined(_PGO_INSTRUMENT) && !__TBB_USE_ADDRESS_SANITIZER
 
 int main() {}
 
@@ -149,7 +149,7 @@ bool dll_isMallocOverloaded();
 #ifdef _PGO_INSTRUMENT
 //! \brief \ref error_guessing
 TEST_CASE("Known issue: test_malloc_atexit hangs if compiled with -prof-genx\n" * doctest::skip(true)) {}
-#elif __TBB_TEST_USE_ADDRESS_SANITIZER
+#elif __TBB_USE_ADDRESS_SANITIZER
 //! \brief \ref error_guessing
 TEST_CASE("Known issue: test_malloc_atexit is not applicable under ASAN\n" * doctest::skip(true)) {}
 #else

--- a/test/tbbmalloc/test_malloc_compliance.cpp
+++ b/test/tbbmalloc/test_malloc_compliance.cpp
@@ -1043,7 +1043,7 @@ TEST_CASE("MAIN TEST") {
         perProcessLimits = false;
 #endif
     //-------------------------------------
-#if __APPLE__ || __TBB_TEST_USE_ADDRESS_SANITIZER
+#if __APPLE__ || __TBB_USE_ADDRESS_SANITIZER
     /* Skip due to lack of memory limit enforcing under macOS. */
     //Skip this test under ASAN , as OOM condition breaks the ASAN as well
 #else

--- a/test/tbbmalloc/test_malloc_new_handler.cpp
+++ b/test/tbbmalloc/test_malloc_new_handler.cpp
@@ -25,7 +25,7 @@
 #include "common/allocator_overload.h"
 
 // Under ASAN current approach is not viable as it breaks the ASAN itself as well
-#if !HARNESS_SKIP_TEST && TBB_USE_EXCEPTIONS && !__TBB_TEST_USE_ADDRESS_SANITIZER
+#if !HARNESS_SKIP_TEST && TBB_USE_EXCEPTIONS && !__TBB_USE_ADDRESS_SANITIZER
 
 #if _MSC_VER
 #pragma warning (push)

--- a/test/tbbmalloc/test_malloc_overload.cpp
+++ b/test/tbbmalloc/test_malloc_overload.cpp
@@ -45,7 +45,7 @@
 #include "common/test.h"
 
 //ASAN overloads memory allocation functions, so no point to run this test under it.
-#if !HARNESS_SKIP_TEST && !__TBB_TEST_USE_ADDRESS_SANITIZER
+#if !HARNESS_SKIP_TEST && !__TBB_USE_ADDRESS_SANITIZER
 
 #if __ANDROID__
   #include <android/api-level.h> // for __ANDROID_API__


### PR DESCRIPTION
Now after [this commit](https://github.com/oneapi-src/oneTBB/commit/0354fc109fe53a5d18c7fe2faae58fe224043862), `tbbmalloc` and `rml` libraries load via `dlopen` with `RTLD_LOCAL` and `RTLD_DEEPBIND` flags, but the correct behavior for such operations is loading with `RTLD_GLOBAL`.

Also this patch removes `RTLD_DEEPBIND` flag during loading the `tbbbind` libraries when the library was compiled with address sanitizer statistic to get rid of the following runtime error:
```
You are trying to dlopen a shared library <library_name> with RTLD_DEEPBIND flag which is incompatible with sanitizer runtime (see https://github.com/google/sanitizers/issues/611 for details). If you want to run <library_name> library under sanitizers please remove RTLD_DEEPBIND from dlopen flags.
```

Signed-off-by: Kochin, Ivan <kochin.ivan@intel.com>