### PR TITLE
CMake: fix compile options for Windows ARM64

### DIFF
--- a/cmake/compilers/MSVC.cmake
+++ b/cmake/compilers/MSVC.cmake
@@ -33,7 +33,7 @@ if (MSVC_VERSION LESS_EQUAL 1900)
     set(TBB_TEST_COMPILE_FLAGS ${TBB_TEST_COMPILE_FLAGS} /wd4503)
 endif()
 set(TBB_LIB_COMPILE_FLAGS -D_CRT_SECURE_NO_WARNINGS /GS)
-set(TBB_COMMON_COMPILE_FLAGS /volatile:iso /FS)
+set(TBB_COMMON_COMPILE_FLAGS /volatile:iso /FS $<$<AND:$<VERSION_LESS:${CMAKE_VERSION},3.17>,$<STREQUAL:${MSVC_CXX_ARCHITECTURE_ID},ARM64>>:/EHsc>)
 
 # Ignore /WX set through add_compile_options() or added to CMAKE_CXX_FLAGS if TBB_STRICT is disabled.
 if (NOT TBB_STRICT AND COMMAND tbb_remove_compile_flag)

--- a/cmake/compilers/MSVC.cmake
+++ b/cmake/compilers/MSVC.cmake
@@ -33,7 +33,7 @@ if (MSVC_VERSION LESS_EQUAL 1900)
     set(TBB_TEST_COMPILE_FLAGS ${TBB_TEST_COMPILE_FLAGS} /wd4503)
 endif()
 set(TBB_LIB_COMPILE_FLAGS -D_CRT_SECURE_NO_WARNINGS /GS)
-set(TBB_COMMON_COMPILE_FLAGS /volatile:iso /FS $<$<AND:$<VERSION_LESS:${CMAKE_VERSION},3.17>,$<STREQUAL:${MSVC_CXX_ARCHITECTURE_ID},ARM64>>:/EHsc>)
+set(TBB_COMMON_COMPILE_FLAGS /volatile:iso /FS /EHsc)
 
 # Ignore /WX set through add_compile_options() or added to CMAKE_CXX_FLAGS if TBB_STRICT is disabled.
 if (NOT TBB_STRICT AND COMMAND tbb_remove_compile_flag)


### PR DESCRIPTION
Signed-off-by: Zheltov, Sergey1 <sergey1.zheltov@intel.com>

### Description 
When building for ARM64 with CMake < 3.17 : `vector(1309,1): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc`
This patch enables adding /EHsc option for MSVC in all cases.

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
