### PR TITLE
Revamp left over removal

### DIFF
--- a/test/tbb/test_task_group.cpp
+++ b/test/tbb/test_task_group.cpp
@@ -403,12 +403,8 @@ public:
     const char* what() const throw() override { return m_strDescription; }
 };
 
-#if TBB_USE_CAPTURED_EXCEPTION
-    #include "tbb/tbb_exception.h"
-    typedef tbb::captured_exception TestException;
-#else
-    typedef test_exception TestException;
-#endif
+
+using TestException = test_exception ;
 
 #include <string.h>
 


### PR DESCRIPTION


### Description 
Removed dead code left after `TBB_CAPTURED_EXCEPTION` removal during revamp


### Type of change

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@pavelkumbrasev 

### Other information
