### PR TITLE
Fix comment in test_limiter_node

### DIFF
--- a/test/tbb/test_limiter_node.cpp
+++ b/test/tbb/test_limiter_node.cpp
@@ -131,9 +131,9 @@ void make_edge_impl(Sender& sender, Receiver& receiver){
     // Seemingly, GNU compiler generates incorrect code for the call of limiter.register_successor in release (-03)
     // The function pointer to make_edge workarounds the issue for unknown reason
     auto make_edge_ptr = tbb::flow::make_edge<int>;
-    make_edge_ptr(sender, receiver); //putting the successor back
+    make_edge_ptr(sender, receiver);
 #else
-    tbb::flow::make_edge(sender, receiver); //putting the successor back
+    tbb::flow::make_edge(sender, receiver);
 #endif
 }
 
@@ -367,7 +367,7 @@ void test_reserve_release_messages() {
     broad.try_put(1); //failed message retrieved.
     g.wait_for_all();
 
-    make_edge_impl(limit, output_queue);
+    make_edge_impl(limit, output_queue); //putting the successor back
 
     broad.try_put(1);  //drop the count
 


### PR DESCRIPTION
Signed-off-by: Mishin, Ilya <ilya.mishin@intel.com>

### Description 
Fix comment erroneously copied in https://github.com/oneapi-src/oneTBB/pull/569 
Noticed in https://github.com/oneapi-src/oneTBB/issues/489

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
