### PR TITLE
Remove several redundant steps inside the parallel_sort algorithm

### DIFF
--- a/include/oneapi/tbb/parallel_sort.h
+++ b/include/oneapi/tbb/parallel_sort.h
@@ -192,6 +192,7 @@ void parallel_quick_sort( RandomAccessIterator begin, RandomAccessIterator end, 
     for( ; k != begin + serial_cutoff; ++k ) {
         if( comp(*(k + 1), *k) ) {
             do_parallel_quick_sort(begin, end, comp);
+            return;
         }
     }
 


### PR DESCRIPTION
### Description 
_Add comprehensive description of proposed changes_

The `parallel_sort` algorithm has to check the first nine range argument order sequentially and starts concurrent order checking only if the first nine elements order isn't broken. But if the order is broken, the algorithm starts parallel sorting.

Due to the bug in the implementation, in this case, if the sort is done, the algorithm is still going to check the order one more time which is redundant. This patch fixes it.

- [X] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [X] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
@alexey-katranov, @kboyarinov 

Signed-off-by: Kochin Ivan <kochin.ivan@intel.com>