### PR TITLE
Deallocate object with based on actual type

### DIFF
--- a/include/oneapi/tbb/detail/_flow_graph_body_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_body_impl.h
@@ -260,8 +260,13 @@ public:
             next_task = nullptr;
         else if (next_task)
             next_task = prioritize_task(my_node.graph_reference(), *next_task);
-        finalize(ed);
+        finalize<forward_task_bypass>(ed);
         return next_task;
+    }
+
+    task* cancel(execution_data& ed) override {
+        finalize<forward_task_bypass>(ed);
+        return nullptr;
     }
 };
 
@@ -284,9 +289,13 @@ public:
             next_task = nullptr;
         else if (next_task)
             next_task = prioritize_task(my_node.graph_reference(), *next_task);
-        finalize(ed);
+        finalize<apply_body_task_bypass>(ed);
         return next_task;
+    }
 
+    task* cancel(execution_data& ed) override {
+        finalize<apply_body_task_bypass>(ed);
+        return nullptr;
     }
 };
 
@@ -304,10 +313,14 @@ public:
             next_task = nullptr;
         else if (next_task)
             next_task = prioritize_task(my_node.graph_reference(), *next_task);
-        finalize(ed);
+        finalize<input_node_task_bypass>(ed);
         return next_task;
     }
 
+    task* cancel(execution_data& ed) override {
+        finalize<input_node_task_bypass>(ed);
+        return nullptr;
+    }
 };
 
 // ------------------------ end of node task bodies -----------------------------------

--- a/include/oneapi/tbb/detail/_flow_graph_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_impl.h
@@ -135,9 +135,11 @@ public:
     graph& my_graph; // graph instance the task belongs to
     // TODO revamp: rename to my_priority
     node_priority_t priority;
+    template <typename DerivedType>
     void destruct_and_deallocate(const execution_data& ed);
     task* cancel(execution_data& ed) override;
 protected:
+    template <typename DerivedType>
     void finalize(const execution_data& ed);
 private:
     // To organize task_list
@@ -359,21 +361,23 @@ private:
 
 };  // class graph
 
+template<typename DerivedType>
 inline void graph_task::destruct_and_deallocate(const execution_data& ed) {
     auto allocator = my_allocator;
     // TODO: investigate if direct call of derived destructor gives any benefits.
     this->~graph_task();
-    allocator.deallocate(this, ed);
+    allocator.deallocate(static_cast<DerivedType*>(this), ed);
 }
 
+template<typename DerivedType>
 inline void graph_task::finalize(const execution_data& ed) {
     graph& g = my_graph;
-    destruct_and_deallocate(ed);
+    destruct_and_deallocate<DerivedType>(ed);
     g.release_wait();
 }
 
 inline task* graph_task::cancel(execution_data& ed) {
-    finalize(ed);
+    finalize<graph_task>(ed);
     return nullptr;
 }
 

--- a/include/oneapi/tbb/detail/_flow_graph_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_impl.h
@@ -137,7 +137,6 @@ public:
     node_priority_t priority;
     template <typename DerivedType>
     void destruct_and_deallocate(const execution_data& ed);
-    task* cancel(execution_data& ed) override;
 protected:
     template <typename DerivedType>
     void finalize(const execution_data& ed);
@@ -374,11 +373,6 @@ inline void graph_task::finalize(const execution_data& ed) {
     graph& g = my_graph;
     destruct_and_deallocate<DerivedType>(ed);
     g.release_wait();
-}
-
-inline task* graph_task::cancel(execution_data& ed) {
-    finalize<graph_task>(ed);
-    return nullptr;
 }
 
 //********************************************************************************

--- a/include/oneapi/tbb/flow_graph.h
+++ b/include/oneapi/tbb/flow_graph.h
@@ -3111,7 +3111,12 @@ protected:
             if ( !register_predecessor(s, o) ) {
                 register_successor(o, s);
             }
-            finalize(ed);
+            finalize<register_predecessor_task>(ed);
+            return nullptr;
+        }
+
+        task* cancel(execution_data& ed) override {
+            finalize<register_predecessor_task>(ed);
             return nullptr;
         }
 


### PR DESCRIPTION
### Description 
`graph_task` deallocates another type than allocated. Provides actual type of object for `small_object_allocator` allocator.

Fixes #639

- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@alexey-katranov 

### Other information
