### PR TITLE
Check the swappable requirement for the parallel_sort algorithm

### DIFF
--- a/include/oneapi/tbb/detail/_range_common.h
+++ b/include/oneapi/tbb/detail/_range_common.h
@@ -21,8 +21,8 @@
 #include "_utils.h"
 #if __TBB_CPP20_CONCEPTS_PRESENT
 #include <concepts>
-#include <iterator>
 #endif
+#include <iterator>
 
 namespace tbb {
 namespace detail {

--- a/include/oneapi/tbb/detail/_range_common.h
+++ b/include/oneapi/tbb/detail/_range_common.h
@@ -73,10 +73,10 @@ auto get_range_split_object( PartitionerSplitType& split_obj )
     return range_split_object_provider<Range>::get(split_obj);
 }
 
-#if __TBB_CPP20_CONCEPTS_PRESENT
 template <typename Range>
 using range_iterator_type = decltype(std::begin(std::declval<Range&>()));
 
+#if __TBB_CPP20_CONCEPTS_PRESENT
 template <typename Iterator>
 using iterator_reference_type = typename std::iterator_traits<Iterator>::reference;
 

--- a/include/oneapi/tbb/parallel_sort.h
+++ b/include/oneapi/tbb/parallel_sort.h
@@ -233,8 +233,7 @@ using range_value_type = typename std::iterator_traits<range_iterator_type<Range
 template<typename RandomAccessIterator, typename Compare>
     __TBB_requires(std::random_access_iterator<RandomAccessIterator> &&
                    compare<Compare, RandomAccessIterator> &&
-                   std::swappable<iter_value_type<RandomAccessIterator>> &&
-                   std::movable<iter_value_type<RandomAccessIterator>>)
+                   std::swappable<iter_value_type<RandomAccessIterator>>)
 void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end, const Compare& comp ) {
     constexpr int min_parallel_size = 500;
     if( end > begin ) {
@@ -251,8 +250,7 @@ void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end, const 
 template<typename RandomAccessIterator>
     __TBB_requires(std::random_access_iterator<RandomAccessIterator> &&
                    less_than_comparable<iter_value_type<RandomAccessIterator>> &&
-                   std::swappable<iter_value_type<RandomAccessIterator>> &&
-                   std::movable<iter_value_type<RandomAccessIterator>>)
+                   std::swappable<iter_value_type<RandomAccessIterator>>)
 void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end ) {
     parallel_sort(begin, end, std::less<typename std::iterator_traits<RandomAccessIterator>::value_type>());
 }
@@ -262,8 +260,7 @@ void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end ) {
 template<typename Range, typename Compare>
     __TBB_requires(container_based_sequence<Range, std::random_access_iterator_tag> &&
                    compare<Compare, range_iterator_type<Range>> &&
-                   std::swappable<range_value_type<Range>> &&
-                   std::movable<range_value_type<Range>>)
+                   std::swappable<range_value_type<Range>>)
 void parallel_sort( Range&& rng, const Compare& comp ) {
     parallel_sort(std::begin(rng), std::end(rng), comp);
 }
@@ -273,8 +270,7 @@ void parallel_sort( Range&& rng, const Compare& comp ) {
 template<typename Range>
     __TBB_requires(container_based_sequence<Range, std::random_access_iterator_tag> &&
                    less_than_comparable<range_value_type<Range>> &&
-                   std::swappable<range_value_type<Range>> &&
-                   std::movable<range_value_type<Range>>)
+                   std::swappable<range_value_type<Range>>)
 void parallel_sort( Range&& rng ) {
     parallel_sort(std::begin(rng), std::end(rng));
 }

--- a/include/oneapi/tbb/parallel_sort.h
+++ b/include/oneapi/tbb/parallel_sort.h
@@ -218,6 +218,9 @@ void parallel_quick_sort( RandomAccessIterator begin, RandomAccessIterator end, 
     See also requirements on \ref parallel_sort_iter_req "iterators for parallel_sort". **/
 //@{
 
+template<typename It>
+using iter_value_type = typename std::iterator_traits<It>::value_type;
+
 //! Sorts the data in [begin,end) using the given comparator
 /** The compare function object is used for all comparisons between elements during sorting.
     The compare object must define a bool operator() function.
@@ -225,7 +228,9 @@ void parallel_quick_sort( RandomAccessIterator begin, RandomAccessIterator end, 
 template<typename RandomAccessIterator, typename Compare>
     __TBB_requires(std::random_access_iterator<RandomAccessIterator> &&
                    compare<Compare, RandomAccessIterator> &&
-                   std::swappable<typename std::iterator_traits<RandomAccessIterator>::value_type>)
+                   std::swappable<iter_value_type<RandomAccessIterator>> &&
+                   std::move_constructible<iter_value_type<RandomAccessIterator>> &&
+                   std::assignable_from<iter_value_type<RandomAccessIterator>&, iter_value_type<RandomAccessIterator>>)
 void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end, const Compare& comp ) {
     constexpr int min_parallel_size = 500;
     if( end > begin ) {
@@ -241,18 +246,25 @@ void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end, const 
 /** @ingroup algorithms **/
 template<typename RandomAccessIterator>
     __TBB_requires(std::random_access_iterator<RandomAccessIterator> &&
-                   less_than_comparable<typename std::iterator_traits<RandomAccessIterator>::value_type> &&
-                   std::swappable<typename std::iterator_traits<RandomAccessIterator>::value_type>)
+                   less_than_comparable<iter_value_type<RandomAccessIterator>> &&
+                   std::swappable<iter_value_type<RandomAccessIterator>> &&
+                   std::move_constructible<iter_value_type<RandomAccessIterator>> &&
+                   std::assignable_from<iter_value_type<RandomAccessIterator>&, iter_value_type<RandomAccessIterator>>)
 void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end ) {
     parallel_sort(begin, end, std::less<typename std::iterator_traits<RandomAccessIterator>::value_type>());
 }
