### PR TITLE
Fixed possible buffer overrun in dynamic_link

### DIFF
--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -281,13 +281,13 @@ namespace r1 {
         }
 
         if ( fname_len>0 ) {
+            ap_data._len += fname_len;
             if ( ap_data._len>PATH_MAX ) {
                 DYNAMIC_LINK_WARNING( dl_buff_too_small );
                 ap_data._len=0;
                 return;
             }
             std::strncpy( ap_data._path+rc, dlinfo.dli_fname, fname_len );
-            ap_data._len += fname_len;
             ap_data._path[ap_data._len]=0;
         }
     #endif /* _WIN32 */


### PR DESCRIPTION
Signed-off-by: Anton Potapov <anton.potapov@intel.com>

### Description 
When `dladdr` returns a relative path to the tbb DL , possible buffer overrun was possible on concatenating current working directory of the process with tbb DL relative path 


### Type of change

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
