### PR TITLE
Fix spelling (contex -> context)

### DIFF
--- a/src/tbb/address_waiter.cpp
+++ b/src/tbb/address_waiter.cpp
@@ -28,12 +28,12 @@ namespace r1 {
 struct address_context {
     address_context() = default;
 
-    address_context(void* address, std::uintptr_t contex) :
-        my_address(address), my_contex(contex)
+    address_context(void* address, std::uintptr_t context) :
+        my_address(address), my_context(context)
     {}
 
     void* my_address{nullptr};
-    std::uintptr_t my_contex{0};
+    std::uintptr_t my_context{0};
 };
 
 class address_waiter : public concurrent_monitor_base<address_context> {
@@ -75,7 +75,7 @@ void notify_by_address(void* address, std::uintptr_t target_context) {
     address_waiter& waiter = get_address_waiter(address);
 
     auto predicate = [address, target_context] (address_context ctx) {
-        return ctx.my_address == address && ctx.my_contex == target_context;
+        return ctx.my_address == address && ctx.my_context == target_context;
     };
 
     waiter.notify_relaxed(predicate);

--- a/test/tbb/test_async_node.cpp
+++ b/test/tbb/test_async_node.cpp
@@ -605,7 +605,7 @@ int run_tests() {
 
 #include "tbb/parallel_for.h"
 template<typename Input, typename Output>
-class equeueing_on_inner_level {
+class enqueueing_on_inner_level {
     typedef Input input_type;
     typedef Output output_type;
     typedef async_activity<input_type, output_type> async_activity_type;
@@ -661,8 +661,8 @@ public:
     }
 };
 
-int run_test_equeueing_on_inner_level() {
-    equeueing_on_inner_level<int, int>::run();
+int run_test_enqueueing_on_inner_level() {
+    enqueueing_on_inner_level<int, int>::run();
     return 0;
 }
 
@@ -824,10 +824,10 @@ TEST_CASE("Spin avoidance test"){
     test_for_spin_avoidance();
 }
 
-//! Test nested enqueing
+//! Test nested enqueuing
 //! \brief \ref error_guessing
-TEST_CASE("Inner enqueing test"){
-    run_test_equeueing_on_inner_level();
+TEST_CASE("Inner enqueuing test"){
+    run_test_enqueueing_on_inner_level();
 }
 
 #if __TBB_PREVIEW_FLOW_GRAPH_NODE_SET


### PR DESCRIPTION
This PR fixes spelling mistakes (`context` -> `context`, `enqueing` -> `enqueuing`)