### PR TITLE
Check presence of Hugepagesize field

### DIFF
--- a/src/tbbmalloc/shared_utils.h
+++ b/src/tbbmalloc/shared_utils.h
@@ -90,7 +90,7 @@ T min ( const T& val1, const T& val2 ) {
 // TODO: add a constructor to remove warnings suppression
 struct parseFileItem {
     const char* format;
-    unsigned long long& value;
+    long long& value;
 };
 
 #if defined(_MSC_VER) && (_MSC_VER<1900) && !defined(__INTEL_COMPILER)

--- a/src/tbbmalloc/tbbmalloc_internal.h
+++ b/src/tbbmalloc/tbbmalloc_internal.h
@@ -447,7 +447,7 @@ private:
     void parseSystemMemInfo() {
         bool hpAvailable  = false;
         bool thpAvailable = false;
-        unsigned long long hugePageSize = 0;
+        unsigned long long hugePageSize = ULLONG_MAX;
 
 #if __unix__
         // Check huge pages existence
@@ -471,7 +471,7 @@ private:
         // We parse a counter number, it can't be huge
         parseFile</*BUFF_SIZE=*/100>("/proc/sys/vm/nr_hugepages", vmItem);
 
-        if (meminfoHugePagesTotal > 0 || vmHugePagesTotal > 0) {
+        if (hugePageSize < ULLONG_MAX && meminfoHugePagesTotal > 0 || vmHugePagesTotal > 0) {
             MALLOC_ASSERT(hugePageSize != 0, "Huge Page size can't be zero if we found preallocated.");
 
             // Any non zero value clearly states that there are preallocated
@@ -484,7 +484,7 @@ private:
         parseFileItem thpItem[] = { { "[alwa%cs] madvise never\n", thpPresent } };
         parseFile</*BUFF_SIZE=*/100>("/sys/kernel/mm/transparent_hugepage/enabled", thpItem);
 
-        if (thpPresent == 'y') {
+        if (hugePageSize < ULLONG_MAX && thpPresent == 'y') {
             MALLOC_ASSERT(hugePageSize != 0, "Huge Page size can't be zero if we found thp existence.");
             thpAvailable = true;
         }

--- a/src/tbbmalloc/tbbmalloc_internal.h
+++ b/src/tbbmalloc/tbbmalloc_internal.h
@@ -447,26 +447,26 @@ private:
     void parseSystemMemInfo() {
         bool hpAvailable  = false;
         bool thpAvailable = false;
-        unsigned long long hugePageSize = ULLONG_MAX;
+        long long hugePageSize = -1;
 
 #if __unix__
         // Check huge pages existence
-        unsigned long long meminfoHugePagesTotal = 0;
+        long long meminfoHugePagesTotal = 0;
 
         parseFileItem meminfoItems[] = {
             // Parse system huge page size
-            { "Hugepagesize: %llu kB", hugePageSize },
+            { "Hugepagesize: %lld kB", hugePageSize },
             // Check if there are preallocated huge pages on the system
             // https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt
-            { "HugePages_Total: %llu", meminfoHugePagesTotal } };
+            { "HugePages_Total: %lld", meminfoHugePagesTotal } };
 
         parseFile</*BUFF_SIZE=*/100>("/proc/meminfo", meminfoItems);
 
         // Double check another system information regarding preallocated
         // huge pages if there are no information in /proc/meminfo
-        unsigned long long vmHugePagesTotal = 0;
+        long long vmHugePagesTotal = 0;
 
-        parseFileItem vmItem[] = { { "%llu", vmHugePagesTotal } };
+        parseFileItem vmItem[] = { { "%lld", vmHugePagesTotal } };
 
         // We parse a counter number, it can't be huge
         parseFile</*BUFF_SIZE=*/100>("/proc/sys/vm/nr_hugepages", vmItem);
@@ -480,11 +480,11 @@ private:
         }
 
         // Check if there is transparent huge pages support on the system
-        unsigned long long thpPresent = 'n';
+        long long thpPresent = 'n';
         parseFileItem thpItem[] = { { "[alwa%cs] madvise never\n", thpPresent } };
         parseFile</*BUFF_SIZE=*/100>("/sys/kernel/mm/transparent_hugepage/enabled", thpItem);
 
-        if (hugePageSize < ULLONG_MAX && thpPresent == 'y') {
+        if (hugePageSize > -1 && thpPresent == 'y') {
             MALLOC_ASSERT(hugePageSize != 0, "Huge Page size can't be zero if we found thp existence.");
             thpAvailable = true;
         }

--- a/src/tbbmalloc/tbbmalloc_internal.h
+++ b/src/tbbmalloc/tbbmalloc_internal.h
@@ -471,7 +471,7 @@ private:
         // We parse a counter number, it can't be huge
         parseFile</*BUFF_SIZE=*/100>("/proc/sys/vm/nr_hugepages", vmItem);
 
-        if (hugePageSize < ULLONG_MAX && meminfoHugePagesTotal > 0 || vmHugePagesTotal > 0) {
+        if (hugePageSize > -1 && (meminfoHugePagesTotal > 0 || vmHugePagesTotal > 0)) {
             MALLOC_ASSERT(hugePageSize != 0, "Huge Page size can't be zero if we found preallocated.");
 
             // Any non zero value clearly states that there are preallocated

--- a/test/common/memory_usage.h
+++ b/test/common/memory_usage.h
@@ -141,32 +141,32 @@ namespace utils {
 #if __unix__
 
     inline bool isTHPEnabledOnMachine() {
-        unsigned long long thpPresent = 'n';
-        unsigned long long hugePageSize = ULLONG_MAX;
+        long long thpPresent = 'n';
+        long long hugePageSize = -1;
 
         parseFileItem thpItem[] = { { "[alwa%cs] madvise never\n", thpPresent } };
-        parseFileItem hpSizeItem[] = { { "Hugepagesize: %llu kB", hugePageSize } };
+        parseFileItem hpSizeItem[] = { { "Hugepagesize: %lld kB", hugePageSize } };
 
         parseFile</*BUFF_SIZE=*/100>("/sys/kernel/mm/transparent_hugepage/enabled", thpItem);
         parseFile</*BUFF_SIZE=*/100>("/proc/meminfo", hpSizeItem);
 
-        if (hugePageSize < ULLONG_MAX && thpPresent == 'y') {
+        if (hugePageSize > -1 && thpPresent == 'y') {
             return true;
         } else {
             return false;
         }
     }
-    inline unsigned long long getSystemTHPAllocatedSize() {
-        unsigned long long anonHugePagesSize = 0;
+    inline long long getSystemTHPAllocatedSize() {
+        long long anonHugePagesSize = 0;
         parseFileItem meminfoItems[] = {
-            { "AnonHugePages: %llu kB", anonHugePagesSize } };
+            { "AnonHugePages: %lld kB", anonHugePagesSize } };
         parseFile</*BUFF_SIZE=*/100>("/proc/meminfo", meminfoItems);
         return anonHugePagesSize;
     }
-    inline unsigned long long getSystemTHPCount() {
-        unsigned long long anonHugePages = 0;
+    inline long long getSystemTHPCount() {
+        long long anonHugePages = 0;
         parseFileItem vmstatItems[] = {
-            { "nr_anon_transparent_hugepages %llu", anonHugePages } };
+            { "nr_anon_transparent_hugepages %lld", anonHugePages } };
         parseFile</*BUFF_SIZE=*/100>("/proc/vmstat", vmstatItems);
         return anonHugePages;
     }

--- a/test/common/memory_usage.h
+++ b/test/common/memory_usage.h
@@ -142,10 +142,15 @@ namespace utils {
 
     inline bool isTHPEnabledOnMachine() {
         unsigned long long thpPresent = 'n';
-        parseFileItem thpItem[] = { { "[alwa%cs] madvise never\n", thpPresent } };
-        parseFile</*BUFF_SIZE=*/100>("/sys/kernel/mm/transparent_hugepage/enabled", thpItem);
+        unsigned long long hugePageSize = ULLONG_MAX;
 
-        if (thpPresent == 'y') {
+        parseFileItem thpItem[] = { { "[alwa%cs] madvise never\n", thpPresent } };
+        parseFileItem hpSizeItem[] = { { "Hugepagesize: %llu kB", hugePageSize } };
+
+        parseFile</*BUFF_SIZE=*/100>("/sys/kernel/mm/transparent_hugepage/enabled", thpItem);
+        parseFile</*BUFF_SIZE=*/100>("/proc/meminfo", hpSizeItem);
+
+        if (hugePageSize < ULLONG_MAX && thpPresent == 'y') {
             return true;
         } else {
             return false;


### PR DESCRIPTION
Signed-off-by: Ilya Isaev <ilya.isaev@intel.com>

### Description 
Don't enable HP and THP support if there is no `Hugepagesize` field in /proc/meminfo

Fixes # - #584 

### Type of change

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@alexey-katranov @John-Yi

### Other information
