### PR TITLE
GCC 11: suppress stringop-overread warning

### DIFF
--- a/src/tbb/parallel_pipeline.cpp
+++ b/src/tbb/parallel_pipeline.cpp
@@ -144,7 +144,7 @@ class input_buffer {
     const bool is_ordered;
 
     //! for parallel filters that accepts NULLs, thread-local flag for reaching end_of_input
-    using end_of_input_tls_t = basic_tls<std::intptr_t>;
+    using end_of_input_tls_t = basic_tls<input_buffer*>;
     end_of_input_tls_t end_of_input_tls;
     bool end_of_input_tls_allocated; // no way to test pthread creation of TLS
 
@@ -240,10 +240,10 @@ public:
             handle_perror(status, "Failed to destroy filter TLS");
     }
     bool my_tls_end_of_input() {
-        return end_of_input_tls.get() != 0;
+        return end_of_input_tls.get() != nullptr;
     }
     void set_my_tls_end_of_input() {
-        end_of_input_tls.set(1);
+        end_of_input_tls.set(this);
     }
 };
 

--- a/test/tbbmalloc/test_malloc_init_shutdown.cpp
+++ b/test/tbbmalloc/test_malloc_init_shutdown.cpp
@@ -142,7 +142,7 @@ struct TestThread: utils::NoAssign {
         // intersectingObjects takes into account object shuffle
         REQUIRE_MESSAGE((!prevLarge || intersectingObjects(currLarge, prevLarge, 32*1024)), "Possible memory leak");
         pthread_key_create( &key, &threadDtor );
-        pthread_setspecific(key, (const void*)42);
+        pthread_setspecific(key, (const void*)this);
     }
 };
 

--- a/test/tbbmalloc/test_malloc_new_handler.cpp
+++ b/test/tbbmalloc/test_malloc_new_handler.cpp
@@ -33,9 +33,7 @@
 #pragma warning (disable: 4800)
 #endif //#if _MSC_VER
 
-#include "../../src/tbb/tls.h"
-
-tbb::detail::r1::tls<bool> new_handler_called;
+thread_local bool new_handler_called = false;
 void customNewHandler() {
     new_handler_called = true;
     throw std::bad_alloc();


### PR DESCRIPTION
pthread_setspecific has attribute access none for second parameter.
GCC 11 causes "stringop-overread" warning in case providing non-pointer value to pthread_setspecific.

test_malloc_new_handler: using thread_local instead of tbb::detail::r1::tls
test_malloc_init_shutdown: Replace magic-value with valid pointer