### PR TITLE
Fix HWLOC_LIBRARY_DIRS when using pkg-config to find hwloc

### DIFF
--- a/src/tbbbind/CMakeLists.txt
+++ b/src/tbbbind/CMakeLists.txt
@@ -37,6 +37,12 @@ function(tbbbind_build TBBBIND_NAME REQUIRED_HWLOC_TARGET)
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         ${HWLOC_INCLUDE_DIRS} # pkg-config defined
     )
+    if (COMMAND target_link_directories)
+	target_link_directories(${TBBBIND_NAME}
+		PRIVATE
+		${HWLOC_LIBRARY_DIRS} # pkg-config defined
+	)
+    endif()
 
     target_compile_options(${TBBBIND_NAME}
         PRIVATE
@@ -66,7 +72,6 @@ function(tbbbind_build TBBBIND_NAME REQUIRED_HWLOC_TARGET)
             ${TBB_LIB_LINK_FLAGS}
             ${TBB_COMMON_LINK_FLAGS}
             ${TBB_IPO_LINK_FLAGS}
-            ${HWLOC_LIBRARY_DIRS} # pkg-config defined
         )
     else()
         target_link_libraries(${TBBBIND_NAME}
@@ -74,7 +79,6 @@ function(tbbbind_build TBBBIND_NAME REQUIRED_HWLOC_TARGET)
             ${TBB_LIB_LINK_FLAGS}
             ${TBB_COMMON_LINK_FLAGS}
             ${TBB_IPO_LINK_FLAGS}
-            ${HWLOC_LIBRARY_DIRS} # pkg-config defined
         )
     endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -258,7 +258,12 @@ function(tbb_add_tbbbind_test)
         )
         set_property(
             TARGET ${_tbbbind_test_NAME}
-            PROPERTY LINK_LIBRARIES ${HWLOC_LIBRARY_DIRS} ${HWLOC_LIBRARIES}
+            PROPERTY LINK_LIBRARIES ${HWLOC_LIBRARIES}
+            APPEND
+        )
+        set_property(
+            TARGET ${_tbbbind_test_NAME}
+			PROPERTY LINK_DIRECTORIES ${HWLOC_LIBRARY_DIRS}
             APPEND
         )
         set_property(


### PR DESCRIPTION
Without this change `cmake` reports this:
```
WARNING: Target "conformance_arena_constraints" requests linking to directory "/usr/lib64".  Targets may link only to libraries.  CMake is dropping the item.
WARNING: Target "test_arena_constraints" requests linking to directory "/usr/lib64".  Targets may link only to libraries.  CMake is dropping the item.
```

And then generated `build.ninja` contains this:

```
...
build gnu_10.2_cxx11_64_relwithdebinfo/libtbbbind_2_5.so.3.3: CXX_SHARED_LIBRARY_LINKER__tbbbind_2_5_RelWithDebInfo src/tbbbind/CMakeFiles/tbbbind_2_5.dir/tbb_bind.cpp.o | ../src/tbbbind/def/lin64-tbbbind.def
  LANGUAGE_COMPILE_FLAGS = -O2 -g -DNDEBUG
  LINK_FLAGS = -Wl,--version-script=/home/artur/Programming/C++/oneTBB/src/tbbbind/def/lin64-tbbbind.def  -flto /usr/lib64
  LINK_LIBRARIES = -lhwloc  -ldl
...
```

This happens because `HWLOC_LIBRARY_DIRS` variable, which is set by `pkg-config`, contains library directories without `-L` prefix (see https://cmake.org/cmake/help/latest/module/FindPkgConfig.html#:~:text=their%20absolute%20paths-,%3CXXX%3E_LIBRARY_DIRS,-the%20paths%20of), so the linker tries to link `/usr/lib64` directory as library and obviously fails. So instead of passing `HWLOC_LIBRARY_DIRS` to `target_link_libraries`, one should pass it to `target_link_directories` instead.

I'm using Void Linux, I tried to reproduce this bug in Alpine docker container with `pkgconf` installed, but failed for unknown reason. Anyway, this bug obviously exists and prevents from updating Void Linux package.
