### PR TITLE
CMake: add python_build target to ALL

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -34,6 +34,7 @@ string(STRIP "${TBB4PY_INCLUDE_STRING}" TBB4PY_INCLUDE_STRING)
 
 add_custom_target(
     python_build
+    ALL
     DEPENDS tbb python_copy
     COMMAND
     ${PYTHON_EXECUTABLE} ${PYTHON_BUILD_WORK_DIR}/setup.py


### PR DESCRIPTION
Signed-off-by: Veprev, Alexey alexey.veprev@intel.com

### Description 
_Add comprehensive description of proposed changes_
This patch includes `python_build` target into `all` target.
Expected effect: if `TBB4PY_BUILD` is set to `ON` during the configuration then `python_build` will be invoked in case of default build or `all` or `install` targets.

Fixes #616  - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
