### PR TITLE
Disable RTM based tests under TSAN

### DIFF
--- a/test/conformance/conformance_mutex.cpp
+++ b/test/conformance/conformance_mutex.cpp
@@ -40,8 +40,12 @@ TEST_CASE("Basic Locable requirement test") {
     GeneralTest<oneapi::tbb::spin_rw_mutex>("Spin RW Mutex");
     GeneralTest<oneapi::tbb::queuing_mutex>("Queuing Mutex");
     GeneralTest<oneapi::tbb::queuing_rw_mutex>("Queuing RW Mutex");
+    // TODO: Consider adding Thread Sanitizer (note that accesses inside the transaction
+    // considered as races by Thread Sanitizer)
+#if !__TBB_USE_THREAD_SANITIZER
     GeneralTest<oneapi::tbb::speculative_spin_mutex>("Speculative Spin Mutex");
     GeneralTest<oneapi::tbb::speculative_spin_rw_mutex>("Speculative Spin RW Mutex");
+#endif
     // NullMutexes
     GeneralTest<oneapi::tbb::null_mutex, utils::AtomicCounter<oneapi::tbb::null_mutex>>("Null Mutex", false);
     GeneralTest<oneapi::tbb::null_rw_mutex, utils::AtomicCounter<oneapi::tbb::null_rw_mutex>>("Null RW Mutex", false);
@@ -56,8 +60,10 @@ TEST_CASE("Lockable requirement test") {
     TestTryAcquire<oneapi::tbb::spin_rw_mutex>("Spin RW Mutex");
     TestTryAcquire<oneapi::tbb::queuing_mutex>("Queuing Mutex");
     TestTryAcquire<oneapi::tbb::queuing_rw_mutex>("Queuing RW Mutex");
+#if !__TBB_USE_THREAD_SANITIZER
     TestTryAcquire<oneapi::tbb::speculative_spin_mutex>("Speculative Spin Mutex");
     TestTryAcquire<oneapi::tbb::speculative_spin_rw_mutex>("Speculative Spin RW Mutex");
+#endif
     TestTryAcquire<oneapi::tbb::null_mutex>("Null Mutex");
 }
 
@@ -67,16 +73,18 @@ TEST_CASE("Shared mutexes (reader/writer) test") {
     // General reader writer capabilities + upgrade/downgrade
     TestReaderWriterLock<oneapi::tbb::spin_rw_mutex>("Spin RW Mutex");
     TestReaderWriterLock<oneapi::tbb::queuing_rw_mutex>("Queuing RW Mutex");
-    TestReaderWriterLock<oneapi::tbb::speculative_spin_rw_mutex>("Speculative Spin RW Mutex");
     TestNullRWMutex<oneapi::tbb::null_rw_mutex>("Null RW Mutex");
     // Single threaded read/write try_acquire operations
     TestTryAcquireReader<oneapi::tbb::spin_rw_mutex>("Spin RW Mutex");
     TestTryAcquireReader<oneapi::tbb::queuing_rw_mutex>("Queuing RW Mutex");
     TestRWStateMultipleChange<oneapi::tbb::spin_rw_mutex>("Spin RW Mutex");
     TestRWStateMultipleChange<oneapi::tbb::queuing_rw_mutex>("Queuing RW Mutex");
+    TestTryAcquireReader<oneapi::tbb::null_rw_mutex>("Null RW Mutex");
+#if !__TBB_USE_THREAD_SANITIZER
+    TestReaderWriterLock<oneapi::tbb::speculative_spin_rw_mutex>("Speculative Spin RW Mutex");
     TestTryAcquireReader<oneapi::tbb::speculative_spin_rw_mutex>("Speculative Spin RW Mutex");
     TestRWStateMultipleChange<oneapi::tbb::speculative_spin_rw_mutex>("Speculative Spin RW Mutex");
-    TestTryAcquireReader<oneapi::tbb::null_rw_mutex>("Null RW Mutex");
+#endif
 }
 
 //! Testing ISO C++ Mutex and Shared Mutex requirements.

--- a/test/tbb/test_mutex.cpp
+++ b/test/tbb/test_mutex.cpp
@@ -33,7 +33,9 @@
 //! \brief Test for [mutex.spin_mutex mutex.spin_rw_mutex mutex.queuing_mutex mutex.queuing_rw_mutexmutex.speculative_spin_mutex mutex.speculative_spin_rw_mutex] specifications
 
 // TODO: Investigate why RTM doesn't work on some macOS.
-#if __TBB_TSX_INTRINSICS_PRESENT && !__APPLE__
+// TODO: Consider adding Thread Sanitizer (note that accesses inside the transaction
+// considered as races by Thread Sanitizer)
+#if __TBB_TSX_INTRINSICS_PRESENT && !__APPLE__ && !__TBB_USE_THREAD_SANITIZER
 
 inline static bool IsInsideTx() {
     return _xtest() != 0;


### PR DESCRIPTION
### Description 

RTM technology resolves races on hardware level that is not detected by Thread Sanitizer. In other words, when concurrent access are not interleaved, the hardware allows them while it is reported as a race.

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users

### Other information
