### PR TITLE
Fix build with MinGW

### DIFF
--- a/cmake/compilers/GNU.cmake
+++ b/cmake/compilers/GNU.cmake
@@ -59,13 +59,13 @@ if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "mips")
     set(TBB_TEST_COMPILE_FLAGS ${TBB_TEST_COMPILE_FLAGS} -DTBB_TEST_LOW_WORKLOAD $<$<CONFIG:DEBUG>:-mxgot>)
 endif()
 
-if (MINGW)
-    list(APPEND TBB_COMMON_COMPILE_FLAGS -U__STRICT_ANSI__)
-endif()
-
 set(TBB_IPO_COMPILE_FLAGS $<$<NOT:$<CONFIG:Debug>>:-flto>)
 set(TBB_IPO_LINK_FLAGS $<$<NOT:$<CONFIG:Debug>>:-flto>)
 
+
+if (MINGW AND CMAKE_SYSTEM_PROCESSOR MATCHES "i.86")
+    list (APPEND TBB_COMMON_COMPILE_FLAGS -msse2)
+endif ()
 
 # TBB malloc settings
 set(TBBMALLOC_LIB_COMPILE_FLAGS -fno-rtti -fno-exceptions)

--- a/include/oneapi/tbb/detail/_machine.h
+++ b/include/oneapi/tbb/detail/_machine.h
@@ -29,7 +29,9 @@
 #include <intrin.h>
 #ifdef __TBBMALLOC_BUILD
 #define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h> // SwitchToThread()
 #endif
 #ifdef _MSC_VER

--- a/src/tbb/allocator.cpp
+++ b/src/tbb/allocator.cpp
@@ -27,11 +27,11 @@
 
 #include <cstdlib>
 
-#if _WIN32 || _WIN64
-#include <Windows.h>
+#ifdef _WIN32
+#include <windows.h>
 #else
 #include <dlfcn.h>
-#endif /* _WIN32||_WIN64 */
+#endif
 
 #if __TBB_WEAK_SYMBOLS_PRESENT
 

--- a/src/tbb/dynamic_link.h
+++ b/src/tbb/dynamic_link.h
@@ -29,8 +29,8 @@
     and CLOSE_INTERNAL_NAMESPACE to override the following default definitions. **/
 
 #include <cstddef>
-#if _WIN32
-#include <Windows.h>
+#ifdef _WIN32
+#include <windows.h>
 #endif /* _WIN32 */
 
 namespace tbb {

--- a/src/tbbbind/tbb_bind.cpp
+++ b/src/tbbbind/tbb_bind.cpp
@@ -405,7 +405,7 @@ class binding_handler {
     affinity_masks_container affinity_backup;
     system_topology::affinity_mask handler_affinity_mask;
 
-#if WIN32
+#ifdef _WIN32
     affinity_masks_container affinity_buffer;
     int my_numa_node_id;
     int my_core_type_id;
@@ -415,7 +415,7 @@ class binding_handler {
 public:
     binding_handler( std::size_t size, int numa_node_id, int core_type_id, int max_threads_per_core )
         : affinity_backup(size)
-#if WIN32
+#ifdef _WIN32
         , affinity_buffer(size)
         , my_numa_node_id(numa_node_id)
         , my_core_type_id(core_type_id)
@@ -424,7 +424,7 @@ public:
     {
         for (std::size_t i = 0; i < size; ++i) {
             affinity_backup[i] = system_topology::instance().allocate_process_affinity_mask();
-#if WIN32
+#ifdef _WIN32
             affinity_buffer[i] = system_topology::instance().allocate_process_affinity_mask();
 #endif
         }
@@ -436,7 +436,7 @@ public:
     ~binding_handler() {
         for (std::size_t i = 0; i < affinity_backup.size(); ++i) {
             system_topology::instance().free_affinity_mask(affinity_backup[i]);
-#if WIN32
+#ifdef _WIN32
             system_topology::instance().free_affinity_mask(affinity_buffer[i]);
 #endif
         }
@@ -452,7 +452,7 @@ public:
 
         topology.store_current_affinity_mask(affinity_backup[slot_num]);
 
-#if WIN32
+#ifdef _WIN32
         // TBBBind supports only systems where NUMA nodes and core types do not cross the border
         // between several processor groups. So if a certain NUMA node or core type constraint
         // specified, then the constraints affinity mask will not cross the processor groups' border.

--- a/test/common/utils_dynamic_libs.h
+++ b/test/common/utils_dynamic_libs.h
@@ -22,8 +22,8 @@
 
 #if __TBB_DYNAMIC_LOAD_ENABLED
 
-#if _WIN32 || _WIN64
-#include <Windows.h>
+#ifdef _WIN32
+#include <windows.h>
 #else
 #include <dlfcn.h>
 #endif


### PR DESCRIPTION
Just a few fixes to be able to build on mingw (successfully tested on i686 and x86_64 / gcc 11.2 / mingw 9.0.0):
- on i686 sse2 should be explicitely enabled to use the sse intrinsics (_mm_getcsr) and al (fine on x86_64)
- windows.h should be lowercase if you compile from linux
- @longnguyen2004 I had to drop your `__STRICT_ANSI__` undefine, dont you get a warning with that ?
If its due to the gcc version I'm using gcc 11, maybe you're using some old version ?
- dont redefine NOMINAX (mingw headers redefine it)


