### PR TITLE
Multiple fixes for constraints

### DIFF
--- a/examples/test_all/fibonacci/fibonacci.cpp
+++ b/examples/test_all/fibonacci/fibonacci.cpp
@@ -211,8 +211,8 @@ struct IntHashCompare {
     bool equal(const int j, const int k) const {
         return j == k;
     }
-    unsigned long hash(const int k) const {
-        return (unsigned long)k;
+    std::size_t hash(const int k) const {
+        return (std::size_t)k;
     }
 };
 //! NumbersTable type based on concurrent_hash_map

--- a/include/oneapi/tbb/concurrent_hash_map.h
+++ b/include/oneapi/tbb/concurrent_hash_map.h
@@ -455,7 +455,7 @@ private:
             , typename M
 			 >
 		__TBB_requires(tbb::detail::hash_compare<HashCompare, Key> &&
-					   ch_map_rw_scoped_lockable<MutexType>)
+					   ch_map_rw_scoped_lockable<M>)
 #else
 			 >
 		__TBB_requires(tbb::detail::hash_compare<HashCompare, Key>)

--- a/include/oneapi/tbb/detail/_range_common.h
+++ b/include/oneapi/tbb/detail/_range_common.h
@@ -95,12 +95,12 @@ template <typename T>
 concept splittable = std::constructible_from<T, T&, tbb::detail::split>;
 
 template <typename Range>
