### PR TITLE
Move enumerable_thread_specific Windows.h usage to cpp

### DIFF
--- a/include/oneapi/tbb/enumerable_thread_specific.h
+++ b/include/oneapi/tbb/enumerable_thread_specific.h
@@ -35,9 +35,7 @@
 
 #include "task.h" // for task::suspend_point
 
-#if _WIN32 || _WIN64
-#include <windows.h>
-#else
+#if !(_WIN32 || _WIN64)
 #include <pthread.h>
 #endif
 
@@ -281,19 +279,11 @@ template <>
 class ets_base<ets_key_per_instance>: public ets_base<ets_no_key> {
     using super = ets_base<ets_no_key>;
 #if _WIN32||_WIN64
-#if __TBB_WIN8UI_SUPPORT
-    using tls_key_t = DWORD;
-    void create_key() { my_key = FlsAlloc(NULL); }
-    void destroy_key() { FlsFree(my_key); }
-    void set_tls(void * value) { FlsSetValue(my_key, (LPVOID)value); }
-    void* get_tls() { return (void *)FlsGetValue(my_key); }
-#else
-    using tls_key_t = DWORD;
-    void create_key() { my_key = TlsAlloc(); }
-    void destroy_key() { TlsFree(my_key); }
-    void set_tls(void * value) { TlsSetValue(my_key, (LPVOID)value); }
-    void* get_tls() { return (void *)TlsGetValue(my_key); }
-#endif
+    using tls_key_t = unsigned long;  // DWORD
+    TBB_EXPORT void __TBB_EXPORTED_FUNC create_key();
+    TBB_EXPORT void __TBB_EXPORTED_FUNC destroy_key();
+    TBB_EXPORT void __TBB_EXPORTED_FUNC set_tls(void * value);
+    TBB_EXPORT void* __TBB_EXPORTED_FUNC get_tls();
 #else
     using tls_key_t = pthread_key_t;
     void create_key() { pthread_key_create(&my_key, NULL); }

--- a/src/tbb/CMakeLists.txt
+++ b/src/tbb/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(tbb
     arena_slot.cpp
     concurrent_bounded_queue.cpp
     dynamic_link.cpp
+    enumerable_thread_specific.cpp
     exception.cpp
     governor.cpp
     global_control.cpp

--- a/src/tbb/def/win32-tbb.def
+++ b/src/tbb/def/win32-tbb.def
@@ -132,6 +132,12 @@ EXPORTS
 ?parallel_pipeline@r1@detail@tbb@@YAXAAVtask_group_context@d1@23@IABVfilter_node@523@@Z
 ?set_end_of_input@r1@detail@tbb@@YAXAAVbase_filter@d1@23@@Z
 
+; Enumerable thread specific (enumerable_thread_specific.cpp)
+?create_key@?$ets_base@$0A@@d1@detail@tbb@@AAAXXZ
+?destroy_key@?$ets_base@$0A@@d1@detail@tbb@@AAAXXZ
+?set_tls@?$ets_base@$0A@@d1@detail@tbb@@AAAXPAX@Z
+?get_tls@?$ets_base@$0A@@d1@detail@tbb@@AAAPAXXZ
+
 ; Concurrent bounded queue (concurrent_bounded_queue.cpp)
 ?abort_bounded_queue_monitors@r1@detail@tbb@@YAXPAVconcurrent_monitor@123@@Z
 ?allocate_bounded_queue_rep@r1@detail@tbb@@YAPAEI@Z

--- a/src/tbb/def/win64-tbb.def
+++ b/src/tbb/def/win64-tbb.def
@@ -132,6 +132,12 @@ EXPORTS
 ?set_end_of_input@r1@detail@tbb@@YAXAEAVbase_filter@d1@23@@Z
 ?parallel_pipeline@r1@detail@tbb@@YAXAEAVtask_group_context@d1@23@_KAEBVfilter_node@523@@Z
 
+; Enumerable thread specific (enumerable_thread_specific.cpp)
+?create_key@?$ets_base@$0A@@d1@detail@tbb@@AEAAXXZ
+?destroy_key@?$ets_base@$0A@@d1@detail@tbb@@AEAAXXZ
+?set_tls@?$ets_base@$0A@@d1@detail@tbb@@AEAAXPEAX@Z
+?get_tls@?$ets_base@$0A@@d1@detail@tbb@@AEAAPEAXXZ
+
 ; Concurrent bounded queue (concurrent_bounded_queue.cpp)
 ?allocate_bounded_queue_rep@r1@detail@tbb@@YAPEAE_K@Z
 ?deallocate_bounded_queue_rep@r1@detail@tbb@@YAXPEAE_K@Z

--- a/src/tbb/enumerable_thread_specific.cpp
+++ b/src/tbb/enumerable_thread_specific.cpp
@@ -1,0 +1,52 @@
+#include "oneapi/tbb/enumerable_thread_specific.h"
+
+#if _WIN32 || _WIN64
+#include <windows.h>
+#else
+#include <pthread.h>
+#endif
+
+namespace tbb {
+namespace detail {
+namespace d1 {
+
+#if _WIN32||_WIN64
+#if __TBB_WIN8UI_SUPPORT
+void __TBB_EXPORTED_FUNC ets_base<ets_key_per_instance>::create_key() {
+    my_key = ::FlsAlloc();
+}
+
+void __TBB_EXPORTED_FUNC ets_base<ets_key_per_instance>::destroy_key() {
+    my_key = ::FlsFree(my_key);
+}
+
+void __TBB_EXPORTED_FUNC ets_base<ets_key_per_instance>::set_tls(void * value) {
+    ::FlsSetValue(my_key, (LPVOID)value); 
+}
+
+void* __TBB_EXPORTED_FUNC ets_base<ets_key_per_instance>::get_tls() {
+    return (void *)FlsGetValue(my_key); 
+}
+
+#else 
+void __TBB_EXPORTED_FUNC ets_base<ets_key_per_instance>::create_key() {
+    my_key = ::TlsAlloc();
+}
+
+void __TBB_EXPORTED_FUNC ets_base<ets_key_per_instance>::destroy_key() {
+    my_key = ::TlsFree(my_key);
+}
+
+void __TBB_EXPORTED_FUNC ets_base<ets_key_per_instance>::set_tls(void * value) {
+    ::TlsSetValue(my_key, (LPVOID)value); 
+}
+
+void* __TBB_EXPORTED_FUNC ets_base<ets_key_per_instance>::get_tls() {
+    return (void *)TlsGetValue(my_key); 
+}
+#endif
+#endif
+
+} // namespace d1
+} // namespace detail
+} // namespace tbb


### PR DESCRIPTION
### Description 
This change gets rid of the Windows.h include in the public `enumerable_thread_specific .h` by moving it a cpp.


Fixes #573

### Type of change

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown