### PR TITLE
Use yield function from tbb in tbbmalloc

### DIFF
--- a/src/tbbmalloc/Customize.h
+++ b/src/tbbmalloc/Customize.h
@@ -61,6 +61,10 @@ static inline bool isPowerOfTwoAtLeast(uintptr_t arg, uintptr_t power2) {
     return arg && tbb::detail::is_power_of_two_at_least(arg,power2);
 }
 
+inline void do_yield() {
+    tbb::detail::yield();
+}
+
 #define USE_DEFAULT_MEMORY_MAPPING 1
 
 // To support malloc replacement

--- a/src/tbbmalloc/frontend.cpp
+++ b/src/tbbmalloc/frontend.cpp
@@ -28,7 +28,6 @@
     #define TlsGetValue_func pthread_getspecific
     #define GetMyTID() pthread_self()
     #include <sched.h>
-    inline void do_yield() {sched_yield();}
     extern "C" { static void mallocThreadShutdownNotification(void*); }
     #if __sun || __SUNPRO_CC
     #define __asm__ asm
@@ -43,12 +42,10 @@
     #define TlsAlloc() FlsAlloc(NULL)
     #define TLS_ALLOC_FAILURE FLS_OUT_OF_INDEXES
     #define TlsFree FlsFree
-    inline void do_yield() {std::this_thread::yield();}
 #else
     #define TlsSetValue_func TlsSetValue
     #define TlsGetValue_func TlsGetValue
     #define TLS_ALLOC_FAILURE TLS_OUT_OF_INDEXES
-    inline void do_yield() {SwitchToThread();}
 #endif
 #else
     #error Must define USE_PTHREAD or USE_WINTHREAD


### PR DESCRIPTION
Signed-off-by: Ilya Isaev <ilya.isaev@intel.com>

### Description 
`yield()` is introduced both in tbb and tbbmalloc. This patch removes that duplicate.

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@alexey-katranov 

### Other information
