### PR TITLE
Fix issue #687 (test_eh_thread)

### DIFF
--- a/test/tbb/test_eh_thread.cpp
+++ b/test/tbb/test_eh_thread.cpp
@@ -36,6 +36,7 @@
 // TODO: enable limitThreads with sanitizer under docker
 #if TBB_USE_EXCEPTIONS && !_WIN32 && !__ANDROID__
 
+#include <limits.h>
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -73,7 +74,8 @@ public:
         mValid = false;
         pthread_attr_t attr;
         // Limit the stack size not to consume all virtual memory on 32 bit platforms.
-        if (pthread_attr_init(&attr) == 0 && pthread_attr_setstacksize(&attr, 100*1024) == 0) {
+        std::size_t stacksize = utils::max(128*1024, PTHREAD_STACK_MIN);
+        if (pthread_attr_init(&attr) == 0 && pthread_attr_setstacksize(&attr, stacksize) == 0) {
             mValid = pthread_create(&mHandle, &attr, thread_routine, /* arg = */ nullptr) == 0;
         }
     }


### PR DESCRIPTION
### Description 
Added use of ``PTHREAD_STACK_MIN`` and change default stack size to 128k (for stacksize is a multiple of all possible values of system page size).

Fixes #687 (test ``test_eh_thread``)

- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@alexey-katranov, @anton-potapov

### Other information