+
+template<typename Range>
+using range_value_type = typename std::iterator_traits<range_iterator_type<Range>>::value_type;
 
 //! Sorts the data in rng using the given comparator
 /** @ingroup algorithms **/
 template<typename Range, typename Compare>
     __TBB_requires(container_based_sequence<Range, std::random_access_iterator_tag> &&
                    compare<Compare, range_iterator_type<Range>> &&
-                   std::swappable<typename std::iterator_traits<range_iterator_type<Range>>>)
+                   std::swappable<range_value_type<Range>> &&
+                   std::move_constructible<range_value_type<Range>> &&
+                   std::assignable_from<range_value_type<Range>&, range_value_type<Range>&&>)
 void parallel_sort( Range&& rng, const Compare& comp ) {
     parallel_sort(std::begin(rng), std::end(rng), comp);
 }
@@ -261,8 +273,10 @@ void parallel_sort( Range&& rng, const Compare& comp ) {
 /** @ingroup algorithms **/
 template<typename Range>
     __TBB_requires(container_based_sequence<Range, std::random_access_iterator_tag> &&
-                   less_than_comparable<typename std::iterator_traits<range_iterator_type<Range>>::value_type> &&
-                   std::swappable<typename std::iterator_traits<range_iterator_type<Range>>>)
+                   less_than_comparable<range_value_type<Range>> &&
+                   std::swappable<range_value_type<Range>> &&
+                   std::move_constructible<range_value_type<Range>> &&
+                   std::assignable_from<range_value_type<Range>&, range_value_type<Range>&&>)
 void parallel_sort( Range&& rng ) {
     parallel_sort(std::begin(rng), std::end(rng));
 }

--- a/include/oneapi/tbb/parallel_sort.h
+++ b/include/oneapi/tbb/parallel_sort.h
@@ -224,7 +224,8 @@ void parallel_quick_sort( RandomAccessIterator begin, RandomAccessIterator end, 
     @ingroup algorithms **/
 template<typename RandomAccessIterator, typename Compare>
     __TBB_requires(std::random_access_iterator<RandomAccessIterator> &&
-                   compare<Compare, RandomAccessIterator>)
+                   compare<Compare, RandomAccessIterator> &&
+                   std::swappable<typename std::iterator_traits<RandomAccessIterator>::value_type>)
 void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end, const Compare& comp ) {
     constexpr int min_parallel_size = 500;
     if( end > begin ) {
@@ -240,7 +241,8 @@ void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end, const 
 /** @ingroup algorithms **/
 template<typename RandomAccessIterator>
     __TBB_requires(std::random_access_iterator<RandomAccessIterator> &&
-                   less_than_comparable<typename std::iterator_traits<RandomAccessIterator>::value_type>)
+                   less_than_comparable<typename std::iterator_traits<RandomAccessIterator>::value_type> &&
+                   std::swappable<typename std::iterator_traits<RandomAccessIterator>::value_type>)
 void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end ) {
     parallel_sort(begin, end, std::less<typename std::iterator_traits<RandomAccessIterator>::value_type>());
 }
@@ -249,7 +251,8 @@ void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end ) {
 /** @ingroup algorithms **/
 template<typename Range, typename Compare>
     __TBB_requires(container_based_sequence<Range, std::random_access_iterator_tag> &&
-                   compare<Compare, range_iterator_type<Range>>)
+                   compare<Compare, range_iterator_type<Range>> &&
+                   std::swappable<typename std::iterator_traits<range_iterator_type<Range>>>)
 void parallel_sort( Range&& rng, const Compare& comp ) {
     parallel_sort(std::begin(rng), std::end(rng), comp);
 }
@@ -258,7 +261,8 @@ void parallel_sort( Range&& rng, const Compare& comp ) {
 /** @ingroup algorithms **/
 template<typename Range>
     __TBB_requires(container_based_sequence<Range, std::random_access_iterator_tag> &&
-                   less_than_comparable<typename std::iterator_traits<range_iterator_type<Range>>::value_type>)
+                   less_than_comparable<typename std::iterator_traits<range_iterator_type<Range>>::value_type> &&
+                   std::swappable<typename std::iterator_traits<range_iterator_type<Range>>>)
 void parallel_sort( Range&& rng ) {
     parallel_sort(std::begin(rng), std::end(rng));
 }

--- a/include/oneapi/tbb/parallel_sort.h
+++ b/include/oneapi/tbb/parallel_sort.h
@@ -233,7 +233,7 @@ using range_value_type = typename std::iterator_traits<range_iterator_type<Range
 template<typename RandomAccessIterator, typename Compare>
     __TBB_requires(std::random_access_iterator<RandomAccessIterator> &&
                    compare<Compare, RandomAccessIterator> &&
-                   std::swappable<iter_value_type<RandomAccessIterator>>)
+                   std::movable<iter_value_type<RandomAccessIterator>>)
 void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end, const Compare& comp ) {
     constexpr int min_parallel_size = 500;
     if( end > begin ) {
@@ -250,7 +250,7 @@ void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end, const 
 template<typename RandomAccessIterator>
     __TBB_requires(std::random_access_iterator<RandomAccessIterator> &&
                    less_than_comparable<iter_value_type<RandomAccessIterator>> &&
-                   std::swappable<iter_value_type<RandomAccessIterator>>)
+                   std::movable<iter_value_type<RandomAccessIterator>>)
 void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end ) {
     parallel_sort(begin, end, std::less<typename std::iterator_traits<RandomAccessIterator>::value_type>());
 }
