### PR TITLE
task_group extensions: documentation for task_group::run_and_wait(task_handle&&) method

### DIFF
--- a/doc/main/reference/task_group_extensions.rst
+++ b/doc/main/reference/task_group_extensions.rst
@@ -49,7 +49,7 @@ Synopsis
                
                task_group_status run_and_wait(task_handle&&);
 
-               //only the requirements for the type of return value F have changed              
+               //only the requirements for the return type of function F are changed              
                template<typename F>
                void run(F&& f);
            }; 
@@ -88,7 +88,7 @@ As an optimization hint, ``F`` might return a ``task_handle``, which task object
 
 Schedules the task object pointed by the ``h`` for execution.
 
-.. caution:: If ``h`` is not empty or ``*this`` is the same ``task_group`` that ``h`` is created with, the behavior is undefined.
+.. caution:: If ``h`` is empty or ``*this`` is not the same ``task_group`` that ``h`` is created with, the behavior is undefined.
 
 
 .. cpp:function:: task_group_status run_and_wait(task_handle&& h)
@@ -98,7 +98,7 @@ Equivalent to ``{run(std::move(h)); return wait();}``.
 **Returns**: The status of ``task_group``.
 
 .. caution::
-   If ``h`` is not empty or ``*this`` is the same ``task_group`` that ``h`` is created with, the behavior is undefined.
+   If ``h`` is empty or ``*this`` is not the same ``task_group`` that ``h`` is created with, the behavior is undefined.
 
  
 .. cpp:function:: template<typename F> void  run(F&& f)

--- a/doc/main/reference/task_group_extensions.rst
+++ b/doc/main/reference/task_group_extensions.rst
@@ -91,7 +91,7 @@ Schedules the task object pointed by the ``h`` for execution.
 
 .. cpp:function:: task_group_status run_and_wait(task_handle&& h)
 
-Equivalent to ``{run(h); return wait();}``, but guarantees that ``h`` runs on the current thread.
+Equivalent to ``{run(h); return wait();}``
 
 .. note::
    The failure to satisfy the following conditions leads to undefined behavior:

--- a/doc/main/reference/task_group_extensions.rst
+++ b/doc/main/reference/task_group_extensions.rst
@@ -15,9 +15,9 @@ Description
 
 |full_name| implementation extends the `tbb::task_group specification <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/task_scheduler/task_group/task_group_cls.html>`_ with the following members:
 
-  - Constructor that takes a custom ``tbb::task_group_context`` object as an argument.
-  - Methods to create and run deferred tasks with ``task_handle``. 
-  - Requirements for a user-provided function object.
+  - constructor that takes a custom ``tbb::task_group_context`` object as an argument
+  - methods to create and run deferred tasks with ``task_handle`` 
+  - requirements for a user-provided function object
    
 
 API
@@ -47,9 +47,9 @@ Synopsis
                    
                void run(task_handle&& h);
                
-               task_group_status run_and_wait(task_handle&& );
+               task_group_status run_and_wait(task_handle&&);
 
-               //only F return type requirements have changed              
+               //only the requirements for the type of return value F have changed              
                template<typename F>
                void run(F&& f);
            }; 
@@ -57,12 +57,15 @@ Synopsis
         } // namespace tbb
     } // namespace oneapi
 
+
+
 Member Functions
 ----------------
 
 .. cpp:function:: task_group(task_group_context& context)
 
 Constructs an empty ``task_group``, which tasks are associated with the ``context``.
+
 
 .. cpp:function:: template<typename F> task_handle  defer(F&& f)
 
@@ -80,26 +83,24 @@ As an optimization hint, ``F`` might return a ``task_handle``, which task object
 
 **Returns:** ``task_handle`` object pointing to task to compute ``f()``.
 
+
 .. cpp:function:: void run(task_handle&& h)
-   
+
 Schedules the task object pointed by the ``h`` for execution.
 
-.. note::
-   The failure to satisfy the following conditions leads to undefined behavior:
-      * ``h`` is not empty.
-      * ``*this`` is the same ``task_group`` that ``h`` is created with.    
+.. caution:: If ``h`` is not empty or ``*this`` is the same ``task_group`` that ``h`` is created with, the behavior is undefined.
+
 
 .. cpp:function:: task_group_status run_and_wait(task_handle&& h)
 
-The equivalent to ``{run(h); return wait();}``.
+Equivalent to ``{run(std::move(h)); return wait();}``.
+ 
+**Returns**: The status of ``task_group``.
 
-.. note::
-   The failure to satisfy the following conditions leads to undefined behavior:
-      * ``h`` is not empty.
-      * ``*this`` is the same ``task_group`` that ``h`` is created with.    
+.. caution::
+   If ``h`` is not empty or ``*this`` is the same ``task_group`` that ``h`` is created with, the behavior is undefined.
 
- **Returns**: The status of ``task_group``. 
-    
+ 
 .. cpp:function:: template<typename F> void  run(F&& f)
 
 As an optimization hint, ``F`` might return a ``task_handle``, which task object can be executed next.

--- a/doc/main/reference/task_group_extensions.rst
+++ b/doc/main/reference/task_group_extensions.rst
@@ -46,6 +46,8 @@ Synopsis
                task_handle defer(F&& f);
                    
                void run(task_handle&& h);
+               
+               task_group_status run_and_wait(task_handle&& );
 
                //only F return type requirements have changed              
                template<typename F>
@@ -87,6 +89,17 @@ Schedules the task object pointed by the ``h`` for execution.
       * ``h`` is not empty.
       * ``*this`` is the same ``task_group`` that ``h`` is created with.    
 
+.. cpp:function:: task_group_status run_and_wait(task_handle&& h)
+
+Equivalent to ``{run(h); return wait();}``, but guarantees that ``h`` runs on the current thread.
+
+.. note::
+   The failure to satisfy the following conditions leads to undefined behavior:
+      * ``h`` is not empty.
+      * ``*this`` is the same ``task_group`` that ``h`` is created with.    
+
+ **Returns**: The status of ``task_group``. 
+    
 .. cpp:function:: template<typename F> void  run(F&& f)
 
 As an optimization hint, ``F`` might return a ``task_handle``, which task object can be executed next.
@@ -99,4 +112,5 @@ As an optimization hint, ``F`` might return a ``task_handle``, which task object
 
 * `oneapi::tbb::task_group specification <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/task_scheduler/task_group/task_group_cls.html>`_
 * `oneapi::tbb::task_group_context specification <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/task_scheduler/scheduling_controls/task_group_context_cls.html>`_
+* `oneapi::tbb::task_group_status specification <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/task_scheduler/task_group/task_group_status_enum.html>`_ 
 * :doc:`oneapi::tbb::task_handle class <task_group_extensions/task_handle>`

--- a/doc/main/reference/task_group_extensions.rst
+++ b/doc/main/reference/task_group_extensions.rst
@@ -91,7 +91,7 @@ Schedules the task object pointed by the ``h`` for execution.
 
 .. cpp:function:: task_group_status run_and_wait(task_handle&& h)
 
-Equivalent to ``{run(h); return wait();}``
+The equivalent to ``{run(h); return wait();}``.
 
 .. note::
    The failure to satisfy the following conditions leads to undefined behavior:


### PR DESCRIPTION
### Description 
documentation for task_group::run_and_wait(task_handle&&) method


### Type of change

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [X] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
@alexey-katranov @alexandraepan 

### Other information
