### PR TITLE
Suppress data race during ittnotify initialization

### DIFF
--- a/cmake/sanitize.cmake
+++ b/cmake/sanitize.cmake
@@ -34,7 +34,9 @@ if (NOT ${FLAG_DISPLAY_NAME})
     "please try another compiler or omit TBB_SANITIZE variable")
 endif()
 
-set(TBB_TESTS_ENVIRONMENT ${TBB_TESTS_ENVIRONMENT} "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/cmake/suppressions/lsan.suppressions")
+set(TBB_TESTS_ENVIRONMENT ${TBB_TESTS_ENVIRONMENT}
+    "TSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/cmake/suppressions/tsan.suppressions"
+    "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/cmake/suppressions/lsan.suppressions")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TBB_SANITIZE_OPTION}")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${TBB_SANITIZE_OPTION}")

--- a/cmake/suppressions/tsan.suppressions
+++ b/cmake/suppressions/tsan.suppressions
@@ -1,0 +1,3 @@
+# TSAN suppression for known issues.
+# Possible data race during ittnotify initialization. Low impact.
+race:__itt_nullify_all_pointers


### PR DESCRIPTION
### Description 
Suppress data race during ittnotify initialization.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change
Adding suppression file for TSAN with corresponding changes.

_Add respective label(s) to PR if you have permissions_

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users

