### PR TITLE
Fix incorrect definition of assignment operator in containers

### DIFF
--- a/include/oneapi/tbb/concurrent_map.h
+++ b/include/oneapi/tbb/concurrent_map.h
@@ -92,7 +92,6 @@ public:
 
     // Include constructors of base type
     using base_type::base_type;
-    using base_type::operator=;
 
     // Required for implicit deduction guides
     concurrent_map() = default;
@@ -103,6 +102,11 @@ public:
     // Required to respect the rule of 5
     concurrent_map& operator=( const concurrent_map& ) = default;
     concurrent_map& operator=( concurrent_map&& ) = default;
+
+    concurrent_map& operator=( std::initializer_list<value_type> il ) {
+        base_type::operator= (il);
+        return *this;
+    }
 
     // Observers
     mapped_type& at(const key_type& key) {
@@ -239,7 +243,6 @@ public:
     // Include constructors of base_type
     using base_type::base_type;
     using base_type::insert;
-    using base_type::operator=;
 
     // Required for implicit deduction guides
     concurrent_multimap() = default;
@@ -250,6 +253,11 @@ public:
     // Required to respect the rule of 5
     concurrent_multimap& operator=( const concurrent_multimap& ) = default;
     concurrent_multimap& operator=( concurrent_multimap&& ) = default;
+
+    concurrent_multimap& operator=( std::initializer_list<value_type> il ) {
+        base_type::operator= (il);
+        return *this;
+    }
 
     template <typename P>
     typename std::enable_if<std::is_constructible<value_type, P&&>::value,

--- a/include/oneapi/tbb/concurrent_set.h
+++ b/include/oneapi/tbb/concurrent_set.h
@@ -75,7 +75,6 @@ public:
 
     // Include constructors of base_type
     using base_type::base_type;
-    using base_type::operator=;
 
     // Required for implicit deduction guides
     concurrent_set() = default;
@@ -86,6 +85,11 @@ public:
     // Required to respect the rule of 5
     concurrent_set& operator=( const concurrent_set& ) = default;
     concurrent_set& operator=( concurrent_set&& ) = default;
+
+    concurrent_set& operator=( std::initializer_list<value_type> il ) {
+        base_type::operator= (il);
+        return *this;
+    }
 
     template<typename OtherCompare>
     void merge(concurrent_set<key_type, OtherCompare, Allocator>& source) {
@@ -172,7 +176,6 @@ public:
 
     // Include constructors of base_type;
     using base_type::base_type;
-    using base_type::operator=;
 
     // Required for implicit deduction guides
     concurrent_multiset() = default;
@@ -183,6 +186,11 @@ public:
     // Required to respect the rule of 5
     concurrent_multiset& operator=( const concurrent_multiset& ) = default;
     concurrent_multiset& operator=( concurrent_multiset&& ) = default;
+
+    concurrent_multiset& operator=( std::initializer_list<value_type> il ) {
+        base_type::operator= (il);
+        return *this;
+    }
 
     template<typename OtherCompare>
     void merge(concurrent_set<key_type, OtherCompare, Allocator>& source) {

--- a/include/oneapi/tbb/concurrent_unordered_map.h
+++ b/include/oneapi/tbb/concurrent_unordered_map.h
@@ -70,7 +70,6 @@ public:
 
     // Include constructors of base type
     using base_type::base_type;
-    using base_type::operator=;
 
     // Required for implicit deduction guides
     concurrent_unordered_map() = default;
@@ -81,6 +80,11 @@ public:
     // Required to respect the rule of 5
     concurrent_unordered_map& operator=( const concurrent_unordered_map& ) = default;
     concurrent_unordered_map& operator=( concurrent_unordered_map&& ) = default;
+
+    concurrent_unordered_map& operator=( std::initializer_list<value_type> il ) {
+        base_type::operator= (il);
+        return *this;
+    }
 
     // Observers
     mapped_type& operator[]( const key_type& key ) {
@@ -255,7 +259,6 @@ public:
 
     // Include constructors of base type
     using base_type::base_type;
-    using base_type::operator=;
     using base_type::insert;
 
     // Required for implicit deduction guides
@@ -267,6 +270,11 @@ public:
     // Required to respect the rule of 5
     concurrent_unordered_multimap& operator=( const concurrent_unordered_multimap& ) = default;
     concurrent_unordered_multimap& operator=( concurrent_unordered_multimap&& ) = default;
+
+    concurrent_unordered_multimap& operator=( std::initializer_list<value_type> il ) {
+        base_type::operator= (il);
+        return *this;
+    }
 
     template <typename P>
     typename std::enable_if<std::is_constructible<value_type, P&&>::value,

--- a/include/oneapi/tbb/concurrent_unordered_set.h
+++ b/include/oneapi/tbb/concurrent_unordered_set.h
@@ -68,7 +68,7 @@ public:
 
     // Include constructors of base_type;
     using base_type::base_type;
-    using base_type::operator=;
+
     // Required for implicit deduction guides
     concurrent_unordered_set() = default;
     concurrent_unordered_set( const concurrent_unordered_set& ) = default;
@@ -78,6 +78,11 @@ public:
     // Required to respect the rule of 5
     concurrent_unordered_set& operator=( const concurrent_unordered_set& ) = default;
     concurrent_unordered_set& operator=( concurrent_unordered_set&& ) = default;
+
+    concurrent_unordered_set& operator=( std::initializer_list<value_type> il ) {
+        base_type::operator= (il);
+        return *this;
+    }
 
     template <typename OtherHash, typename OtherKeyEqual>
     void merge( concurrent_unordered_set<key_type, OtherHash, OtherKeyEqual, allocator_type>& source ) {
@@ -193,7 +198,6 @@ public:
 
     // Include constructors of base_type;
     using base_type::base_type;
-    using base_type::operator=;
 
     // Required for implicit deduction guides
     concurrent_unordered_multiset() = default;
@@ -204,6 +208,11 @@ public:
     // Required to respect the rule of 5
     concurrent_unordered_multiset& operator=( const concurrent_unordered_multiset& ) = default;
     concurrent_unordered_multiset& operator=( concurrent_unordered_multiset&& ) = default;
+
+    concurrent_unordered_multiset& operator=( std::initializer_list<value_type> il ) {
+        base_type::operator= (il);
+        return *this;
+    }
 
     template <typename OtherHash, typename OtherKeyEqual>
     void merge( concurrent_unordered_set<key_type, OtherHash, OtherKeyEqual, allocator_type>& source ) {

--- a/test/common/initializer_list_support.h
+++ b/test/common/initializer_list_support.h
@@ -21,6 +21,7 @@
 
 #include <initializer_list>
 #include <vector>
+#include <type_traits>
 
 namespace initializer_list_support_tests {
 
@@ -33,6 +34,9 @@ void test_ctor( std::initializer_list<ElementType> init, const ContainerType& ex
 template <typename ContainerType, typename ElementType>
 void test_assignment_operator( std::initializer_list<ElementType> init, const ContainerType& expected ) {
     ContainerType cont;
+    static_assert(std::is_same< decltype(cont = init), ContainerType& >::value == true,
+        "ContainerType::operator=(std::intializer_list) must return ContainerType&");
+
     cont = init;
     REQUIRE_MESSAGE(cont == expected, "Assignment from the initializer_list failed");
 }


### PR DESCRIPTION
### Description 
Is a part of https://github.com/oneapi-src/oneTBB/pull/318

Fixes #372 

- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and for some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@anton-potapov @Lastique

### Other information