@@ -260,7 +260,7 @@ void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end ) {
 template<typename Range, typename Compare>
     __TBB_requires(container_based_sequence<Range, std::random_access_iterator_tag> &&
                    compare<Compare, range_iterator_type<Range>> &&
-                   std::swappable<range_value_type<Range>>)
+                   std::movable<range_value_type<Range>>)
 void parallel_sort( Range&& rng, const Compare& comp ) {
     parallel_sort(std::begin(rng), std::end(rng), comp);
 }
@@ -270,7 +270,7 @@ void parallel_sort( Range&& rng, const Compare& comp ) {
 template<typename Range>
     __TBB_requires(container_based_sequence<Range, std::random_access_iterator_tag> &&
                    less_than_comparable<range_value_type<Range>> &&
-                   std::swappable<range_value_type<Range>>)
+                   std::movable<range_value_type<Range>>)
 void parallel_sort( Range&& rng ) {
     parallel_sort(std::begin(rng), std::end(rng));
 }

--- a/include/oneapi/tbb/parallel_sort.h
+++ b/include/oneapi/tbb/parallel_sort.h
@@ -218,8 +218,13 @@ void parallel_quick_sort( RandomAccessIterator begin, RandomAccessIterator end, 
     See also requirements on \ref parallel_sort_iter_req "iterators for parallel_sort". **/
 //@{
 
+#if __TBB_CPP20_CONCEPTS_PRESENT
 template<typename It>
 using iter_value_type = typename std::iterator_traits<It>::value_type;
+
+template<typename Range>
+using range_value_type = typename std::iterator_traits<range_iterator_type<Range>>::value_type;
+#endif
 
 //! Sorts the data in [begin,end) using the given comparator
 /** The compare function object is used for all comparisons between elements during sorting.
@@ -229,8 +234,7 @@ template<typename RandomAccessIterator, typename Compare>
     __TBB_requires(std::random_access_iterator<RandomAccessIterator> &&
                    compare<Compare, RandomAccessIterator> &&
                    std::swappable<iter_value_type<RandomAccessIterator>> &&
-                   std::move_constructible<iter_value_type<RandomAccessIterator>> &&
-                   std::assignable_from<iter_value_type<RandomAccessIterator>&, iter_value_type<RandomAccessIterator>>)
+                   std::movable<iter_value_type<RandomAccessIterator>>)
 void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end, const Compare& comp ) {
     constexpr int min_parallel_size = 500;
     if( end > begin ) {
@@ -248,14 +252,10 @@ template<typename RandomAccessIterator>
     __TBB_requires(std::random_access_iterator<RandomAccessIterator> &&
                    less_than_comparable<iter_value_type<RandomAccessIterator>> &&
                    std::swappable<iter_value_type<RandomAccessIterator>> &&
-                   std::move_constructible<iter_value_type<RandomAccessIterator>> &&
-                   std::assignable_from<iter_value_type<RandomAccessIterator>&, iter_value_type<RandomAccessIterator>>)
+                   std::movable<iter_value_type<RandomAccessIterator>>)
 void parallel_sort( RandomAccessIterator begin, RandomAccessIterator end ) {
     parallel_sort(begin, end, std::less<typename std::iterator_traits<RandomAccessIterator>::value_type>());
 }
-
-template<typename Range>
-using range_value_type = typename std::iterator_traits<range_iterator_type<Range>>::value_type;
 
 //! Sorts the data in rng using the given comparator
 /** @ingroup algorithms **/
@@ -263,8 +263,7 @@ template<typename Range, typename Compare>
     __TBB_requires(container_based_sequence<Range, std::random_access_iterator_tag> &&
                    compare<Compare, range_iterator_type<Range>> &&
                    std::swappable<range_value_type<Range>> &&
-                   std::move_constructible<range_value_type<Range>> &&
-                   std::assignable_from<range_value_type<Range>&, range_value_type<Range>&&>)
+                   std::movable<range_value_type<Range>>)
 void parallel_sort( Range&& rng, const Compare& comp ) {
     parallel_sort(std::begin(rng), std::end(rng), comp);
 }
@@ -275,8 +274,7 @@ template<typename Range>
     __TBB_requires(container_based_sequence<Range, std::random_access_iterator_tag> &&
                    less_than_comparable<range_value_type<Range>> &&
                    std::swappable<range_value_type<Range>> &&
-                   std::move_constructible<range_value_type<Range>> &&
-                   std::assignable_from<range_value_type<Range>&, range_value_type<Range>&&>)
+                   std::movable<range_value_type<Range>>)
 void parallel_sort( Range&& rng ) {
     parallel_sort(std::begin(rng), std::end(rng));
 }

