### PR TITLE
Workaround gcc bug in test_limiter_node

### DIFF
--- a/test/tbb/test_limiter_node.cpp
+++ b/test/tbb/test_limiter_node.cpp
@@ -125,6 +125,18 @@ struct put_dec_body : utils::NoAssign {
 
 };
 
+template< typename Sender, typename Receiver >
+void make_edge_impl(Sender& sender, Receiver& receiver){
+#if __GNUC__ < 12 && !TBB_USE_DEBUG
+    // Seemingly, GNU compiler generates incorrect code for the call of limiter.register_successor in release (-03)
+    // The function pointer to make_edge workarounds the issue for unknown reason
+    auto make_edge_ptr = tbb::flow::make_edge<int>;
+    make_edge_ptr(sender, receiver); //putting the successor back
+#else
+    tbb::flow::make_edge(sender, receiver); //putting the successor back
+#endif
+}
+
 template< typename T >
 void test_puts_with_decrements( int num_threads, tbb::flow::limiter_node< T >& lim , tbb::flow::graph& g) {
     parallel_receiver<T> r(g);
@@ -355,14 +367,7 @@ void test_reserve_release_messages() {
     broad.try_put(1); //failed message retrieved.
     g.wait_for_all();
 
-#if __GNUC__ && __GNUC__ < 12 && !TBB_USE_DEBUG
-    // Seemingly, GNU compiler generates incorrect code for the call of limiter.register_successor in release (-03)
-    // The function pointer to make_edge workarounds the issue for unknown reason
-    auto make_edge_ptr = make_edge<int>;
-    make_edge_ptr(limit, output_queue); //putting the successor back
-#else
-    make_edge(limit, output_queue); //putting the successor back
-#endif
+    make_edge_impl(limit, output_queue);
 
     broad.try_put(1);  //drop the count
 
@@ -445,14 +450,9 @@ void test_try_put_without_successors() {
     int try_put_num{3};
     tbb::flow::buffer_node<int> bn(g);
     tbb::flow::limiter_node<int> ln(g, try_put_num);
-#if __GNUC__ && __GNUC__ < 12 && !TBB_USE_DEBUG
-    // Seemingly, GNU compiler generates incorrect code for the call of limiter.register_successor in release (-03)
-    // The function pointer to make_edge workarounds the issue for unknown reason
-    auto make_edge_ptr = tbb::flow::make_edge<int>;
-    make_edge_ptr(bn, ln); //putting the successor back
-#else
-    tbb::flow::make_edge(bn, ln); //putting the successor back
-#endif
+
+    tbb::flow::make_edge(bn, ln);
+
     int i = 1;
     for (; i <= try_put_num; i++)
         bn.try_put(i);
@@ -464,11 +464,9 @@ void test_try_put_without_successors() {
             return int{};
         }
     );
-#if __GNUC__ && __GNUC__ < 12 && !TBB_USE_DEBUG
-    make_edge_ptr(ln, fn); //putting the successor back
-#else
-    tbb::flow::make_edge(ln, fn); //putting the successor back
-#endif
+
+    make_edge_impl(ln, fn);
+
     g.wait_for_all();
     CHECK((counter == i * try_put_num / 2));
 


### PR DESCRIPTION
Signed-off-by: Mishin, Ilya <ilya.mishin@intel.com>

### Description 
GNU compiler generates incorrect code for the call of limiter.register_successor in release (-03)
The function pointer to make_edge workarounds the issue.

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [x] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
Linked issue https://github.com/oneapi-src/oneTBB/issues/342