### PR TITLE
Rework workers leave behavior

### DIFF
--- a/include/oneapi/tbb/detail/_utils.h
+++ b/include/oneapi/tbb/detail/_utils.h
@@ -132,6 +132,11 @@ bool timed_spin_wait_until(Condition condition) {
 }
 
 template <typename T>
+T clamp(T value, T low_bound, T high_bound) {
+    return value > low_bound ? (value > high_bound ? high_bound : value) : low_bound;
+}
+
+template <typename T>
 std::uintptr_t log2(T in) {
     __TBB_ASSERT(in > 0, "The logarithm of a non-positive value is undefined.");
     return machine_log2(in);

--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -177,7 +177,7 @@ arena::arena ( market& m, unsigned num_slots, unsigned num_reserved_slots, unsig
     my_num_reserved_slots = num_reserved_slots;
     my_max_num_workers = num_slots-num_reserved_slots;
     my_priority_level = priority_level;
-    my_references = ref_external; // accounts for the external thread
+    my_references.store(ref_external, std::memory_order_relaxed); // accounts for the external thread
     my_aba_epoch = m.my_arenas_aba_epoch.load(std::memory_order_relaxed);
     my_observers.my_arena = this;
     my_co_cache.init(4 * num_slots);
@@ -274,7 +274,7 @@ bool arena::is_out_of_work() {
     if (my_local_concurrency_flag.try_clear_if([this] {
         return !has_enqueued_tasks();
     })) {
-        my_market->adjust_demand(*this, /* delta = */ -1, /* mandatory = */ true);
+        my_market->decrease_demand(*this, /* delta = */ 1, /* mandatory = */ true);
     }
 #endif
 
@@ -325,7 +325,9 @@ bool arena::is_out_of_work() {
                     if (my_pool_state.compare_exchange_strong(expected_state, SNAPSHOT_EMPTY)) {
                         // This thread transitioned pool to empty state, and thus is
                         // responsible for telling the market that there is no work to do.
-                        my_market->adjust_demand(*this, -current_demand, /* mandatory = */ false);
+                        if (current_demand > 0) {
+                            my_market->decrease_demand(*this, current_demand, /* mandatory = */ false);
+                        }
                         return true;
                     }
                     return false;
@@ -341,6 +343,44 @@ bool arena::is_out_of_work() {
         // Another thread is taking a snapshot.
         return false;
     }
+}
+
+int arena::get_max_num_workers() {
+    int max_num_workers = int(my_max_num_workers);
+#if __TBB_ENQUEUE_ENFORCED_CONCURRENCY
+    // At least one thread should be requested when mandatory concurrency
+    if (my_local_concurrency_requests > 0 && max_num_workers == 0) {
+        max_num_workers = 1;
+    }
+#endif
+    return max_num_workers;
+}
+
+int arena::update_workers_request(int delta, bool mandatory) {
+    suppress_unused_warning(mandatory);
+#if __TBB_ENQUEUE_ENFORCED_CONCURRENCY
+    if (mandatory) {
+        __TBB_ASSERT(delta == 1 || delta == -1, nullptr);
+        // Count the number of mandatory requests and proceed only for 0->1 and 1->0 transitions.
+        my_local_concurrency_requests += delta;
+        bool enable_mandatory_concurrency = delta > 0 && my_local_concurrency_requests == 1;
+        bool disable_mandatory_concurrency = delta < 0 && my_local_concurrency_requests == 0;
+        if (!enable_mandatory_concurrency && !disable_mandatory_concurrency) {
+            return 0;
+        }
+    }
+#endif
+    my_total_num_workers_requested += delta;
+    // Cap target_workers into interval [0, my_max_num_workers]
+    int target_workers = clamp(my_total_num_workers_requested, 0, get_max_num_workers());
+
+    delta = target_workers - my_num_workers_requested;
+    my_num_workers_requested += delta;
+    if (my_num_workers_requested == 0) {
+        my_num_workers_allotted.store(0, std::memory_order_relaxed);
+    }
+
+    return delta;
 }
 
 void arena::enqueue_task(d1::task& t, d1::task_group_context& ctx, thread_data& td) {
@@ -479,7 +519,7 @@ bool task_arena_impl::attach(d1::task_arena_base& ta) {
         arena* a = td->my_arena;
         // There is an active arena to attach to.
         // It's still used by s, so won't be destroyed right away.
-        __TBB_ASSERT(a->my_references > 0, NULL );
+        __TBB_ASSERT(a->my_references.load(std::memory_order_relaxed) > 0, NULL );
         a->my_references += arena::ref_external;
         ta.my_num_reserved_slots = a->my_num_reserved_slots;
         ta.my_priority = arena_priority(a->my_priority_level);
@@ -530,7 +570,7 @@ public:
             // If the calling thread occupies the slots out of external thread reserve we need to notify the
             // market that this arena requires one worker less.
             if (td.my_arena_index >= td.my_arena->my_num_reserved_slots) {
-                td.my_arena->my_market->adjust_demand(*td.my_arena, /* delta = */ -1, /* mandatory = */ false);
+                td.my_arena->my_market->decrease_demand(*td.my_arena, /* delta = */ 1, /* mandatory = */ false);
             }
 
             td.my_last_observer = nullptr;
@@ -566,7 +606,7 @@ public:
             // Notify the market that this thread releasing a one slot
             // that can be used by a worker thread.
             if (td.my_arena_index >= td.my_arena->my_num_reserved_slots) {
-                td.my_arena->my_market->adjust_demand(*td.my_arena, /* delta = */ 1, /* mandatory = */ false);
+                td.my_arena->my_market->increase_demand(*td.my_arena, /* delta = */ 1, /* mandatory = */ false);
             }
 
             td.my_task_dispatcher->set_stealing_threshold(0);

--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -348,6 +348,18 @@ public:
         return my_references.load(std::memory_order_acquire) >> ref_external_bits;
     }
 
+    bool try_add_worker_reference() {
+        unsigned references = my_references.load(std::memory_order_relaxed);
+        do {
+            if ((references >> ref_external_bits) == my_num_workers_allotted.load(std::memory_order_relaxed)) {
+                return false;
+            }
+        } while (!my_references.compare_exchange_strong(references, references + arena::ref_worker));
+        __TBB_ASSERT(num_workers_active() <= my_num_workers_allotted.load(std::memory_order_relaxed), nullptr);
+
+        return true;
+    }
+
     //! Check if the recall is requested by the market.
     bool is_recall_requested() const {
         return num_workers_active() > my_num_workers_allotted.load(std::memory_order_relaxed);
@@ -372,6 +384,11 @@ public:
     /** Return true if no job or if arena is being cleaned up. */
     bool is_out_of_work();
 
+    //! Recompute the number of workers requested by the arena based on the passed delta demand value.
+    //! Returns the actual delta value the request was updated with.
+    //! Should be called under market::my_arenas_list_mutex
+    int update_workers_request(int delta, bool mandatory);
+
     //! enqueue a task into starvation-resistance queue
     void enqueue_task(d1::task&, d1::task_group_context&, thread_data&);
 
@@ -384,6 +401,10 @@ public:
 
     //! Check for the presence of enqueued tasks at all priority levels
     bool has_enqueued_tasks();
+
+    //! Get max_num workers
+    //! Should be called under market::my_arenas_list_mutex
+    int get_max_num_workers();
 
     static const std::size_t out_of_arena = ~size_t(0);
     //! Tries to occupy a slot in the arena. On success, returns the slot index; if no slot is available, returns out_of_arena.
@@ -494,7 +515,7 @@ void arena::advertise_new_work() {
             my_market->enable_mandatory_concurrency(this);
 
         if (my_max_num_workers == 0 && my_num_reserved_slots == 1 && my_local_concurrency_flag.test_and_set()) {
-            my_market->adjust_demand(*this, /* delta = */ 1, /* mandatory = */ true);
+            my_market->increase_demand(*this, /* delta = */ 1, /* mandatory = */ true);
         }
 #endif /* __TBB_ENQUEUE_ENFORCED_CONCURRENCY */
         // Local memory fence here and below is required to avoid missed wakeups; see the comment below.
@@ -537,7 +558,9 @@ void arena::advertise_new_work() {
             }
 #endif /* __TBB_ENQUEUE_ENFORCED_CONCURRENCY */
             // TODO: investigate adjusting of arena's demand by a single worker.
-            my_market->adjust_demand(*this, my_max_num_workers, /* mandatory = */ false);
+            if (my_max_num_workers) {
+                my_market->increase_demand(*this, my_max_num_workers, /* mandatory = */ false);
+            }
 
             // Notify all sleeping threads that work has appeared in the arena.
             my_market->get_wait_list().notify(is_related_arena);

--- a/src/tbb/market.cpp
+++ b/src/tbb/market.cpp
@@ -168,6 +168,15 @@ void market::destroy () {
     __TBB_InitOnce::remove_ref();
 }
 
+void market::notify_server(int target_epoch, int delta) {
+    my_adjust_demand_current_epoch.wait_until(target_epoch - 1, /* context = */ target_epoch - 1, std::memory_order_acquire);
+    // Must be called outside of any locks
+    my_server->adjust_job_count_estimate(delta);
+    __TBB_ASSERT(my_adjust_demand_current_epoch.load(std::memory_order_relaxed) == target_epoch - 1, nullptr);
+    my_adjust_demand_current_epoch.exchange(target_epoch);
+    my_adjust_demand_current_epoch.notify_relaxed(target_epoch);
+}
+
 bool market::release ( bool is_public, bool blocking_terminate ) {
     market::enforce([this] { return theMarket == this; }, "Global market instance was destroyed prematurely?");
     bool do_release = false;
@@ -204,6 +213,15 @@ bool market::release ( bool is_public, bool blocking_terminate ) {
         }
     }
     if( do_release ) {
+        int delta{}, target_epoch{};
+        {
+            arenas_list_mutex_type::scoped_lock lock(my_arenas_list_mutex);
+            delta = my_num_workers_actual_request;
+            my_num_workers_actual_request = 0;
+            target_epoch = ++my_adjust_demand_target_epoch;
+        }
+        notify_server(target_epoch, -delta);
+
         __TBB_ASSERT( !my_public_ref_count.load(std::memory_order_relaxed),
             "No public references remain if we remove the market." );
         // inform RML that blocking termination is required
@@ -214,18 +232,47 @@ bool market::release ( bool is_public, bool blocking_terminate ) {
     return false;
 }
 
-int market::update_workers_request() {
-    int old_request = my_num_workers_requested;
-    my_num_workers_requested = min(my_total_demand.load(std::memory_order_relaxed),
-                                   (int)my_num_workers_soft_limit.load(std::memory_order_relaxed));
+int market::get_num_target_workers() {
+    int soft_limit = (int)my_num_workers_soft_limit.load(std::memory_order_relaxed);
+    int num_workers_target_request = min(my_total_demand.load(std::memory_order_relaxed), soft_limit);
 #if __TBB_ENQUEUE_ENFORCED_CONCURRENCY
     if (my_mandatory_num_requested > 0) {
-        __TBB_ASSERT(my_num_workers_soft_limit.load(std::memory_order_relaxed) == 0, NULL);
-        my_num_workers_requested = 1;
+        __TBB_ASSERT(soft_limit == 0, NULL);
+        __TBB_ASSERT(num_workers_target_request == 0, NULL);
+        num_workers_target_request = 1;
     }
 #endif
-    update_allotment(my_num_workers_requested);
-    return my_num_workers_requested - old_request;
+
+    return num_workers_target_request;
+}
+
+int market::update_workers_request(int old_request) {
+    int num_workers_target_request = get_num_target_workers();
+    update_allotment(num_workers_target_request);
+
+    int request_diff = num_workers_target_request - old_request;
+    if (request_diff > 0) {
+#if __TBB_ENQUEUE_ENFORCED_CONCURRENCY
+        if (my_mandatory_num_requested > 0) {
+            __TBB_ASSERT(request_diff == 1, nullptr);
+            if (my_num_workers_actual_request == 0) {
+                my_num_workers_actual_request = 1;
+            } else {
+                request_diff = 0;
+            }
+        } else
+#endif
+        {
+            request_diff = min(request_diff,
+                (int)my_num_workers_soft_limit.load(std::memory_order_relaxed) - my_num_workers_actual_request);
+            if (request_diff > 0) {
+                my_num_workers_actual_request += request_diff;
+            }
+        }
+    }
+    __TBB_ASSERT(my_num_workers_actual_request >= num_workers_target_request, nullptr);
+
+    return request_diff;
 }
 
 void market::set_active_num_workers ( unsigned soft_limit ) {
@@ -242,10 +289,11 @@ void market::set_active_num_workers ( unsigned soft_limit ) {
     }
     // have my_ref_count for market, use it safely
 
-    int delta = 0;
+    int delta = 0, old_workers_request = 0;
     {
         arenas_list_mutex_type::scoped_lock lock( m->my_arenas_list_mutex );
         __TBB_ASSERT(soft_limit <= m->my_num_workers_hard_limit, NULL);
+        old_workers_request = m->get_num_target_workers();
 
 #if __TBB_ENQUEUE_ENFORCED_CONCURRENCY
         arena_list_type* arenas = m->my_arenas;
@@ -274,11 +322,13 @@ void market::set_active_num_workers ( unsigned soft_limit ) {
         }
 #endif
 
-        delta = m->update_workers_request();
+        delta = m->update_workers_request(old_workers_request);
     }
-    // adjust_job_count_estimate must be called outside of any locks
-    if( delta!=0 )
+
+    if (delta > 0) {
+        // adjust_job_count_estimate must be called outside of any locks
         m->my_server->adjust_job_count_estimate( delta );
+    }
     // release internal market reference to match ++m->my_ref_count above
     m->release( /*is_public=*/false, /*blocking_terminate=*/false );
 }
@@ -364,9 +414,11 @@ arena* market::arena_in_need ( arena_list_type* arenas, arena* hint ) {
             } while ( arenas[curr_priority_level].empty() );
             it = arenas[curr_priority_level].begin();
         }
-        if( a.num_workers_active() < a.my_num_workers_allotted.load(std::memory_order_relaxed) ) {
-            a.my_references += arena::ref_worker;
-            return &a;
+
+        if (a.num_workers_active() < a.my_num_workers_allotted.load(std::memory_order_relaxed)) {
+            if (a.try_add_worker_reference()) {
+                return &a;
+            }
         }
     } while ( it != hint );
     return nullptr;
@@ -421,6 +473,7 @@ int market::update_allotment ( arena_list_type* arenas, int workers_demand, int 
                 __TBB_ASSERT(allotted <= a.my_num_workers_requested, nullptr);
                 __TBB_ASSERT(allotted <= int(a.my_num_slots - a.my_num_reserved_slots), nullptr);
             }
+
             a.my_num_workers_allotted.store(allotted, std::memory_order_relaxed);
             a.my_is_top_priority.store(list_idx == max_priority_level, std::memory_order_relaxed);
             assigned += allotted;
@@ -471,10 +524,10 @@ void market::enable_mandatory_concurrency ( arena *a ) {
             return;
 
         enable_mandatory_concurrency_impl(a);
-        delta = update_workers_request();
+        delta = update_workers_request(0);
     }
 
-    if (delta != 0)
+    if (delta > 0)
         my_server->adjust_job_count_estimate(delta);
 }
 
@@ -492,7 +545,7 @@ void market::mandatory_concurrency_disable ( arena *a ) {
         arenas_list_mutex_type::scoped_lock lock(my_arenas_list_mutex);
         if (!a->my_global_concurrency_mode.load(std::memory_order_relaxed))
             return;
-        // There is a racy window in advertise_new_work between mandtory concurrency enabling and 
+        // There is a racy window in advertise_new_work between mandatory concurrency enabling and
         // setting SNAPSHOT_FULL. It gives a chance to spawn request to disable mandatory concurrency.
         // Therefore, we double check that there is no enqueued tasks.
         if (a->has_enqueued_tasks())
@@ -501,108 +554,138 @@ void market::mandatory_concurrency_disable ( arena *a ) {
         __TBB_ASSERT(my_num_workers_soft_limit.load(std::memory_order_relaxed) == 0, NULL);
         disable_mandatory_concurrency_impl(a);
 
-        delta = update_workers_request();
+        delta = update_workers_request(1);
     }
-    if (delta != 0)
+    if (delta > 0)
         my_server->adjust_job_count_estimate(delta);
 }
 #endif /* __TBB_ENQUEUE_ENFORCED_CONCURRENCY */
 
-void market::adjust_demand ( arena& a, int delta, bool mandatory ) {
-    if (!delta) {
-        return;
+void market::update_demand(int delta, int priority_level) {
+    int total_demand = my_total_demand.load(std::memory_order_relaxed) + delta;
+    my_total_demand.store(total_demand, std::memory_order_relaxed);
+    my_priority_level_demand[priority_level] += delta;
+}
+
+int market::effective_soft_limit() {
+    unsigned limit = my_num_workers_soft_limit.load(std::memory_order_relaxed);
+    if (my_mandatory_num_requested > 0) {
+        __TBB_ASSERT(limit == 0, NULL);
+        limit = 1;
     }
+
+    return limit;
+}
+
+static int clamp_delta(int delta, int max_delta) {
+    return max_delta > 0 ? clamp(delta, 0, max_delta) : 0;
+}
+
+int market::adjust_demand(arena& a, int delta, bool mandatory) {
+    __TBB_ASSERT(theMarket != nullptr, "market instance was destroyed prematurely?");
+
+    delta = a.update_workers_request(delta, mandatory);
+    if (delta) {
+        update_demand(delta, a.my_priority_level);
+
+        int soft_limit = effective_soft_limit();
+        update_allotment(soft_limit);
+
+        delta = clamp_delta(delta, soft_limit - my_num_workers_actual_request);
+        my_num_workers_actual_request += delta;
+    }
+    return delta;
+}
+
+void market::increase_demand(arena& a, int delta, bool mandatory) {
+    __TBB_ASSERT(delta >= 0, nullptr);
     int target_epoch{};
     {
         arenas_list_mutex_type::scoped_lock lock(my_arenas_list_mutex);
-        __TBB_ASSERT(theMarket != nullptr, "market instance was destroyed prematurely?");
-#if __TBB_ENQUEUE_ENFORCED_CONCURRENCY
-        if (mandatory) {
-            __TBB_ASSERT(delta == 1 || delta == -1, nullptr);
-            // Count the number of mandatory requests and proceed only for 0->1 and 1->0 transitions.
-            a.my_local_concurrency_requests += delta;
-            if ((delta > 0 && a.my_local_concurrency_requests != 1) ||
-                (delta < 0 && a.my_local_concurrency_requests != 0))
-            {
-                return;
-            }
-        }
-#endif
-        a.my_total_num_workers_requested += delta;
-        int target_workers = 0;
-        // Cap target_workers into interval [0, a.my_max_num_workers]
-        if (a.my_total_num_workers_requested > 0) {
-#if __TBB_ENQUEUE_ENFORCED_CONCURRENCY
-            // At least one thread should be requested when mandatory concurrency
-            int max_num_workers = int(a.my_max_num_workers);
-            if (a.my_local_concurrency_requests > 0 && max_num_workers == 0) {
-                max_num_workers = 1;
-            }
-#endif
-            target_workers = min(a.my_total_num_workers_requested, max_num_workers);
-        }
-
-        delta = target_workers - a.my_num_workers_requested;
-
-        if (delta == 0) {
+        delta = adjust_demand(a, delta, mandatory);
+        if (!delta) {
             return;
         }
+        target_epoch = ++my_adjust_demand_target_epoch;
+    }
+    if (target_epoch) {
+        notify_server(target_epoch, delta);
+    }
+}
 
-        a.my_num_workers_requested += delta;
-        if (a.my_num_workers_requested == 0) {
-            a.my_num_workers_allotted.store(0, std::memory_order_relaxed);
+// The decrease demand logic does not notify RML about decreased demand.
+// The idea is that the worker threads notify RML when they leave the market.
+// This logic allows allocating more threads than total demand of all arenas
+// (to satisfy full arena requests if some empty arenas cannot release workers).
+void market::decrease_demand(arena& a, int delta, bool mandatory) {
+    delta *= -1;
+    __TBB_ASSERT(delta <= 0, nullptr);
+    arenas_list_mutex_type::scoped_lock lock(my_arenas_list_mutex);
+    delta = adjust_demand(a, delta, mandatory);
+    __TBB_ASSERT_EX(delta == 0, nullptr);
+}
+
+arena* market::try_leave_market(int ticket, arena* prev_arena) {
+    int target_epoch{};
+    int delta{};
+    {
+        arenas_list_mutex_type::scoped_lock lock(my_arenas_list_mutex);
+        if (ticket < my_num_workers_actual_request) {
+            __TBB_ASSERT(my_num_workers_actual_request > 0, nullptr);
+            arena* next_arena = nullptr;
+            if (is_arena_alive(prev_arena)) {
+                next_arena = arena_in_need(my_arenas, prev_arena);
+            } else {
+                next_arena = arena_in_need(my_arenas, nullptr);
+            }
+
+            if (next_arena) {
+                return next_arena;
+            }
+
+            delta = min(1, my_num_workers_actual_request - get_num_target_workers());
+            __TBB_ASSERT(delta >= 0, nullptr);
+
+            my_num_workers_actual_request -= delta;
+        } else {
+            return nullptr;
         }
 
-        int total_demand = my_total_demand.load(std::memory_order_relaxed) + delta;
-        my_total_demand.store(total_demand, std::memory_order_relaxed);
-        my_priority_level_demand[a.my_priority_level] += delta;
-        unsigned effective_soft_limit = my_num_workers_soft_limit.load(std::memory_order_relaxed);
-        if (my_mandatory_num_requested > 0) {
-            __TBB_ASSERT(effective_soft_limit == 0, NULL);
-            effective_soft_limit = 1;
-        }
-
-        update_allotment(effective_soft_limit);
-        if (delta > 0) {
-            // can't overflow soft_limit, but remember values request by arenas in
-            // my_total_demand to not prematurely release workers to RML
-            if (my_num_workers_requested + delta > (int)effective_soft_limit)
-                delta = effective_soft_limit - my_num_workers_requested;
-        }
-        else {
-            // the number of workers should not be decreased below my_total_demand
-            if (my_num_workers_requested + delta < total_demand)
-                delta = min(total_demand, (int)effective_soft_limit) - my_num_workers_requested;
-        }
-        my_num_workers_requested += delta;
-        __TBB_ASSERT(my_num_workers_requested <= (int)effective_soft_limit, NULL);
-
-        target_epoch = my_adjust_demand_target_epoch++;
+        target_epoch = ++my_adjust_demand_target_epoch;
     }
 
-    my_adjust_demand_current_epoch.wait_until(target_epoch, /* context = */ target_epoch, std::memory_order_acquire);
-    // Must be called outside of any locks
-    my_server->adjust_job_count_estimate( delta );
-    my_adjust_demand_current_epoch.exchange(target_epoch + 1);
-    my_adjust_demand_current_epoch.notify_relaxed(target_epoch + 1);
+    notify_server(target_epoch, -delta);
+    return nullptr;
 }
 
 void market::process( job& j ) {
     thread_data& td = static_cast<thread_data&>(j);
     // td.my_arena can be dead. Don't access it until arena_in_need is called
-    arena *a = td.my_arena;
-    for (int i = 0; i < 2; ++i) {
-        while ( (a = arena_in_need(a)) ) {
-            a->process(td);
+    arena* a = td.my_arena;
+    arena* next_arena = nullptr;
+    arena* prev_arena = nullptr;
+    do {
+        ++my_num_active_workers;
+        if (next_arena) {
+            next_arena->process(td);
         }
-        // Workers leave market because there is no arena in need. It can happen earlier than
-        // adjust_job_count_estimate() decreases my_slack and RML can put this thread to sleep.
-        // It might result in a busy-loop checking for my_slack<0 and calling this method instantly.
-        // the yield refines this spinning.
-        if ( !i ) {
-            yield();
+
+        for (int i = 0; i < 2; ++i) {
+            while ( (a = arena_in_need(a)) ) {
+                a->process(td);
+                prev_arena = a;
+            }
+            // Workers leave market because there is no arena in need. It can happen earlier than
+            // adjust_job_count_estimate() decreases my_slack and RML can put this thread to sleep.
+            // It might result in a busy-loop checking for my_slack<0 and calling this method instantly.
+            // the yield refines this spinning.
+            if ( !i ) {
+                yield();
+            }
         }
-    }
+        int ticket = --my_num_active_workers;
+        next_arena = try_leave_market(ticket, prev_arena);
+    } while (next_arena);
 }
 
 void market::cleanup( job& j) {

--- a/src/tbb/private_server.cpp
+++ b/src/tbb/private_server.cpp
@@ -270,9 +270,9 @@ void private_worker::run() noexcept {
             // Prepare to wait
             my_thread_monitor.prepare_wait(c);
             // Check/set the invariant for sleeping
-            if( my_state.load(std::memory_order_acquire)!=st_quit && my_server.try_insert_in_asleep_list(*this) ) {
+            if (my_state.load(std::memory_order_acquire) != st_quit && my_server.try_insert_in_asleep_list(*this)) {
                 my_thread_monitor.commit_wait(c);
-                __TBB_ASSERT( my_state==st_quit || !my_next, "Thread monitor missed a spurious wakeup?" );
+                __TBB_ASSERT(my_state.load(std::memory_order_relaxed) == st_quit || !my_next, "Thread monitor missed a spurious wakeup?" );
                 my_server.propagate_chain_reaction();
             } else {
                 // Invariant broken


### PR DESCRIPTION
Currently market notifies RML about surplus threads at the time of without of work. However, some workers can not leave arena immediately, but counted as workers to join other arenas. As result other arenas might not have enough threads.

The patch changes the behavior of market to postpone RML notification of surplus workers to the moment when a worker is ready to leave the market. In other words workers make decision to notify RML themselves.
Signed-off-by: pavelkumbrasev <pavel.kumbrasev@intel.com>