--- a/test/common/concepts_common.h
+++ b/test/common/concepts_common.h
@@ -237,17 +237,17 @@ template <typename T, typename F = T> using WithFeederWrongSecondInputOperatorRo
 } // namespace parallel_for_each_body
 namespace container_based_sequence {
 
-using iterator = int*;
-
-template <bool EnableBegin, bool EnableEnd>
+template <bool EnableBegin, bool EnableEnd, typename T = int>
 struct ContainerBasedSequence {
-    int* begin() requires EnableBegin { return nullptr; }
-    int* end() requires EnableEnd { return nullptr; }
+    using iterator = T*;
+    T* begin() requires EnableBegin { return nullptr; }
+    T* end() requires EnableEnd { return nullptr; }
 };
 
 using Correct = ContainerBasedSequence</*Begin = */true, /*End = */true>;
 using NoBegin = ContainerBasedSequence</*Begin = */false, /*End = */true>;
 using NoEnd = ContainerBasedSequence</*Begin = */true, /*End = */false>;
+using ConstantCBS = ContainerBasedSequence</*Begin = */true, /*End = */false, /*T = */const int>;
 
 struct ForwardIteratorCBS {
     utils::ForwardIterator<int> begin() { return utils::ForwardIterator<int>{}; }

--- a/test/common/concepts_common.h
+++ b/test/common/concepts_common.h
@@ -276,8 +276,8 @@ using CustomValueCBS = ContainerBasedSequence</*Begin = */true, /*End = */true, 
 template <typename T>
 struct ConstantAccessCBS {
     using iterator = utils::RandomIterator<const T>;
-    iterator begin() requires EnableBegin { return nullptr; }
-    iterator end() requires EnableEnd { return nullptr; }
+    iterator begin() { return nullptr; }
+    iterator end() { return nullptr; }
 };
 
 struct ForwardIteratorCBS {

--- a/test/common/concepts_common.h
+++ b/test/common/concepts_common.h
@@ -239,17 +239,13 @@ namespace parallel_sort_value {
 template<bool MovableV, bool MoveAssignableV, bool ComparableV>
 struct ParallelSortValue
 {
-    ParallelSortValue(ParallelSortValue&&) requires MovableV {}
-    ParallelSortValue& operator=(ParallelSortValue&&) requires MoveAssignableV {return *this;}
+    ParallelSortValue(ParallelSortValue&&) requires MovableV = default;
+    ParallelSortValue& operator=(ParallelSortValue&&) requires MoveAssignableV = default;
 
     friend bool operator<(const ParallelSortValue&, const ParallelSortValue&) requires ComparableV { return true; }
 };
 
-template<bool MovableV, bool MoveAssignableV, bool ComparableV>
-void swap(ParallelSortValue<MovableV, MoveAssignableV, ComparableV>&,
-          ParallelSortValue<MovableV, MoveAssignableV, ComparableV>&)
-{}
-
+using CorrectValue = ParallelSortValue</*MovableV = */true, /*MoveAssignableV = */true, /*ComparableV = */true>;
 using NonMovableValue = ParallelSortValue</*MovableV = */false, /*MoveAssignableV = */true, /*ComparableV = */true>;
 using NonMoveAssignableValue = ParallelSortValue</*MovableV = */true, /*MoveAssignableV = */false, /*ComparableV = */true>;
 using NonComparableValue = ParallelSortValue</*MovableV = */true, /*MoveAssignableV = */true, /*ComparableV = */false>;

--- a/test/common/concepts_common.h
+++ b/test/common/concepts_common.h
@@ -236,25 +236,23 @@ template <typename T, typename F = T> using WithFeederWrongFirstInputOperatorRou
 template <typename T, typename F = T> using WithFeederWrongSecondInputOperatorRoundBrackets = ParallelForEachFeederBody<T, F, /*() = */State::incorrect_second_input>;
 } // namespace parallel_for_each_body
 namespace parallel_sort_value {
-    template<bool MovableV, bool MoveAssignableV, bool ComparableV>
-    struct ParallelSortValue
-    {
-        ParallelSortValue(ParallelSortValue&&) requires MovableV {}
-        ParallelSortValue& operator=(ParallelSortValue&&) requires MoveAssignableV {return *this;}
+template<bool MovableV, bool MoveAssignableV, bool ComparableV>
+struct ParallelSortValue
+{
+    ParallelSortValue(ParallelSortValue&&) requires MovableV {}
+    ParallelSortValue& operator=(ParallelSortValue&&) requires MoveAssignableV {return *this;}
 
-        friend bool operator<(const ParallelSortValue&, const ParallelSortValue&) requires ComparableV { return true; }
-    };
+    friend bool operator<(const ParallelSortValue&, const ParallelSortValue&) requires ComparableV { return true; }
+};
 
-    template<bool MovableV, bool MoveAssignableV, bool ComparableV>
-    void swap(ParallelSortValue<MovableV, MoveAssignableV, ComparableV>&,
-              ParallelSortValue<MovableV, MoveAssignableV, ComparableV>&)
-    {}
+template<bool MovableV, bool MoveAssignableV, bool ComparableV>
+void swap(ParallelSortValue<MovableV, MoveAssignableV, ComparableV>&,
+          ParallelSortValue<MovableV, MoveAssignableV, ComparableV>&)
+{}
 
-
-    using NonSwappableValue = ParallelSortValue</*MovableV = */true, /*MoveAssignableV = */true, /*ComparableV = */true>;
-    using NonMovableValue = ParallelSortValue</*MovableV = */false, /*MoveAssignableV = */true, /*ComparableV = */true>;
-    using NonMoveAssignableValue = ParallelSortValue</*MovableV = */true, /*MoveAssignableV = */false, /*ComparableV = */true>;
-    using NonComparableValue = ParallelSortValue</*MovableV = */true, /*MoveAssignableV = */true, /*ComparableV = */false>;
+using NonMovableValue = ParallelSortValue</*MovableV = */false, /*MoveAssignableV = */true, /*ComparableV = */true>;
+using NonMoveAssignableValue = ParallelSortValue</*MovableV = */true, /*MoveAssignableV = */false, /*ComparableV = */true>;
+using NonComparableValue = ParallelSortValue</*MovableV = */true, /*MoveAssignableV = */true, /*ComparableV = */false>;
 } // namespace parallel_sort_value
 template <typename T>
 class ConstantIT {

--- a/test/common/concepts_common.h
+++ b/test/common/concepts_common.h
@@ -256,6 +256,11 @@ namespace parallel_sort_value {
     using NonMoveAssignableValue = ParallelSortValue</*MovableV = */true, /*MoveAssignableV = */false, /*ComparableV = */true>;
     using NonComparableValue = ParallelSortValue</*MovableV = */true, /*MoveAssignableV = */true, /*ComparableV = */false>;
 } // namespace parallel_sort_value
+template <typename T>
+class ConstantIT {
+    T data{};
+    const T& operator* () const { return data; }
+};
 namespace container_based_sequence {
 
 template <bool EnableBegin, bool EnableEnd, typename T = int>
@@ -272,12 +277,9 @@ using NoEnd = ContainerBasedSequence</*Begin = */true, /*End = */false>;
 template <typename T>
 using CustomValueCBS = ContainerBasedSequence</*Begin = */true, /*End = */true, T>;
 
-
-template <typename T>
-struct ConstantAccessCBS {
-    using iterator = utils::RandomIterator<const T>;
-    iterator begin() { return nullptr; }
-    iterator end() { return nullptr; }
+struct ConstantCBS {
+    ConstantIT<int> begin() const { return ConstantIT<int>{}; }
+    ConstantIT<int> end() const { return ConstantIT<int>{}; }
 };
 
 struct ForwardIteratorCBS {

--- a/test/conformance/conformance_parallel_sort.cpp
+++ b/test/conformance/conformance_parallel_sort.cpp
@@ -93,27 +93,27 @@ TEST_CASE ("Range sorting test (greater comparator)") {
 struct CustomSwappable {
     int data{0};
 
-    CustomSwappable (int in_data) : data{in_data} {}
+    CustomSwappable (CustomSwappable&&) = delete;
+    CustomSwappable& operator=(CustomSwappable&&) = delete;
+
+    CustomSwappable (const CustomSwappable&) = delete;
+    CustomSwappable& operator=(const CustomSwappable&) = delete;
 };
 
 bool operator<(const CustomSwappable& lhs, const CustomSwappable& rhs) {
     return lhs.data < rhs.data;
 }
 
-std::atomic<bool> custom_swap_call_flag{false};
-
 void swap(CustomSwappable& lhs, CustomSwappable& rhs) {
-    custom_swap_call_flag = true;
     std::swap(lhs.data, rhs.data);
 }
 
 //! Testing range with custom swap overload
 //! \brief \ref requirement \ref interface
 TEST_CASE ("Testing range with custom swap overload") {
-    std::vector<CustomSwappable> test_sequence = {5, 4, 3, 2, 1};
+    CustomSwappable test_sequence[5] = {5, 4, 3, 2, 1};
     oneapi::tbb::parallel_sort(test_sequence);
-    REQUIRE_MESSAGE(custom_swap_call_flag, "Custom swap was not used to sort the sequence");
 
-    for(auto it = test_sequence.begin(); it != test_sequence.end() - 1; ++it)
-        REQUIRE_MESSAGE(*(it+1) < *(it), "Testing data not sorted");
+    for(auto it = std::begin(test_sequence); it != std::end(test_sequence) - 1; ++it)
+        REQUIRE_MESSAGE(*(it) < *(it+1), "Testing data not sorted");
 }

--- a/test/conformance/conformance_parallel_sort.cpp
+++ b/test/conformance/conformance_parallel_sort.cpp
@@ -89,31 +89,3 @@ TEST_CASE ("Range sorting test (greater comparator)") {
             REQUIRE_MESSAGE(*it >= *(it+1), "Testing data not sorted");
     }
 }
-
-struct CustomSwappable {
-    int data{0};
-
-    CustomSwappable (CustomSwappable&&) = delete;
-    CustomSwappable& operator=(CustomSwappable&&) = delete;
-
-    CustomSwappable (const CustomSwappable&) = delete;
-    CustomSwappable& operator=(const CustomSwappable&) = delete;
-};
-
-bool operator<(const CustomSwappable& lhs, const CustomSwappable& rhs) {
-    return lhs.data < rhs.data;
-}
-
-void swap(CustomSwappable& lhs, CustomSwappable& rhs) {
-    std::swap(lhs.data, rhs.data);
-}
-
-//! Testing range with custom swap overload
-//! \brief \ref requirement \ref interface
-TEST_CASE ("Testing range with custom swap overload") {
-    CustomSwappable test_sequence[5] = {5, 4, 3, 2, 1};
-    oneapi::tbb::parallel_sort(test_sequence);
-
-    for(auto it = std::begin(test_sequence); it != std::end(test_sequence) - 1; ++it)
-        REQUIRE_MESSAGE(*(it) < *(it+1), "Testing data not sorted");
-}

--- a/test/tbb/test_parallel_for_each.cpp
+++ b/test/tbb/test_parallel_for_each.cpp
@@ -127,10 +127,12 @@ concept can_call_parallel_for_each_with_cbs = requires( ContainerBasedSequence c
     tbb::parallel_for_each(const_cbs, body, ctx);
 };
 
+using CorrectCBS = test_concepts::container_based_sequence::Correct;
+
 template <typename Body>
 concept can_call_parallel_for_each =
-    can_call_parallel_for_each_with_iterator<test_concepts::container_based_sequence::iterator, Body> &&
-    can_call_parallel_for_each_with_cbs<test_concepts::container_based_sequence::Correct, Body>;
+    can_call_parallel_for_each_with_iterator<CorrectCBS::iterator, Body> &&
+    can_call_parallel_for_each_with_cbs<CorrectCBS, Body>;
 
 template <typename Iterator>
 using CorrectBody = test_concepts::parallel_for_each_body::Correct<decltype(*std::declval<Iterator>())>;
@@ -144,10 +146,9 @@ void test_pfor_each_iterator_constraints() {
 
 void test_pfor_each_container_based_sequence_constraints() {
     using namespace test_concepts::container_based_sequence;
-    using iterator = test_concepts::container_based_sequence::iterator;
-    static_assert(can_call_parallel_for_each_with_cbs<Correct, CorrectBody<iterator>>);
-    static_assert(!can_call_parallel_for_each_with_cbs<NoBegin, CorrectBody<iterator>>);
-    static_assert(!can_call_parallel_for_each_with_cbs<NoEnd, CorrectBody<iterator>>);
+    static_assert(can_call_parallel_for_each_with_cbs<Correct, CorrectBody<Correct::iterator>>);
+    static_assert(!can_call_parallel_for_each_with_cbs<NoBegin, CorrectBody<NoBegin::iterator>>);
+    static_assert(!can_call_parallel_for_each_with_cbs<NoEnd, CorrectBody<NoEnd::iterator>>);
 }
 
 void test_pfor_each_body_constraints() {

--- a/test/tbb/test_parallel_sort.cpp
+++ b/test/tbb/test_parallel_sort.cpp
@@ -235,17 +235,20 @@ void test_psort_iterator_constraints() {
     static_assert(can_call_parallel_sort_with_iterator<typename std::vector<int>::iterator>);
     static_assert(!can_call_parallel_sort_with_iterator<utils::ForwardIterator<int>>);
     static_assert(!can_call_parallel_sort_with_iterator<utils::InputIterator<int>>);
+    static_assert(!can_call_parallel_sort_with_iterator<utils::RandomIterator<const int>>);
 
     static_assert(can_call_parallel_sort_with_iterator_and_compare<utils::RandomIterator<int>, CorrectCompare<int>>);
     static_assert(can_call_parallel_sort_with_iterator_and_compare<typename std::vector<int>::iterator, CorrectCompare<int>>);
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::ForwardIterator<int>, CorrectCompare<int>>);
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::InputIterator<int>, CorrectCompare<int>>);
+    static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::RandomIterator<const int>, CorrectCompare<int>>);
 }
 
 void test_psort_compare_constraints() {
     using namespace test_concepts::compare;
-    using CorrectIterator = test_concepts::container_based_sequence::iterator;
     using CorrectCBS = test_concepts::container_based_sequence::Correct;
+    using CorrectIterator = CorrectCBS::iterator;
+
     static_assert(can_call_parallel_sort_with_iterator_and_compare<CorrectIterator, Correct<int>>);
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<CorrectIterator, NoOperatorRoundBrackets<int>>);
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<CorrectIterator, WrongFirstInputOperatorRoundBrackets<int>>);
@@ -266,11 +269,13 @@ void test_psort_cbs_constraints() {
     static_assert(!can_call_parallel_sort_with_cbs<NoBegin>);
     static_assert(!can_call_parallel_sort_with_cbs<NoEnd>);
     static_assert(!can_call_parallel_sort_with_cbs<ForwardIteratorCBS>);
+    static_assert(!can_call_parallel_sort_with_cbs<ConstantCBS>);
 
     static_assert(can_call_parallel_sort_with_cbs_and_compare<Correct, CorrectCompare>);
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<NoBegin, CorrectCompare>);
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<NoEnd, CorrectCompare>);
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<ForwardIteratorCBS, CorrectCompare>);
+    static_assert(!can_call_parallel_sort_with_cbs_and_compare<ConstantCBS, CorrectCompare>);
 }
 
 #endif // __TBB_CPP20_CONCEPTS_PRESENT

--- a/test/tbb/test_parallel_sort.cpp
+++ b/test/tbb/test_parallel_sort.cpp
@@ -231,7 +231,6 @@ template <typename T>
 using CorrectCompare = test_concepts::compare::Correct<T>;
 
 void test_psort_iterator_constraints() {
-    using namespace test_concepts;
     using namespace test_concepts::parallel_sort_value;
 
     static_assert(can_call_parallel_sort_with_iterator<utils::RandomIterator<int>>);
@@ -241,7 +240,7 @@ void test_psort_iterator_constraints() {
     static_assert(!can_call_parallel_sort_with_iterator<utils::RandomIterator<NonMovableValue>>);
     static_assert(!can_call_parallel_sort_with_iterator<utils::RandomIterator<NonMoveAssignableValue>>);
     static_assert(!can_call_parallel_sort_with_iterator<utils::RandomIterator<NonComparableValue>>);
-    static_assert(!can_call_parallel_sort_with_iterator<ConstantIT<int>>);
+    static_assert(!can_call_parallel_sort_with_iterator<test_concepts::ConstantIT<int>>);
 
     static_assert(can_call_parallel_sort_with_iterator_and_compare<utils::RandomIterator<int>, CorrectCompare<int>>);
     static_assert(can_call_parallel_sort_with_iterator_and_compare<typename std::vector<int>::iterator, CorrectCompare<int>>);
@@ -249,12 +248,11 @@ void test_psort_iterator_constraints() {
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::InputIterator<int>, CorrectCompare<int>>);
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::RandomIterator<NonMovableValue>, CorrectCompare<NonMovableValue>>);
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::RandomIterator<NonMoveAssignableValue>, CorrectCompare<NonMoveAssignableValue>>);
-    static_assert(!can_call_parallel_sort_with_iterator_and_compare<ConstantIT<int>, CorrectCompare<const int>>);
+    static_assert(!can_call_parallel_sort_with_iterator_and_compare<test_concepts::ConstantIT<int>, CorrectCompare<const int>>);
 }
 
 void test_psort_compare_constraints() {
     using namespace test_concepts::compare;
-    using namespace test_concepts::parallel_sort_value;
 
     using CorrectCBS = test_concepts::container_based_sequence::Correct;
     using CorrectIterator = CorrectCBS::iterator;

--- a/test/tbb/test_parallel_sort.cpp
+++ b/test/tbb/test_parallel_sort.cpp
@@ -238,18 +238,18 @@ void test_psort_iterator_constraints() {
     static_assert(can_call_parallel_sort_with_iterator<typename std::vector<int>::iterator>);
     static_assert(!can_call_parallel_sort_with_iterator<utils::ForwardIterator<int>>);
     static_assert(!can_call_parallel_sort_with_iterator<utils::InputIterator<int>>);
-    static_assert(!can_call_parallel_sort_with_iterator<utils::RandomIterator<const int>>);
     static_assert(!can_call_parallel_sort_with_iterator<utils::RandomIterator<NonMovableValue>>);
     static_assert(!can_call_parallel_sort_with_iterator<utils::RandomIterator<NonMoveAssignableValue>>);
     static_assert(!can_call_parallel_sort_with_iterator<utils::RandomIterator<NonComparableValue>>);
+    static_assert(!can_call_parallel_sort_with_iterator<ConstantIT<int>>);
 
     static_assert(can_call_parallel_sort_with_iterator_and_compare<utils::RandomIterator<int>, CorrectCompare<int>>);
     static_assert(can_call_parallel_sort_with_iterator_and_compare<typename std::vector<int>::iterator, CorrectCompare<int>>);
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::ForwardIterator<int>, CorrectCompare<int>>);
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::InputIterator<int>, CorrectCompare<int>>);
-    static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::RandomIterator<const int>, CorrectCompare<const int>>);
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::RandomIterator<NonMovableValue>, CorrectCompare<NonMovableValue>>);
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::RandomIterator<NonMoveAssignableValue>, CorrectCompare<NonMoveAssignableValue>>);
+    static_assert(!can_call_parallel_sort_with_iterator_and_compare<ConstantIT<int>, CorrectCompare<const int>>);
 }
 
 void test_psort_compare_constraints() {
@@ -279,7 +279,7 @@ void test_psort_cbs_constraints() {
     static_assert(!can_call_parallel_sort_with_cbs<NoBegin>);
     static_assert(!can_call_parallel_sort_with_cbs<NoEnd>);
     static_assert(!can_call_parallel_sort_with_cbs<ForwardIteratorCBS>);
-    static_assert(!can_call_parallel_sort_with_cbs<ConstantAccessCBS<int>>);
+    static_assert(!can_call_parallel_sort_with_cbs<ConstantCBS>);
     static_assert(!can_call_parallel_sort_with_iterator<CustomValueCBS<NonMovableValue>>);
     static_assert(!can_call_parallel_sort_with_iterator<CustomValueCBS<NonMoveAssignableValue>>);
     static_assert(!can_call_parallel_sort_with_iterator<CustomValueCBS<NonComparableValue>>);
@@ -292,7 +292,7 @@ void test_psort_cbs_constraints() {
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<NoBegin, CorrectCompare>);
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<NoEnd, CorrectCompare>);
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<ForwardIteratorCBS, CorrectCompare>);
-    static_assert(!can_call_parallel_sort_with_cbs_and_compare<ConstantAccessCBS<int>, CorrectCompare>);
+    static_assert(!can_call_parallel_sort_with_cbs_and_compare<ConstantCBS, CorrectCompare>);
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<CustomValueCBS<NonMovableValue>, CompareMovable>);
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<CustomValueCBS<NonMoveAssignableValue>, CompareMoveAssignable>);
 }

