### PR TITLE
vars.bat: fix issue with no TBB in PATH

### DIFF
--- a/integration/windows/env/vars.bat
+++ b/integration/windows/env/vars.bat
@@ -49,12 +49,12 @@ if /i "%1"=="all"          (set TBB_TARGET_VS=vc_mt)      & shift & goto ParseAr
 :SetEnv
 if exist "%TBBROOT%\redist\%TBB_TARGET_ARCH%\%TBB_TARGET_VS%\tbb12.dll" (
     set "TBB_DLL_PATH=%TBBROOT%\redist\%TBB_TARGET_ARCH%\%TBB_TARGET_VS%"
-    set "PATH=%TBB_DLL_PATH%;%PATH%"
 )
 if exist "%TBBROOT%\..\redist\%TBB_TARGET_ARCH%\tbb\%TBB_TARGET_VS%\tbb12.dll" (
     set "TBB_DLL_PATH=%TBBROOT%\..\redist\%TBB_TARGET_ARCH%\tbb\%TBB_TARGET_VS%"
-    set "PATH=%TBB_DLL_PATH%;%PATH%"
 )
+
+set "PATH=%TBB_DLL_PATH%;%PATH%"
 
 set "LIB=%TBBROOT%\lib\%TBB_TARGET_ARCH%\%TBB_TARGET_VS%;%LIB%"
 set "INCLUDE=%TBBROOT%\include;%INCLUDE%"


### PR DESCRIPTION
Signed-off-by: Ilya Isaev <ilya.isaev@intel.com>

### Description 
`PATH` environment variable is not set under `if` block because of delayed expansion.

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@AlexVeprev 

### Other information