-concept range = std::copy_constructible<Range> &&
-                splittable<Range> &&
-                requires( const std::remove_reference_t<Range>& range ) {
-                    { range.empty() } -> relaxed_convertible_to<bool>;
-                    { range.is_divisible() } -> relaxed_convertible_to<bool>;
-                };
+concept ranger = std::copy_constructible<Range> &&
+                 splittable<Range> &&
+                 requires( const std::remove_reference_t<Range>& range ) {
+                     { range.empty() } -> relaxed_convertible_to<bool>;
+                     { range.is_divisible() } -> relaxed_convertible_to<bool>;
+                 };
 
 template <typename Iterator>
 constexpr bool iterator_concept_helper( std::input_iterator_tag ) {

--- a/include/oneapi/tbb/detail/_range_common.h
+++ b/include/oneapi/tbb/detail/_range_common.h
@@ -95,12 +95,12 @@ template <typename T>
 concept splittable = std::constructible_from<T, T&, tbb::detail::split>;
 
 template <typename Range>
-concept ranger = std::copy_constructible<Range> &&
-                 splittable<Range> &&
-                 requires( const std::remove_reference_t<Range>& range ) {
-                     { range.empty() } -> relaxed_convertible_to<bool>;
-                     { range.is_divisible() } -> relaxed_convertible_to<bool>;
-                 };
+concept tbb_range = std::copy_constructible<Range> &&
+                    splittable<Range> &&
+                    requires( const std::remove_reference_t<Range>& range ) {
+                        { range.empty() } -> relaxed_convertible_to<bool>;
+                        { range.is_divisible() } -> relaxed_convertible_to<bool>;
+                    };
 
 template <typename Iterator>
 constexpr bool iterator_concept_helper( std::input_iterator_tag ) {

--- a/include/oneapi/tbb/parallel_for.h
+++ b/include/oneapi/tbb/parallel_for.h
@@ -226,7 +226,7 @@ public:
 //! Parallel iteration over range with default partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body ) {
     start_for<Range,Body,const __TBB_DEFAULT_PARTITIONER>::run(range,body,__TBB_DEFAULT_PARTITIONER());
 }
@@ -234,7 +234,7 @@ void parallel_for( const Range& range, const Body& body ) {
 //! Parallel iteration over range with simple partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, const simple_partitioner& partitioner ) {
     start_for<Range,Body,const simple_partitioner>::run(range,body,partitioner);
 }
@@ -242,7 +242,7 @@ void parallel_for( const Range& range, const Body& body, const simple_partitione
 //! Parallel iteration over range with auto_partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, const auto_partitioner& partitioner ) {
     start_for<Range,Body,const auto_partitioner>::run(range,body,partitioner);
 }
@@ -250,7 +250,7 @@ void parallel_for( const Range& range, const Body& body, const auto_partitioner&
 //! Parallel iteration over range with static_partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, const static_partitioner& partitioner ) {
     start_for<Range,Body,const static_partitioner>::run(range,body,partitioner);
 }
@@ -258,7 +258,7 @@ void parallel_for( const Range& range, const Body& body, const static_partitione
 //! Parallel iteration over range with affinity_partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, affinity_partitioner& partitioner ) {
     start_for<Range,Body,affinity_partitioner>::run(range,body,partitioner);
 }
@@ -266,7 +266,7 @@ void parallel_for( const Range& range, const Body& body, affinity_partitioner& p
 //! Parallel iteration over range with default partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, task_group_context& context ) {
     start_for<Range,Body,const __TBB_DEFAULT_PARTITIONER>::run(range, body, __TBB_DEFAULT_PARTITIONER(), context);
 }
@@ -274,7 +274,7 @@ void parallel_for( const Range& range, const Body& body, task_group_context& con
 //! Parallel iteration over range with simple partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, const simple_partitioner& partitioner, task_group_context& context ) {
     start_for<Range,Body,const simple_partitioner>::run(range, body, partitioner, context);
 }
@@ -282,7 +282,7 @@ void parallel_for( const Range& range, const Body& body, const simple_partitione
 //! Parallel iteration over range with auto_partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, const auto_partitioner& partitioner, task_group_context& context ) {
     start_for<Range,Body,const auto_partitioner>::run(range, body, partitioner, context);
 }
@@ -290,7 +290,7 @@ void parallel_for( const Range& range, const Body& body, const auto_partitioner&
 //! Parallel iteration over range with static_partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, const static_partitioner& partitioner, task_group_context& context ) {
     start_for<Range,Body,const static_partitioner>::run(range, body, partitioner, context);
 }
@@ -298,7 +298,7 @@ void parallel_for( const Range& range, const Body& body, const static_partitione
 //! Parallel iteration over range with affinity_partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, affinity_partitioner& partitioner, task_group_context& context ) {
     start_for<Range,Body,affinity_partitioner>::run(range,body,partitioner, context);
 }
@@ -308,7 +308,7 @@ template <typename Index, typename Function, typename Partitioner>
 void parallel_for_impl(Index first, Index last, Index step, const Function& f, Partitioner& partitioner) {
     if (step <= 0 )
         throw_exception(exception_id::nonpositive_step); // throws std::invalid_argument
-    else if (last > first) {
+    else if (first < last) {
         // Above "else" avoids "potential divide by zero" warning on some platforms
         Index end = (last - first - Index(1)) / step + Index(1);
         blocked_range<Index> range(static_cast<Index>(0), end);

--- a/include/oneapi/tbb/parallel_for.h
+++ b/include/oneapi/tbb/parallel_for.h
@@ -226,7 +226,7 @@ public:
 //! Parallel iteration over range with default partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body ) {
     start_for<Range,Body,const __TBB_DEFAULT_PARTITIONER>::run(range,body,__TBB_DEFAULT_PARTITIONER());
 }
@@ -234,7 +234,7 @@ void parallel_for( const Range& range, const Body& body ) {
 //! Parallel iteration over range with simple partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, const simple_partitioner& partitioner ) {
     start_for<Range,Body,const simple_partitioner>::run(range,body,partitioner);
 }
@@ -242,7 +242,7 @@ void parallel_for( const Range& range, const Body& body, const simple_partitione
 //! Parallel iteration over range with auto_partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, const auto_partitioner& partitioner ) {
     start_for<Range,Body,const auto_partitioner>::run(range,body,partitioner);
 }
@@ -250,7 +250,7 @@ void parallel_for( const Range& range, const Body& body, const auto_partitioner&
 //! Parallel iteration over range with static_partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, const static_partitioner& partitioner ) {
     start_for<Range,Body,const static_partitioner>::run(range,body,partitioner);
 }
@@ -258,7 +258,7 @@ void parallel_for( const Range& range, const Body& body, const static_partitione
 //! Parallel iteration over range with affinity_partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, affinity_partitioner& partitioner ) {
     start_for<Range,Body,affinity_partitioner>::run(range,body,partitioner);
 }
@@ -266,7 +266,7 @@ void parallel_for( const Range& range, const Body& body, affinity_partitioner& p
 //! Parallel iteration over range with default partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, task_group_context& context ) {
     start_for<Range,Body,const __TBB_DEFAULT_PARTITIONER>::run(range, body, __TBB_DEFAULT_PARTITIONER(), context);
 }
@@ -274,7 +274,7 @@ void parallel_for( const Range& range, const Body& body, task_group_context& con
 //! Parallel iteration over range with simple partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, const simple_partitioner& partitioner, task_group_context& context ) {
     start_for<Range,Body,const simple_partitioner>::run(range, body, partitioner, context);
 }
@@ -282,7 +282,7 @@ void parallel_for( const Range& range, const Body& body, const simple_partitione
 //! Parallel iteration over range with auto_partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, const auto_partitioner& partitioner, task_group_context& context ) {
     start_for<Range,Body,const auto_partitioner>::run(range, body, partitioner, context);
 }
@@ -290,7 +290,7 @@ void parallel_for( const Range& range, const Body& body, const auto_partitioner&
 //! Parallel iteration over range with static_partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, const static_partitioner& partitioner, task_group_context& context ) {
     start_for<Range,Body,const static_partitioner>::run(range, body, partitioner, context);
 }
@@ -298,7 +298,7 @@ void parallel_for( const Range& range, const Body& body, const static_partitione
 //! Parallel iteration over range with affinity_partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_for_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_for_body<Body, Range>)
 void parallel_for( const Range& range, const Body& body, affinity_partitioner& partitioner, task_group_context& context ) {
     start_for<Range,Body,affinity_partitioner>::run(range,body,partitioner, context);
 }

--- a/include/oneapi/tbb/parallel_reduce.h
+++ b/include/oneapi/tbb/parallel_reduce.h
@@ -418,7 +418,7 @@ public:
 //! Parallel iteration with reduction and default partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body ) {
     start_reduce<Range,Body, const __TBB_DEFAULT_PARTITIONER>::run( range, body, __TBB_DEFAULT_PARTITIONER() );
 }
@@ -426,7 +426,7 @@ void parallel_reduce( const Range& range, Body& body ) {
 //! Parallel iteration with reduction and simple_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, const simple_partitioner& partitioner ) {
     start_reduce<Range,Body,const simple_partitioner>::run( range, body, partitioner );
 }
@@ -434,7 +434,7 @@ void parallel_reduce( const Range& range, Body& body, const simple_partitioner& 
 //! Parallel iteration with reduction and auto_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, const auto_partitioner& partitioner ) {
     start_reduce<Range,Body,const auto_partitioner>::run( range, body, partitioner );
 }
@@ -442,7 +442,7 @@ void parallel_reduce( const Range& range, Body& body, const auto_partitioner& pa
 //! Parallel iteration with reduction and static_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, const static_partitioner& partitioner ) {
     start_reduce<Range,Body,const static_partitioner>::run( range, body, partitioner );
 }
@@ -450,7 +450,7 @@ void parallel_reduce( const Range& range, Body& body, const static_partitioner& 
 //! Parallel iteration with reduction and affinity_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, affinity_partitioner& partitioner ) {
     start_reduce<Range,Body,affinity_partitioner>::run( range, body, partitioner );
 }
@@ -458,7 +458,7 @@ void parallel_reduce( const Range& range, Body& body, affinity_partitioner& part
 //! Parallel iteration with reduction, default partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, task_group_context& context ) {
     start_reduce<Range,Body,const __TBB_DEFAULT_PARTITIONER>::run( range, body, __TBB_DEFAULT_PARTITIONER(), context );
 }
@@ -466,7 +466,7 @@ void parallel_reduce( const Range& range, Body& body, task_group_context& contex
 //! Parallel iteration with reduction, simple partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, const simple_partitioner& partitioner, task_group_context& context ) {
     start_reduce<Range,Body,const simple_partitioner>::run( range, body, partitioner, context );
 }
@@ -474,7 +474,7 @@ void parallel_reduce( const Range& range, Body& body, const simple_partitioner& 
 //! Parallel iteration with reduction, auto_partitioner and user-supplied context
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, const auto_partitioner& partitioner, task_group_context& context ) {
     start_reduce<Range,Body,const auto_partitioner>::run( range, body, partitioner, context );
 }
@@ -482,7 +482,7 @@ void parallel_reduce( const Range& range, Body& body, const auto_partitioner& pa
 //! Parallel iteration with reduction, static_partitioner and user-supplied context
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, const static_partitioner& partitioner, task_group_context& context ) {
     start_reduce<Range,Body,const static_partitioner>::run( range, body, partitioner, context );
 }
@@ -490,7 +490,7 @@ void parallel_reduce( const Range& range, Body& body, const static_partitioner& 
 //! Parallel iteration with reduction, affinity_partitioner and user-supplied context
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, affinity_partitioner& partitioner, task_group_context& context ) {
     start_reduce<Range,Body,affinity_partitioner>::run( range, body, partitioner, context );
 }
@@ -500,7 +500,7 @@ void parallel_reduce( const Range& range, Body& body, affinity_partitioner& part
 //! Parallel iteration with reduction and default partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction ) {
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
@@ -512,7 +512,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction and simple_partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        const simple_partitioner& partitioner ) {
@@ -525,7 +525,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction and auto_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        const auto_partitioner& partitioner ) {
@@ -538,7 +538,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction and static_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        const static_partitioner& partitioner ) {
@@ -551,7 +551,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction and affinity_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        affinity_partitioner& partitioner ) {
@@ -564,7 +564,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction, default partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        task_group_context& context ) {
@@ -577,7 +577,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction, simple partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        const simple_partitioner& partitioner, task_group_context& context ) {
@@ -590,7 +590,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction, auto_partitioner and user-supplied context
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        const auto_partitioner& partitioner, task_group_context& context ) {
@@ -603,7 +603,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction, static_partitioner and user-supplied context
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        const static_partitioner& partitioner, task_group_context& context ) {
@@ -616,7 +616,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction, affinity_partitioner and user-supplied context
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        affinity_partitioner& partitioner, task_group_context& context ) {
@@ -629,7 +629,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with deterministic reduction and default simple partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_deterministic_reduce( const Range& range, Body& body ) {
     start_deterministic_reduce<Range, Body, const simple_partitioner>::run(range, body, simple_partitioner());
 }
@@ -637,7 +637,7 @@ void parallel_deterministic_reduce( const Range& range, Body& body ) {
 //! Parallel iteration with deterministic reduction and simple partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_deterministic_reduce( const Range& range, Body& body, const simple_partitioner& partitioner ) {
     start_deterministic_reduce<Range, Body, const simple_partitioner>::run(range, body, partitioner);
 }
@@ -645,7 +645,7 @@ void parallel_deterministic_reduce( const Range& range, Body& body, const simple
 //! Parallel iteration with deterministic reduction and static partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_deterministic_reduce( const Range& range, Body& body, const static_partitioner& partitioner ) {
     start_deterministic_reduce<Range, Body, const static_partitioner>::run(range, body, partitioner);
 }
@@ -653,7 +653,7 @@ void parallel_deterministic_reduce( const Range& range, Body& body, const static
 //! Parallel iteration with deterministic reduction, default simple partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_deterministic_reduce( const Range& range, Body& body, task_group_context& context ) {
     start_deterministic_reduce<Range,Body, const simple_partitioner>::run( range, body, simple_partitioner(), context );
 }
@@ -661,7 +661,7 @@ void parallel_deterministic_reduce( const Range& range, Body& body, task_group_c
 //! Parallel iteration with deterministic reduction, simple partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_deterministic_reduce( const Range& range, Body& body, const simple_partitioner& partitioner, task_group_context& context ) {
     start_deterministic_reduce<Range, Body, const simple_partitioner>::run(range, body, partitioner, context);
 }
@@ -669,7 +669,7 @@ void parallel_deterministic_reduce( const Range& range, Body& body, const simple
 //! Parallel iteration with deterministic reduction, static partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_reduce_body<Body, Range>)
 void parallel_deterministic_reduce( const Range& range, Body& body, const static_partitioner& partitioner, task_group_context& context ) {
     start_deterministic_reduce<Range, Body, const static_partitioner>::run(range, body, partitioner, context);
 }
@@ -681,7 +681,7 @@ void parallel_deterministic_reduce( const Range& range, Body& body, const static
 // TODO: consider making static_partitioner the default
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_deterministic_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction ) {
     return parallel_deterministic_reduce(range, identity, real_body, reduction, simple_partitioner());
@@ -690,7 +690,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
 //! Parallel iteration with deterministic reduction and simple partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_deterministic_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction, const simple_partitioner& partitioner ) {
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
@@ -702,7 +702,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
 //! Parallel iteration with deterministic reduction and static partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_deterministic_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction, const static_partitioner& partitioner ) {
     lambda_reduce_body<Range, Value, RealBody, Reduction> body(identity, real_body, reduction);
@@ -714,7 +714,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
 //! Parallel iteration with deterministic reduction, default simple partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_deterministic_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
     task_group_context& context ) {
@@ -724,7 +724,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
 //! Parallel iteration with deterministic reduction, simple partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_deterministic_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
     const simple_partitioner& partitioner, task_group_context& context ) {
@@ -737,7 +737,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
 //! Parallel iteration with deterministic reduction, static partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_deterministic_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
     const static_partitioner& partitioner, task_group_context& context ) {

--- a/include/oneapi/tbb/parallel_reduce.h
+++ b/include/oneapi/tbb/parallel_reduce.h
@@ -418,7 +418,7 @@ public:
 //! Parallel iteration with reduction and default partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body ) {
     start_reduce<Range,Body, const __TBB_DEFAULT_PARTITIONER>::run( range, body, __TBB_DEFAULT_PARTITIONER() );
 }
@@ -426,7 +426,7 @@ void parallel_reduce( const Range& range, Body& body ) {
 //! Parallel iteration with reduction and simple_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, const simple_partitioner& partitioner ) {
     start_reduce<Range,Body,const simple_partitioner>::run( range, body, partitioner );
 }
@@ -434,7 +434,7 @@ void parallel_reduce( const Range& range, Body& body, const simple_partitioner& 
 //! Parallel iteration with reduction and auto_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, const auto_partitioner& partitioner ) {
     start_reduce<Range,Body,const auto_partitioner>::run( range, body, partitioner );
 }
@@ -442,7 +442,7 @@ void parallel_reduce( const Range& range, Body& body, const auto_partitioner& pa
 //! Parallel iteration with reduction and static_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, const static_partitioner& partitioner ) {
     start_reduce<Range,Body,const static_partitioner>::run( range, body, partitioner );
 }
@@ -450,7 +450,7 @@ void parallel_reduce( const Range& range, Body& body, const static_partitioner& 
 //! Parallel iteration with reduction and affinity_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, affinity_partitioner& partitioner ) {
     start_reduce<Range,Body,affinity_partitioner>::run( range, body, partitioner );
 }
@@ -458,7 +458,7 @@ void parallel_reduce( const Range& range, Body& body, affinity_partitioner& part
 //! Parallel iteration with reduction, default partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, task_group_context& context ) {
     start_reduce<Range,Body,const __TBB_DEFAULT_PARTITIONER>::run( range, body, __TBB_DEFAULT_PARTITIONER(), context );
 }
@@ -466,7 +466,7 @@ void parallel_reduce( const Range& range, Body& body, task_group_context& contex
 //! Parallel iteration with reduction, simple partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, const simple_partitioner& partitioner, task_group_context& context ) {
     start_reduce<Range,Body,const simple_partitioner>::run( range, body, partitioner, context );
 }
@@ -474,7 +474,7 @@ void parallel_reduce( const Range& range, Body& body, const simple_partitioner& 
 //! Parallel iteration with reduction, auto_partitioner and user-supplied context
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, const auto_partitioner& partitioner, task_group_context& context ) {
     start_reduce<Range,Body,const auto_partitioner>::run( range, body, partitioner, context );
 }
@@ -482,7 +482,7 @@ void parallel_reduce( const Range& range, Body& body, const auto_partitioner& pa
 //! Parallel iteration with reduction, static_partitioner and user-supplied context
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, const static_partitioner& partitioner, task_group_context& context ) {
     start_reduce<Range,Body,const static_partitioner>::run( range, body, partitioner, context );
 }
@@ -490,7 +490,7 @@ void parallel_reduce( const Range& range, Body& body, const static_partitioner& 
 //! Parallel iteration with reduction, affinity_partitioner and user-supplied context
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_reduce( const Range& range, Body& body, affinity_partitioner& partitioner, task_group_context& context ) {
     start_reduce<Range,Body,affinity_partitioner>::run( range, body, partitioner, context );
 }
@@ -500,7 +500,7 @@ void parallel_reduce( const Range& range, Body& body, affinity_partitioner& part
 //! Parallel iteration with reduction and default partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction ) {
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
@@ -512,7 +512,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction and simple_partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        const simple_partitioner& partitioner ) {
@@ -525,7 +525,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction and auto_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        const auto_partitioner& partitioner ) {
@@ -538,7 +538,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction and static_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        const static_partitioner& partitioner ) {
@@ -551,7 +551,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction and affinity_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        affinity_partitioner& partitioner ) {
@@ -564,7 +564,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction, default partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        task_group_context& context ) {
@@ -577,7 +577,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction, simple partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        const simple_partitioner& partitioner, task_group_context& context ) {
@@ -590,7 +590,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction, auto_partitioner and user-supplied context
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        const auto_partitioner& partitioner, task_group_context& context ) {
@@ -603,7 +603,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction, static_partitioner and user-supplied context
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        const static_partitioner& partitioner, task_group_context& context ) {
@@ -616,7 +616,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with reduction, affinity_partitioner and user-supplied context
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
                        affinity_partitioner& partitioner, task_group_context& context ) {
@@ -629,7 +629,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
 //! Parallel iteration with deterministic reduction and default simple partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_deterministic_reduce( const Range& range, Body& body ) {
     start_deterministic_reduce<Range, Body, const simple_partitioner>::run(range, body, simple_partitioner());
 }
@@ -637,7 +637,7 @@ void parallel_deterministic_reduce( const Range& range, Body& body ) {
 //! Parallel iteration with deterministic reduction and simple partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_deterministic_reduce( const Range& range, Body& body, const simple_partitioner& partitioner ) {
     start_deterministic_reduce<Range, Body, const simple_partitioner>::run(range, body, partitioner);
 }
@@ -645,7 +645,7 @@ void parallel_deterministic_reduce( const Range& range, Body& body, const simple
 //! Parallel iteration with deterministic reduction and static partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_deterministic_reduce( const Range& range, Body& body, const static_partitioner& partitioner ) {
     start_deterministic_reduce<Range, Body, const static_partitioner>::run(range, body, partitioner);
 }
@@ -653,7 +653,7 @@ void parallel_deterministic_reduce( const Range& range, Body& body, const static
 //! Parallel iteration with deterministic reduction, default simple partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_deterministic_reduce( const Range& range, Body& body, task_group_context& context ) {
     start_deterministic_reduce<Range,Body, const simple_partitioner>::run( range, body, simple_partitioner(), context );
 }
@@ -661,7 +661,7 @@ void parallel_deterministic_reduce( const Range& range, Body& body, task_group_c
 //! Parallel iteration with deterministic reduction, simple partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_deterministic_reduce( const Range& range, Body& body, const simple_partitioner& partitioner, task_group_context& context ) {
     start_deterministic_reduce<Range, Body, const simple_partitioner>::run(range, body, partitioner, context);
 }
@@ -669,7 +669,7 @@ void parallel_deterministic_reduce( const Range& range, Body& body, const simple
 //! Parallel iteration with deterministic reduction, static partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_reduce_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_reduce_body<Body, Range>)
 void parallel_deterministic_reduce( const Range& range, Body& body, const static_partitioner& partitioner, task_group_context& context ) {
     start_deterministic_reduce<Range, Body, const static_partitioner>::run(range, body, partitioner, context);
 }
@@ -681,7 +681,7 @@ void parallel_deterministic_reduce( const Range& range, Body& body, const static
 // TODO: consider making static_partitioner the default
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_deterministic_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction ) {
     return parallel_deterministic_reduce(range, identity, real_body, reduction, simple_partitioner());
@@ -690,7 +690,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
 //! Parallel iteration with deterministic reduction and simple partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_deterministic_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction, const simple_partitioner& partitioner ) {
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
@@ -702,7 +702,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
 //! Parallel iteration with deterministic reduction and static partitioner.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_deterministic_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction, const static_partitioner& partitioner ) {
     lambda_reduce_body<Range, Value, RealBody, Reduction> body(identity, real_body, reduction);
@@ -714,7 +714,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
 //! Parallel iteration with deterministic reduction, default simple partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_deterministic_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
     task_group_context& context ) {
@@ -724,7 +724,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
 //! Parallel iteration with deterministic reduction, simple partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_deterministic_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
     const simple_partitioner& partitioner, task_group_context& context ) {
@@ -737,7 +737,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
 //! Parallel iteration with deterministic reduction, static partitioner and user-supplied context.
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename RealBody, typename Reduction>
-    __TBB_requires(range<Range> && parallel_reduce_function<RealBody, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_reduce_function<RealBody, Range, Value> &&
                    parallel_reduce_combine<Reduction, Value>)
 Value parallel_deterministic_reduce( const Range& range, const Value& identity, const RealBody& real_body, const Reduction& reduction,
     const static_partitioner& partitioner, task_group_context& context ) {

--- a/include/oneapi/tbb/parallel_scan.h
+++ b/include/oneapi/tbb/parallel_scan.h
@@ -558,7 +558,7 @@ public:
 //! Parallel prefix with default partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_scan_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_scan_body<Body, Range>)
 void parallel_scan( const Range& range, Body& body ) {
     start_scan<Range, Body, auto_partitioner>::run(range,body,__TBB_DEFAULT_PARTITIONER());
 }
@@ -566,7 +566,7 @@ void parallel_scan( const Range& range, Body& body ) {
 //! Parallel prefix with simple_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_scan_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_scan_body<Body, Range>)
 void parallel_scan( const Range& range, Body& body, const simple_partitioner& partitioner ) {
     start_scan<Range, Body, simple_partitioner>::run(range, body, partitioner);
 }
@@ -574,7 +574,7 @@ void parallel_scan( const Range& range, Body& body, const simple_partitioner& pa
 //! Parallel prefix with auto_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(ranger<Range> && parallel_scan_body<Body, Range>)
+    __TBB_requires(tbb_range<Range> && parallel_scan_body<Body, Range>)
 void parallel_scan( const Range& range, Body& body, const auto_partitioner& partitioner ) {
     start_scan<Range,Body,auto_partitioner>::run(range, body, partitioner);
 }
@@ -582,7 +582,7 @@ void parallel_scan( const Range& range, Body& body, const auto_partitioner& part
 //! Parallel prefix with default partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename Scan, typename ReverseJoin>
-    __TBB_requires(ranger<Range> && parallel_scan_function<Scan, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_scan_function<Scan, Range, Value> &&
                    parallel_scan_combine<ReverseJoin, Value>)
 Value parallel_scan( const Range& range, const Value& identity, const Scan& scan, const ReverseJoin& reverse_join ) {
     lambda_scan_body<Range, Value, Scan, ReverseJoin> body(identity, scan, reverse_join);
@@ -593,7 +593,7 @@ Value parallel_scan( const Range& range, const Value& identity, const Scan& scan
 //! Parallel prefix with simple_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename Scan, typename ReverseJoin>
-    __TBB_requires(ranger<Range> && parallel_scan_function<Scan, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_scan_function<Scan, Range, Value> &&
                    parallel_scan_combine<ReverseJoin, Value>)
 Value parallel_scan( const Range& range, const Value& identity, const Scan& scan, const ReverseJoin& reverse_join,
                      const simple_partitioner& partitioner ) {
@@ -605,7 +605,7 @@ Value parallel_scan( const Range& range, const Value& identity, const Scan& scan
 //! Parallel prefix with auto_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename Scan, typename ReverseJoin>
-    __TBB_requires(ranger<Range> && parallel_scan_function<Scan, Range, Value> &&
+    __TBB_requires(tbb_range<Range> && parallel_scan_function<Scan, Range, Value> &&
                    parallel_scan_combine<ReverseJoin, Value>)
 Value parallel_scan( const Range& range, const Value& identity, const Scan& scan, const ReverseJoin& reverse_join,
                      const auto_partitioner& partitioner ) {

--- a/include/oneapi/tbb/parallel_scan.h
+++ b/include/oneapi/tbb/parallel_scan.h
@@ -558,7 +558,7 @@ public:
 //! Parallel prefix with default partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_scan_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_scan_body<Body, Range>)
 void parallel_scan( const Range& range, Body& body ) {
     start_scan<Range, Body, auto_partitioner>::run(range,body,__TBB_DEFAULT_PARTITIONER());
 }
@@ -566,7 +566,7 @@ void parallel_scan( const Range& range, Body& body ) {
 //! Parallel prefix with simple_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_scan_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_scan_body<Body, Range>)
 void parallel_scan( const Range& range, Body& body, const simple_partitioner& partitioner ) {
     start_scan<Range, Body, simple_partitioner>::run(range, body, partitioner);
 }
@@ -574,7 +574,7 @@ void parallel_scan( const Range& range, Body& body, const simple_partitioner& pa
 //! Parallel prefix with auto_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Body>
-    __TBB_requires(range<Range> && parallel_scan_body<Body, Range>)
+    __TBB_requires(ranger<Range> && parallel_scan_body<Body, Range>)
 void parallel_scan( const Range& range, Body& body, const auto_partitioner& partitioner ) {
     start_scan<Range,Body,auto_partitioner>::run(range, body, partitioner);
 }
@@ -582,7 +582,7 @@ void parallel_scan( const Range& range, Body& body, const auto_partitioner& part
 //! Parallel prefix with default partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename Scan, typename ReverseJoin>
-    __TBB_requires(range<Range> && parallel_scan_function<Scan, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_scan_function<Scan, Range, Value> &&
                    parallel_scan_combine<ReverseJoin, Value>)
 Value parallel_scan( const Range& range, const Value& identity, const Scan& scan, const ReverseJoin& reverse_join ) {
     lambda_scan_body<Range, Value, Scan, ReverseJoin> body(identity, scan, reverse_join);
@@ -593,7 +593,7 @@ Value parallel_scan( const Range& range, const Value& identity, const Scan& scan
 //! Parallel prefix with simple_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename Scan, typename ReverseJoin>
-    __TBB_requires(range<Range> && parallel_scan_function<Scan, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_scan_function<Scan, Range, Value> &&
                    parallel_scan_combine<ReverseJoin, Value>)
 Value parallel_scan( const Range& range, const Value& identity, const Scan& scan, const ReverseJoin& reverse_join,
                      const simple_partitioner& partitioner ) {
@@ -605,7 +605,7 @@ Value parallel_scan( const Range& range, const Value& identity, const Scan& scan
 //! Parallel prefix with auto_partitioner
 /** @ingroup algorithms **/
 template<typename Range, typename Value, typename Scan, typename ReverseJoin>
-    __TBB_requires(range<Range> && parallel_scan_function<Scan, Range, Value> &&
+    __TBB_requires(ranger<Range> && parallel_scan_function<Scan, Range, Value> &&
                    parallel_scan_combine<ReverseJoin, Value>)
 Value parallel_scan( const Range& range, const Value& identity, const Scan& scan, const ReverseJoin& reverse_join,
                      const auto_partitioner& partitioner ) {

--- a/test/common/concepts_common.h
+++ b/test/common/concepts_common.h
@@ -643,7 +643,7 @@ template <typename I, typename K> using WrongReturnOperatorRoundBrackets = JoinN
 } // namespace join_node_function_object
 
 template <typename T>
-concept container_range = tbb::detail::range<T> &&
+concept container_range = tbb::detail::ranger<T> &&
                           std::input_iterator<typename T::iterator> &&
                           requires(T& range) {
                               typename T::value_type;

--- a/test/conformance/conformance_concurrent_hash_map.cpp
+++ b/test/conformance/conformance_concurrent_hash_map.cpp
@@ -160,7 +160,7 @@ public:
         return j.key==k.key;
     }
 
-    unsigned long hash( const MyKey& k ) const {
+    std::size_t hash( const MyKey& k ) const {
         return k.key;
     }
 };
@@ -171,7 +171,7 @@ public:
         return j.key==k.key;
     }
 
-    unsigned long hash( const MyKey& ) const {
+    std::size_t hash( const MyKey& ) const {
         return 1;
     }
 };


### PR DESCRIPTION
Add fixes for multiple problems with C++20 constraints on Windows and Linux. Added workaround for a problem on Windows: "failed to select the destructor for the class" in case of constrained destructor (in tests)