--- a/test/tbb/test_parallel_sort.cpp
+++ b/test/tbb/test_parallel_sort.cpp
@@ -278,21 +278,22 @@ void test_psort_cbs_constraints() {
     static_assert(!can_call_parallel_sort_with_cbs<NoEnd>);
     static_assert(!can_call_parallel_sort_with_cbs<ForwardIteratorCBS>);
     static_assert(!can_call_parallel_sort_with_cbs<ConstantCBS>);
-    static_assert(!can_call_parallel_sort_with_iterator<CustomValueCBS<NonMovableValue>>);
-    static_assert(!can_call_parallel_sort_with_iterator<CustomValueCBS<NonMoveAssignableValue>>);
-    static_assert(!can_call_parallel_sort_with_iterator<CustomValueCBS<NonComparableValue>>);
 
+    static_assert(can_call_parallel_sort_with_cbs<CustomValueCBS<CorrectValue>>);
+    static_assert(!can_call_parallel_sort_with_cbs<CustomValueCBS<NonMovableValue>>);
+    static_assert(!can_call_parallel_sort_with_cbs<CustomValueCBS<NonMoveAssignableValue>>);
+    static_assert(!can_call_parallel_sort_with_cbs<CustomValueCBS<NonComparableValue>>);\
 
     using CorrectCompare = test_concepts::compare::Correct<int>;
-    using CompareMovable = test_concepts::compare::Correct<NonMovableValue>;
-    using CompareMoveAssignable = test_concepts::compare::Correct<NonMoveAssignableValue>;
+    using NonMovableCompare = test_concepts::compare::Correct<NonMovableValue>;
+    using NonMoveAssignableCompare = test_concepts::compare::Correct<NonMoveAssignableValue>;
     static_assert(can_call_parallel_sort_with_cbs_and_compare<Correct, CorrectCompare>);
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<NoBegin, CorrectCompare>);
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<NoEnd, CorrectCompare>);
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<ForwardIteratorCBS, CorrectCompare>);
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<ConstantCBS, CorrectCompare>);
-    static_assert(!can_call_parallel_sort_with_cbs_and_compare<CustomValueCBS<NonMovableValue>, CompareMovable>);
-    static_assert(!can_call_parallel_sort_with_cbs_and_compare<CustomValueCBS<NonMoveAssignableValue>, CompareMoveAssignable>);
+    static_assert(!can_call_parallel_sort_with_cbs_and_compare<CustomValueCBS<NonMovableValue>, NonMovableCompare>);
+    static_assert(!can_call_parallel_sort_with_cbs_and_compare<CustomValueCBS<NonMoveAssignableValue>, NonMoveAssignableCompare>);
 }
 
 #endif // __TBB_CPP20_CONCEPTS_PRESENT

