### PR TITLE
Fix a race condition in AddrRange in tbbmalloc

### DIFF
--- a/test/tbbmalloc/test_malloc_overload.cpp
+++ b/test/tbbmalloc/test_malloc_overload.cpp
@@ -514,6 +514,7 @@ TEST_CASE("Address range tracker regression test") {
                 ptr = realloc(ptr, 1024*1024 + 4096*j);
             }
         }
+        free(ptr);
     });
 }
 #endif // !HARNESS_SKIP_TEST

--- a/test/tbbmalloc/test_malloc_overload.cpp
+++ b/test/tbbmalloc/test_malloc_overload.cpp
@@ -500,4 +500,20 @@ TEST_CASE("Main set of tests") {
     TestZoneOverload();
     TestRuntimeRoutines();
 }
+
+//! Test address range tracker in backend that could be
+//! broken during remap because of incorrect order of
+//! deallocation event and the mremap system call
+//! \brief \ref regression
+TEST_CASE("Address range tracker regression test") {
+    int numThreads = 16;
+    utils::NativeParallelFor(numThreads, [](int) {
+        void *ptr = nullptr;
+        for (int i = 0; i < 1000; ++i) {
+            for (int j = 0; j < 100; ++j) {
+                ptr = realloc(ptr, 1024*1024 + 4096*j);
+            }
+        }
+    });
+}
 #endif // !HARNESS_SKIP_TEST


### PR DESCRIPTION
The issue affect only `realloc` when overloaded with `tbbmalloc_proxy` on Linux. The root cause that memory range is unregistered after returning memory back to the OS. It leads to a race condition that memory can be reused for another thread and memory range will not be registered (because unregister might be not performed yet).

The patch moves the unregistration before memory deallocation to the OS.