### PR TITLE
Prevent vars generation conflict

### DIFF
--- a/integration/cmake/generate_vars.cmake
+++ b/integration/cmake/generate_vars.cmake
@@ -30,7 +30,9 @@ if (WIN32)
     file(TO_NATIVE_PATH "${BIN_PATH}" BINARY_PATH_REPLACEMENT)
 endif()
 
-configure_file( ${INPUT_FILE} ${OUTPUT_FILE} @ONLY )
+if (NOT EXISTS ${OUTPUT_FILE})
+    configure_file(${INPUT_FILE} ${OUTPUT_FILE} @ONLY)
+endif()
 
 if (TBB_INSTALL_VARS)
     set(OUTPUT_FILE "${BINARY_DIR}/internal_install_vars")


### PR DESCRIPTION
Vars scripts auto-generation may conflict during the concurrent build. The cause of this issue is that several targets try to create vars script concurrently. In such cases, some targets cannot successfully create the vars, therefore CMake deletes the already built library. Error text:
```
2021-06-29T05:25:15.9457587Z CMake Error at <path>/integration/cmake/generate_vars.cmake:33 (configure_file):
2021-06-29T05:25:15.9459242Z   configure_file Problem configuring file
2021-06-29T05:25:15.9459663Z 
2021-06-29T05:25:15.9459877Z 
2021-06-29T05:25:15.9469099Z make[2]: *** [gnu_7.5_cxx14_64_release/libtbbbind_2_0.so.3.3] Error 1
2021-06-29T05:25:15.9471043Z make[2]: *** Deleting file 'gnu_7.5_cxx14_64_release/libtbbbind_2_0.so.3.3'
2021-06-29T05:25:15.9472900Z make[2]: Target 'src/tbbbind/CMakeFiles/tbbbind_2_0.dir/build' not remade because of errors.
```

This patch improves the logic by additional file existence check which should prevent the vars generation conflicts. 

Signed-off-by: Kochin, Ivan <kochin.ivan@intel.com>