### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/test/common/utils_concurrency_limit.h
+++ b/test/common/utils_concurrency_limit.h
@@ -37,12 +37,11 @@
 #endif
 #include <string.h>
 #include <sched.h>
-#elif __FreeBSD__
-#include <unistd.h>
+#if __FreeBSD__
 #include <errno.h>
-#include <string.h>
 #include <sys/param.h>
 #include <sys/cpuset.h>
+#endif
 #endif
 #include <thread>
 


### PR DESCRIPTION
__unix__ is defined on FreeBSD and makes #elif __FreeBSD__ section skipped

### Description 
_Add comprehensive description of proposed changes_


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
