### PR TITLE
test_limiter_node: Build issue: GCC 4.8 bug

### DIFF
--- a/test/tbb/test_limiter_node.cpp
+++ b/test/tbb/test_limiter_node.cpp
@@ -605,18 +605,18 @@ TEST_CASE( "Deduction guides" ) {
 }
 #endif
 
+struct TestLargeStruct {
+    char bytes[512]{ 0 };
+};
+
 //! Test correct node deallocation while using small_object_pool.
 //! (see https://github.com/oneapi-src/oneTBB/issues/639)
 //! \brief \ref error_guessing
 TEST_CASE("Test correct node deallocation while using small_object_pool") {
-    struct TestLargeStruct {
-        char bytes[512]{ 0 };
-    };
-
     tbb::flow::graph graph;
-    tbb::flow::queue_node<TestLargeStruct> input_node{ graph };
-    tbb::flow::function_node<TestLargeStruct> func{ graph, tbb::flow::serial,
-        [](const TestLargeStruct& input) { return input; } };
+    tbb::flow::queue_node<TestLargeStruct> input_node( graph );
+    tbb::flow::function_node<TestLargeStruct> func( graph, tbb::flow::serial,
+        [](const TestLargeStruct& input) { return input; } );
 
     tbb::flow::make_edge( input_node, func );
     CHECK( input_node.try_put( TestLargeStruct{} ) );


### PR DESCRIPTION
### Description 
Class template inheritance doesn't work well with function-local types.
Moving class definition to global scope
[GCC Commit](https://gcc.gnu.org/git/?p=gcc.git&a=commit;h=f92c74268a1f3e9ff6921097e8da418879769e2b)

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@anton-potapov 

### Other information
