### PR TITLE
Increase number of iterations to cover 'resume_node::reset' call

### DIFF
--- a/test/tbb/test_resumable_tasks.cpp
+++ b/test/tbb/test_resumable_tasks.cpp
@@ -263,7 +263,7 @@ void TestSuspendResume() {
     inner_par_iters = outer_par_iters = 0;
 
     tbb::parallel_for(0, N, [&](int) {
-        for (int i = 0; i < 100; ++i) {
+        for (int i = 0; i < 50000; ++i) {
             ets_fiber.local() = i;
 
             int local_epoch;
@@ -286,7 +286,7 @@ void TestSuspendResume() {
         ++outer_par_iters;
     });
     CHECK(outer_par_iters == N);
-    CHECK(inner_par_iters == N*N*100);
+    CHECK(inner_par_iters == N*N*50000);
 }
 
 // During cleanup external thread's local task pool may

--- a/test/tbb/test_resumable_tasks.cpp
+++ b/test/tbb/test_resumable_tasks.cpp
@@ -255,7 +255,7 @@ private:
 
 // Simple test for basic resumable tasks functionality
 void TestSuspendResume() {
-#if __TBB_USE_SANITIZER
+#if __TBB_USE_SANITIZERS
     constexpr int iter_size = 100;
 #else
     constexpr int iter_size = 50000;

--- a/test/tbb/test_resumable_tasks.cpp
+++ b/test/tbb/test_resumable_tasks.cpp
@@ -255,6 +255,12 @@ private:
 
 // Simple test for basic resumable tasks functionality
 void TestSuspendResume() {
+#if __TBB_USE_SANITIZER
+    constexpr int iter_size = 100;
+#else
+    constexpr int iter_size = 50000;
+#endif
+
     std::atomic<int> global_epoch; global_epoch = 0;
     EpochAsyncActivity async(4, global_epoch);
 
@@ -263,7 +269,7 @@ void TestSuspendResume() {
     inner_par_iters = outer_par_iters = 0;
 
     tbb::parallel_for(0, N, [&](int) {
-        for (int i = 0; i < 50000; ++i) {
+        for (int i = 0; i < iter_size; ++i) {
             ets_fiber.local() = i;
 
             int local_epoch;
@@ -286,7 +292,7 @@ void TestSuspendResume() {
         ++outer_par_iters;
     });
     CHECK(outer_par_iters == N);
-    CHECK(inner_par_iters == N*N*50000);
+    CHECK(inner_par_iters == N*N*iter_size);
 }
 
 // During cleanup external thread's local task pool may


### PR DESCRIPTION
Increased number of iterations to have a more stable coverage of `resume_node::reset()` function.

Signed-off-by: Ilya Isaev <ilya.isaev@intel.com>