### PR TITLE
Rvalue and constant ranges support for the tbb::parallel_sort algorithm

### DIFF
--- a/include/oneapi/tbb/parallel_sort.h
+++ b/include/oneapi/tbb/parallel_sort.h
@@ -250,8 +250,8 @@ void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end ) {
 template<typename Range, typename Compare>
     __TBB_requires(container_based_sequence<Range, std::random_access_iterator_tag> &&
                    compare<Compare, range_iterator_type<Range>>)
-void parallel_sort( Range& rng, const Compare& comp ) {
-    parallel_sort(std::begin(rng), std::end(rng), comp);
+void parallel_sort( Range&& rng, const Compare& comp ) {
+    parallel_sort(std::begin(std::forward<Range>(rng)), std::end(std::forward<Range>(rng)), comp);
 }
 
 //! Sorts the data in rng with a default comparator \c std::less<RandomAccessIterator>
@@ -259,8 +259,8 @@ void parallel_sort( Range& rng, const Compare& comp ) {
 template<typename Range>
     __TBB_requires(container_based_sequence<Range, std::random_access_iterator_tag> &&
                    less_than_comparable<typename std::iterator_traits<range_iterator_type<Range>>::value_type>)
-void parallel_sort( Range& rng ) {
-    parallel_sort(std::begin(rng), std::end(rng));
+void parallel_sort( Range&& rng ) {
+    parallel_sort(std::begin(std::forward<Range>(rng)), std::end(std::forward<Range>(rng)));
 }
 //@}
 


### PR DESCRIPTION
### Description 
At that moment, the `tbb::parallel_sort` algorithm allows passing only non-constant lvalue reference to a range. But some ranges (like std::span) may provide access to data independent from the container state.


Fixes #500

### Type of change

- [X] new feature - _change which adds functionality_

### Tests

- [X] added - _required for new features and for some bug fixes_

### Documentation

- [ ] updated in # - _add PR number_
- [X] needs to be updated

### Breaks backward compatibility
- [X] No

### Notify the following users
@kboyarinov 