--- a/test/tbb/test_parallel_sort.cpp
+++ b/test/tbb/test_parallel_sort.cpp
@@ -231,24 +231,33 @@ template <typename T>
 using CorrectCompare = test_concepts::compare::Correct<T>;
 
 void test_psort_iterator_constraints() {
+    using namespace test_concepts;
+    using namespace test_concepts::parallel_sort_value;
+
     static_assert(can_call_parallel_sort_with_iterator<utils::RandomIterator<int>>);
     static_assert(can_call_parallel_sort_with_iterator<typename std::vector<int>::iterator>);
     static_assert(!can_call_parallel_sort_with_iterator<utils::ForwardIterator<int>>);
     static_assert(!can_call_parallel_sort_with_iterator<utils::InputIterator<int>>);
     static_assert(!can_call_parallel_sort_with_iterator<utils::RandomIterator<const int>>);
+    static_assert(!can_call_parallel_sort_with_iterator<utils::RandomIterator<NonMovableValue>>);
+    static_assert(!can_call_parallel_sort_with_iterator<utils::RandomIterator<NonMoveAssignableValue>>);
+    static_assert(!can_call_parallel_sort_with_iterator<utils::RandomIterator<NonComparableValue>>);
 
     static_assert(can_call_parallel_sort_with_iterator_and_compare<utils::RandomIterator<int>, CorrectCompare<int>>);
     static_assert(can_call_parallel_sort_with_iterator_and_compare<typename std::vector<int>::iterator, CorrectCompare<int>>);
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::ForwardIterator<int>, CorrectCompare<int>>);
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::InputIterator<int>, CorrectCompare<int>>);
-    static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::RandomIterator<const int>, CorrectCompare<int>>);
+    static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::RandomIterator<const int>, CorrectCompare<const int>>);
+    static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::RandomIterator<NonMovableValue>, CorrectCompare<NonMovableValue>>);
+    static_assert(!can_call_parallel_sort_with_iterator_and_compare<utils::RandomIterator<NonMoveAssignableValue>, CorrectCompare<NonMoveAssignableValue>>);
 }
 
 void test_psort_compare_constraints() {
     using namespace test_concepts::compare;
+    using namespace test_concepts::parallel_sort_value;
+
     using CorrectCBS = test_concepts::container_based_sequence::Correct;
     using CorrectIterator = CorrectCBS::iterator;
-
     static_assert(can_call_parallel_sort_with_iterator_and_compare<CorrectIterator, Correct<int>>);
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<CorrectIterator, NoOperatorRoundBrackets<int>>);
     static_assert(!can_call_parallel_sort_with_iterator_and_compare<CorrectIterator, WrongFirstInputOperatorRoundBrackets<int>>);
