### PR TITLE
Improve tbb/info.h code coverage

### DIFF
--- a/include/oneapi/tbb/info.h
+++ b/include/oneapi/tbb/info.h
@@ -22,6 +22,7 @@
 
 #if __TBB_ARENA_BINDING
 #include <vector>
+#include <cstdint>
 
 namespace tbb {
 namespace detail {

--- a/test/tbb/test_arena_constraints.cpp
+++ b/test/tbb/test_arena_constraints.cpp
@@ -212,3 +212,10 @@ TEST_CASE("Test concurrency getters output for constraints with custom concurren
     c.set_max_threads_per_core(1);
     check_concurrency_level(c);
 }
+
+//! Testing constraints_threads_per_core() reserved entry point
+//! \brief \ref interface \ref error_guessing
+TEST_CASE("Testing constraints_threads_per_core() reserved entry point") {
+    tbb::task_arena::constraints c{};
+    REQUIRE(tbb::detail::r1::constraints_threads_per_core(c) == tbb::task_arena::automatic);
+}

--- a/test/tbb/test_arena_constraints.cpp
+++ b/test/tbb/test_arena_constraints.cpp
@@ -214,7 +214,7 @@ TEST_CASE("Test concurrency getters output for constraints with custom concurren
 }
 
 //! Testing constraints_threads_per_core() reserved entry point
-//! \brief \ref interface \ref error_guessing
+//! \brief \ref error_guessing
 TEST_CASE("Testing constraints_threads_per_core() reserved entry point") {
     tbb::task_arena::constraints c{};
     REQUIRE(tbb::detail::r1::constraints_threads_per_core(c) == tbb::task_arena::automatic);


### PR DESCRIPTION
### Description 

Now the `tbb/info.h` header has undocumented reserved `threads_per_core()` interface. This patch covers this function by testing + adds the missing include.

### Type of change

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [X] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [X] added - _required for new features and for some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown
