### PR TITLE
Fix build error if defined _WIN32_WINNT

### DIFF
--- a/test/common/utils_report.h
+++ b/test/common/utils_report.h
@@ -53,6 +53,10 @@
         // Suppress "typedef ignored ... when no variable is declared" warning by vc14
         #pragma warning (push)
         #pragma warning (disable: 4091)
+        #ifndef NOMINMAX
+            #define NOMINMAX
+        #endif
+        #include <windows.h>
         #include <dbghelp.h>
         #pragma warning (pop)
         #pragma comment (lib, "dbghelp.lib")


### PR DESCRIPTION
### Description 
Fix build error if defined _WIN32_WINNT


Fixes #565, #627, #628

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@anton-potapov

### Other information