@@ -264,18 +273,28 @@ void test_psort_compare_constraints() {
 
 void test_psort_cbs_constraints() {
     using namespace test_concepts::container_based_sequence;
-    using CorrectCompare = test_concepts::compare::Correct<int>;
+    using namespace test_concepts::parallel_sort_value;
+
     static_assert(can_call_parallel_sort_with_cbs<Correct>);
     static_assert(!can_call_parallel_sort_with_cbs<NoBegin>);
     static_assert(!can_call_parallel_sort_with_cbs<NoEnd>);
     static_assert(!can_call_parallel_sort_with_cbs<ForwardIteratorCBS>);
-    static_assert(!can_call_parallel_sort_with_cbs<ConstantCBS>);
+    static_assert(!can_call_parallel_sort_with_cbs<ConstantAccessCBS<int>>);
+    static_assert(!can_call_parallel_sort_with_iterator<CustomValueCBS<NonMovableValue>>);
+    static_assert(!can_call_parallel_sort_with_iterator<CustomValueCBS<NonMoveAssignableValue>>);
+    static_assert(!can_call_parallel_sort_with_iterator<CustomValueCBS<NonComparableValue>>);
 
+
+    using CorrectCompare = test_concepts::compare::Correct<int>;
+    using CompareMovable = test_concepts::compare::Correct<NonMovableValue>;
+    using CompareMoveAssignable = test_concepts::compare::Correct<NonMoveAssignableValue>;
     static_assert(can_call_parallel_sort_with_cbs_and_compare<Correct, CorrectCompare>);
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<NoBegin, CorrectCompare>);
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<NoEnd, CorrectCompare>);
     static_assert(!can_call_parallel_sort_with_cbs_and_compare<ForwardIteratorCBS, CorrectCompare>);
-    static_assert(!can_call_parallel_sort_with_cbs_and_compare<ConstantCBS, CorrectCompare>);
+    static_assert(!can_call_parallel_sort_with_cbs_and_compare<ConstantAccessCBS<int>, CorrectCompare>);
+    static_assert(!can_call_parallel_sort_with_cbs_and_compare<CustomValueCBS<NonMovableValue>, CompareMovable>);
+    static_assert(!can_call_parallel_sort_with_cbs_and_compare<CustomValueCBS<NonMoveAssignableValue>, CompareMoveAssignable>);
 }
 
 #endif // __TBB_CPP20_CONCEPTS_PRESENT


### PR DESCRIPTION
### Description 
The oneTBB spec contains the swappable requirement for the iterators, but this requirement isn't handled by the C++ constraints in the implementation. This patch enables these constraints for all the overloads to improve the diagnostic and also extends the testing.

- [X] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [X] added - _required for new features and for some bug fixes_

### Documentation

https://github.com/oneapi-src/oneAPI-spec/pull/391

### Breaks backward compatibility
- [X] Yes

### Notify the following users

@kboyarinov 

Signed-off-by: Kochin Ivan <kochin.ivan@intel.com>
