### PR TITLE
Fix stack overflow protection mechanism

### DIFF
--- a/src/tbb/global_control.cpp
+++ b/src/tbb/global_control.cpp
@@ -93,7 +93,7 @@ class alignas(max_nfs_size) stack_size_control : public control_storage {
         static auto ThreadStackSizeDefault = [] {
             ULONG_PTR hi, lo;
             GetCurrentThreadStackLimits(&lo, &hi);
-            return std::size_t(hi - lo);
+            return hi - lo;
         }();
         return ThreadStackSizeDefault;
 #else

--- a/src/tbb/global_control.cpp
+++ b/src/tbb/global_control.cpp
@@ -89,7 +89,16 @@ public:
 
 class alignas(max_nfs_size) stack_size_control : public control_storage {
     std::size_t default_value() const override {
+#if _WIN32_WINNT >= 0x0602 /* _WIN32_WINNT_WIN8 */
+        static auto ThreadStackSizeDefault = [] {
+            ULONG_PTR hi, lo;
+            GetCurrentThreadStackLimits(&lo, &hi);
+            return std::size_t(hi - lo);
+        }();
+        return ThreadStackSizeDefault;
+#else
         return ThreadStackSize;
+#endif
     }
     void apply_active(std::size_t new_active) override {
         control_storage::apply_active(new_active);

--- a/src/tbb/governor.cpp
+++ b/src/tbb/governor.cpp
@@ -132,11 +132,11 @@ void governor::one_time_init() {
 static std::uintptr_t get_stack_base(std::size_t stack_size) {
     // Stacks are growing top-down. Highest address is called "stack base",
     // and the lowest is "stack limit".
-#if USE_WINTHREAD
+#if __TBB_USE_WINAPI
     suppress_unused_warning(stack_size);
     NT_TIB* pteb = (NT_TIB*)NtCurrentTeb();
     __TBB_ASSERT(&pteb < pteb->StackBase && &pteb > pteb->StackLimit, "invalid stack info in TEB");
-    return pteb->StackBase;
+    return std::uintptr_t(pteb->StackBase);
 #else /* USE_PTHREAD */
     // There is no portable way to get stack base address in Posix, so we use
     // non-portable method (on all modern Linux) or the simplified approach

--- a/src/tbb/governor.cpp
+++ b/src/tbb/governor.cpp
@@ -136,7 +136,7 @@ static std::uintptr_t get_stack_base(std::size_t stack_size) {
     suppress_unused_warning(stack_size);
     NT_TIB* pteb = (NT_TIB*)NtCurrentTeb();
     __TBB_ASSERT(&pteb < pteb->StackBase && &pteb > pteb->StackLimit, "invalid stack info in TEB");
-    return std::uintptr_t(pteb->StackBase);
+    return reinterpret_cast<std::uintptr_t>(pteb->StackBase);
 #else /* USE_PTHREAD */
     // There is no portable way to get stack base address in Posix, so we use
     // non-portable method (on all modern Linux) or the simplified approach

--- a/src/tbb/governor.cpp
+++ b/src/tbb/governor.cpp
@@ -137,7 +137,7 @@ static std::uintptr_t get_stack_base(std::size_t stack_size) {
     NT_TIB* pteb = (NT_TIB*)NtCurrentTeb();
     __TBB_ASSERT(&pteb < pteb->StackBase && &pteb > pteb->StackLimit, "invalid stack info in TEB");
     return reinterpret_cast<std::uintptr_t>(pteb->StackBase);
-#else /* USE_PTHREAD */
+#else
     // There is no portable way to get stack base address in Posix, so we use
     // non-portable method (on all modern Linux) or the simplified approach
     // based on the common sense assumptions. The most important assumption
@@ -164,7 +164,7 @@ static std::uintptr_t get_stack_base(std::size_t stack_size) {
         stack_base = reinterpret_cast<std::uintptr_t>(&anchor);
     }
     return stack_base;
-#endif /* USE_PTHREAD */
+#endif /* __TBB_USE_WINAPI */
 }
 
 #if (_WIN32||_WIN64) && !__TBB_DYNAMIC_LOAD_ENABLED

--- a/src/tbb/misc.h
+++ b/src/tbb/misc.h
@@ -53,11 +53,9 @@ class task_scheduler_observer;
 
 const std::size_t MByte = 1024*1024;
 
-#if __TBB_WIN8UI_SUPPORT && (_WIN32_WINNT < 0x0A00)
-// In Win8UI mode (Windows 8 Store* applications), TBB uses a thread creation API
-// that does not allow to specify the stack size.
-// Still, the thread stack size value, either explicit or default, is used by the scheduler.
-// So here we set the default value to match the platform's default of 1MB.
+#if __TBB_USE_WINAPI
+// The Microsoft Documentation about Thread Stack Size states that
+// "The default stack reservation size used by the linker is 1 MB"
 const std::size_t ThreadStackSize = 1*MByte;
 #else
 const std::size_t ThreadStackSize = (sizeof(uintptr_t) <= 4 ? 2 : 4 )*MByte;

--- a/src/tbb/scheduler_common.h
+++ b/src/tbb/scheduler_common.h
@@ -488,6 +488,7 @@ public:
 #endif
 
 inline std::uintptr_t calculate_stealing_threshold(std::uintptr_t base, std::size_t stack_size) {
+    __TBB_ASSERT(base > stack_size / 2, "Stack anchor calculation overflow");
     return base - stack_size / 2;
 }
 


### PR DESCRIPTION
The stack size is incorrectly supposed to be 4 MB on Windows. However, MSDN [states](https://docs.microsoft.com/en-us/windows/win32/procthread/thread-stack-size) that "_The default stack reservation size used by the linker is 1 MB_". It leads to two issues:

1. The stack overflow protection mechanism does not work on Windows properly, i.e. stealing can be allowed even if the stack is fully consumed.
2. The [stack anchor calculation](https://github.com/oneapi-src/oneTBB/blob/35147e0021727916c789287ba52a3499eb3ab348/src/tbb/scheduler_common.h#L490-L492) might overflow and block the stealing completely (that is reproduced in https://github.com/oneapi-src/oneTBB/issues/478#issuecomment-891669250) due to main thread stack mapping on low address).

The fix changes the assumption to 1 MB on Windows. If compiled with modern Windows, the system API is used to query stack size instead of the assumption. 