### PR TITLE
Define ITT_ARCH_IA64 when undefiend

### DIFF
--- a/src/tbb/tools_api/ittnotify_config.h
+++ b/src/tbb/tools_api/ittnotify_config.h
@@ -147,6 +147,10 @@
 #  define ITT_ARCH_IA32E 2
 #endif /* ITT_ARCH_IA32E */
 
+#ifndef ITT_ARCH_IA64
+#  define ITT_ARCH_IA64 3
+#endif /* ITT_ARCH_IA64 */
+
 #ifndef ITT_ARCH_ARM
 #  define ITT_ARCH_ARM  4
 #endif /* ITT_ARCH_ARM */


### PR DESCRIPTION
I am not sure why ITT_ARCH_IA64 was skipped here. This results in unsupported architecture (RISC-V, in my case) falls to the `ITT_ARCH==ITT_ARCH_IA64` branch below (because both of them are undefined) and results in a build error due to `__TBB_machine_fetchadd4` being undefined.