### PR TITLE
Cover the constraints_threads_per_core() reserved interface by testing

### DIFF
--- a/test/tbb/test_arena_constraints.cpp
+++ b/test/tbb/test_arena_constraints.cpp
@@ -217,5 +217,5 @@ TEST_CASE("Test concurrency getters output for constraints with custom concurren
 //! \brief \ref interface \ref error_guessing
 TEST_CASE("Testing constraints_threads_per_core() reserved entry point") {
     tbb::task_arena::constraints c{};
-    REQUIRE(tbb::detail::r1::constraints_threads_per_core(c) == tbb::task_arena::automatic);
+    REQUIRE((tbb::detail::r1::constraints_threads_per_core(c) == tbb::task_arena::automatic));
 }

--- a/test/tbb/test_arena_constraints.cpp
+++ b/test/tbb/test_arena_constraints.cpp
@@ -212,3 +212,10 @@ TEST_CASE("Test concurrency getters output for constraints with custom concurren
     c.set_max_threads_per_core(1);
     check_concurrency_level(c);
 }
+
+//! Testing constraints_threads_per_core() reserved entry point
+//! \brief \ref interface \ref error_guessing
+TEST_CASE("Testing constraints_threads_per_core() reserved entry point") {
+    tbb::task_arena::constraints c{};
+    REQUIRE(tbb::detail::r1::constraints_threads_per_core(c) == tbb::task_arena::automatic);
+}

--- a/test/tbb/test_arena_constraints.cpp
+++ b/test/tbb/test_arena_constraints.cpp
@@ -214,8 +214,8 @@ TEST_CASE("Test concurrency getters output for constraints with custom concurren
 }
 
 //! Testing constraints_threads_per_core() reserved entry point
-//! \brief \ref interface \ref error_guessing
+//! \brief \ref error_guessing
 TEST_CASE("Testing constraints_threads_per_core() reserved entry point") {
     tbb::task_arena::constraints c{};
-    REQUIRE((tbb::detail::r1::constraints_threads_per_core(c) == tbb::task_arena::automatic));
+    tbb::detail::r1::constraints_threads_per_core(c);
 }


### PR DESCRIPTION
Now we have the uncovered entry-point inside the `tbb::info` namespace. This request test this function to improve code coverage.

Signed-off-by: Kochin Ivan <kochin.ivan@intel.com>