### PR TITLE
Fix using tbb::this_task_arena::current_thread_index() with uninitilized arena

### DIFF
--- a/include/oneapi/tbb/task_arena.h
+++ b/include/oneapi/tbb/task_arena.h
@@ -451,8 +451,8 @@ inline auto isolate(F&& f) -> decltype(f()) {
 
 //! Returns the index, aka slot number, of the calling thread in its current arena
 inline int current_thread_index() {
-    int idx = r1::execution_slot(nullptr);
-    return idx == -1 ? task_arena_base::not_initialized : idx;
+    slot_id idx = r1::execution_slot(nullptr);
+    return idx == slot_id(-1) ? task_arena_base::not_initialized : int(idx);
 }
 
 #if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS

--- a/src/tbb/task_dispatcher.cpp
+++ b/src/tbb/task_dispatcher.cpp
@@ -133,7 +133,7 @@ d1::slot_id __TBB_EXPORTED_FUNC execution_slot(const d1::execution_data* ed) {
         return ed_ext->task_disp->m_thread_data->my_arena_index;
     } else {
         thread_data* td = governor::get_thread_data_if_initialized();
-        return td ? int(td->my_arena_index) : -1;
+        return td ? td->my_arena_index : -1;
     }
 }
 

--- a/src/tbb/task_dispatcher.cpp
+++ b/src/tbb/task_dispatcher.cpp
@@ -133,7 +133,7 @@ d1::slot_id __TBB_EXPORTED_FUNC execution_slot(const d1::execution_data* ed) {
         return ed_ext->task_disp->m_thread_data->my_arena_index;
     } else {
         thread_data* td = governor::get_thread_data_if_initialized();
-        return td ? td->my_arena_index : -1;
+        return td ? td->my_arena_index : d1::slot_id(-1);
     }
 }
 

--- a/test/conformance/conformance_task_arena.cpp
+++ b/test/conformance/conformance_task_arena.cpp
@@ -25,6 +25,13 @@
 //! \file conformance_task_arena.cpp
 //! \brief Test for [scheduler.task_arena scheduler.task_scheduler_observer] specification
 
+// This test requires TBB in an uninitialized state
+//! Test for uninitilized arena
+//! \brief \ref requirement \ref interface
+TEST_CASE("Test current_thread_index") {
+    REQUIRE_MESSAGE((tbb::this_task_arena::current_thread_index() == tbb::task_arena::not_initialized), "TBB was initialized state");
+}
+
 //! Test task arena interfaces
 //! \brief \ref requirement \ref interface
 TEST_CASE("Arena interfaces") {

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -1752,7 +1752,7 @@ struct enqueue_test_helper {
 //! Test for uninitilized arena
 //! \brief \ref requirement \ref error_guessing
 TEST_CASE("Test current_thread_index") {
-    CHECK(tbb::this_task_arena::current_thread_index() < 0);
+    CHECK((tbb::this_task_arena::current_thread_index() == tbb::task_arena::not_initialized));
 }
 
 // This test requires TBB in an uninitialized state

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -1752,12 +1752,13 @@ struct enqueue_test_helper {
 //! Test for uninitilized arena
 //! \brief \ref requirement \ref error_guessing
 TEST_CASE("Test current_thread_index") {
-    CHECK((tbb::this_task_arena::current_thread_index() == tbb::task_arena::not_initialized));
+    REQUIRE_MESSAGE((tbb::this_task_arena::current_thread_index() == tbb::task_arena::not_initialized), "TBB was initialized state");
 }
 
 // This test requires TBB in an uninitialized state
 //! \brief \ref requirement
 TEST_CASE("task_arena initialize soft limit ignoring affinity mask") {
+    REQUIRE_MESSAGE((tbb::this_task_arena::current_thread_index() == tbb::task_arena::not_initialized), "TBB was initialized state");
     tbb::enumerable_thread_specific<int> ets;
 
     tbb::task_arena arena(int(utils::get_platform_max_threads() * 2));

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -1748,7 +1748,13 @@ struct enqueue_test_helper {
 
 //--------------------------------------------------//
 
-// This test should be first
+//! Test for uninitilized arena
+//! \brief \ref requirement \ref error_guessing
+TEST_CASE("Test current_thread_index") {
+    CHECK(tbb::this_task_arena::current_thread_index() < 0);
+}
+
+// This test requires TBB in an uninitialized state
 //! \brief \ref requirement
 TEST_CASE("task_arena initialize soft limit ignoring affinity mask") {
     tbb::enumerable_thread_specific<int> ets;

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -1749,13 +1749,6 @@ struct enqueue_test_helper {
 //--------------------------------------------------//
 
 // This test requires TBB in an uninitialized state
-//! Test for uninitilized arena
-//! \brief \ref requirement \ref error_guessing
-TEST_CASE("Test current_thread_index") {
-    REQUIRE_MESSAGE((tbb::this_task_arena::current_thread_index() == tbb::task_arena::not_initialized), "TBB was initialized state");
-}
-
-// This test requires TBB in an uninitialized state
 //! \brief \ref requirement
 TEST_CASE("task_arena initialize soft limit ignoring affinity mask") {
     REQUIRE_MESSAGE((tbb::this_task_arena::current_thread_index() == tbb::task_arena::not_initialized), "TBB was initialized state");

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -1748,6 +1748,7 @@ struct enqueue_test_helper {
 
 //--------------------------------------------------//
 
+// This test requires TBB in an uninitialized state
 //! Test for uninitilized arena
 //! \brief \ref requirement \ref error_guessing
 TEST_CASE("Test current_thread_index") {


### PR DESCRIPTION
Replaced `int` on `slot_id` to avoid problem with uninitilized arena.
Signed-off-by: pavelkumbrasev <pavel.kumbrasev@intel.com>