### PR TITLE
Performance: Avoid lock during working with multiple arenas

### DIFF
--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -186,6 +186,12 @@ public:
     Intrusive list node base class is used by market to form a list of arenas. **/
 // TODO: Analyze arena_base cache lines placement
 struct arena_base : padded<intrusive_list_node> {
+    //! The target serialization epoch for callers of adjust_job_count_estimate
+    int my_adjust_demand_target_epoch;
+
+    //! The current serialization epoch for callers of adjust_job_count_estimate
+    d1::waitable_atomic<int> my_adjust_demand_current_epoch;
+
     //! The number of workers that have been marked out by the resource manager to service the arena.
     std::atomic<unsigned> my_num_workers_allotted;   // heavy use in stealing loop
 

--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -186,12 +186,6 @@ public:
     Intrusive list node base class is used by market to form a list of arenas. **/
 // TODO: Analyze arena_base cache lines placement
 struct arena_base : padded<intrusive_list_node> {
-    //! The target serialization epoch for callers of adjust_job_count_estimate
-    int my_adjust_demand_target_epoch;
-
-    //! The current serialization epoch for callers of adjust_job_count_estimate
-    d1::waitable_atomic<int> my_adjust_demand_current_epoch;
-
     //! The number of workers that have been marked out by the resource manager to service the arena.
     std::atomic<unsigned> my_num_workers_allotted;   // heavy use in stealing loop
 
@@ -286,6 +280,12 @@ struct arena_base : padded<intrusive_list_node> {
     unsigned my_num_reserved_slots;
     //! The number of workers requested by the external thread owning the arena.
     unsigned my_max_num_workers;
+
+    //! The target serialization epoch for callers of adjust_job_count_estimate
+    int my_adjust_demand_target_epoch;
+
+    //! The current serialization epoch for callers of adjust_job_count_estimate
+    d1::waitable_atomic<int> my_adjust_demand_current_epoch;
 
 #if TBB_USE_ASSERT
     //! Used to trap accesses to the object after its destruction.

--- a/src/tbb/market.cpp
+++ b/src/tbb/market.cpp
@@ -578,14 +578,14 @@ void market::adjust_demand ( arena& a, int delta, bool mandatory ) {
         my_num_workers_requested += delta;
         __TBB_ASSERT(my_num_workers_requested <= (int)effective_soft_limit, NULL);
 
-        target_epoch = my_adjust_demand_target_epoch++;
+        target_epoch = a.my_adjust_demand_target_epoch++;
     }
 
-    my_adjust_demand_current_epoch.wait_until(target_epoch, /* context = */ target_epoch, std::memory_order_acquire);
+    a.my_adjust_demand_current_epoch.wait_until(target_epoch, /* context = */ target_epoch, std::memory_order_relaxed);
     // Must be called outside of any locks
     my_server->adjust_job_count_estimate( delta );
-    my_adjust_demand_current_epoch.exchange(target_epoch + 1);
-    my_adjust_demand_current_epoch.notify_relaxed(target_epoch + 1);
+    a.my_adjust_demand_current_epoch.exchange(target_epoch + 1);
+    a.my_adjust_demand_current_epoch.notify_relaxed(target_epoch + 1);
 }
 
 void market::process( job& j ) {

--- a/src/tbb/market.h
+++ b/src/tbb/market.h
@@ -105,12 +105,6 @@ private:
     //! Number of workers currently requested from RML
     int my_num_workers_requested;
 
-    //! The target serialization epoch for callers of adjust_job_count_estimate
-    int my_adjust_demand_target_epoch;
-
-    //! The current serialization epoch for callers of adjust_job_count_estimate
-    d1::waitable_atomic<int> my_adjust_demand_current_epoch;
-
     //! First unused index of worker
     /** Used to assign indices to the new workers coming from RML, and busy part
         of my_workers array. **/


### PR DESCRIPTION
Synchronization order of calls function `market::adjust_demand` should be made for arena, not for the market itself.