### PR TITLE
Fix unordered and ordered containers ranges for empty containers

### DIFF
--- a/include/oneapi/tbb/detail/_concurrent_skip_list.h
+++ b/include/oneapi/tbb/detail/_concurrent_skip_list.h
@@ -72,7 +72,7 @@ public:
     using pointer = typename value_allocator_traits::pointer;
     using const_pointer = typename value_allocator_traits::const_pointer;
 
-    //In perfect world these constructor and destructor would have been private, 
+    //In perfect world these constructor and destructor would have been private,
     //however this seems technically impractical due to use of allocator_traits.
 
     //Should not be called directly, instead use create method
@@ -671,24 +671,34 @@ public:
         using reference = typename iterator::reference;
 
         bool empty() const {
-            return my_begin.my_node_ptr->next(0) == my_end.my_node_ptr;
+            return my_begin.my_node_ptr ? (my_begin.my_node_ptr->next(0) == my_end.my_node_ptr)
+                                        : true;
         }
 
         bool is_divisible() const {
-            return my_level != 0 ? my_begin.my_node_ptr->next(my_level - 1) != my_end.my_node_ptr : false;
+            return my_begin.my_node_ptr && my_level != 0
+                        ? my_begin.my_node_ptr->next(my_level - 1) != my_end.my_node_ptr
+                        : false;
         }
 
         size_type size() const { return std::distance(my_begin, my_end); }
 
         const_range_type( const_range_type& r, split)
             : my_end(r.my_end) {
-            my_begin = iterator(r.my_begin.my_node_ptr->next(r.my_level - 1));
-            my_level = my_begin.my_node_ptr->height();
+            if (r.empty()) {
+                __TBB_ASSERT(my_end.my_node_ptr == nullptr, nullptr);
+                my_begin = my_end;
+                my_level = 0;
+            } else {
+                my_begin = iterator(r.my_begin.my_node_ptr->next(r.my_level - 1));
+                my_level = my_begin.my_node_ptr->height();
+            }
             r.my_end = my_begin;
         }
 
         const_range_type( const concurrent_skip_list& l)
-            : my_end(l.end()), my_begin(l.begin()), my_level(my_begin.my_node_ptr->height() ) {}
+            : my_end(l.end()), my_begin(l.begin()),
+              my_level(my_begin.my_node_ptr ? my_begin.my_node_ptr->height() : 0) {}
 
         iterator begin() const { return my_begin; }
         iterator end() const { return my_end; }

--- a/include/oneapi/tbb/detail/_concurrent_unordered_base.h
+++ b/include/oneapi/tbb/detail/_concurrent_unordered_base.h
@@ -727,7 +727,7 @@ public:
         iterator end() const { return iterator(my_instance.first_value_node(my_end_node)); }
 
         const_range_type( const concurrent_unordered_base& table )
-            : my_instance(table), my_begin_node(const_cast<node_ptr>(&table.my_head)), my_end_node(nullptr)
+            : my_instance(table), my_begin_node(my_instance.first_value_node(const_cast<node_ptr>(&table.my_head))), my_end_node(nullptr)
         {
             set_midpoint();
         }

--- a/include/oneapi/tbb/detail/_concurrent_unordered_base.h
+++ b/include/oneapi/tbb/detail/_concurrent_unordered_base.h
@@ -703,7 +703,7 @@ public:
         using difference_type = typename concurrent_unordered_base::difference_type;
         using iterator = typename concurrent_unordered_base::const_iterator;
 
-        bool empty() const { return my_instance.first_value_node(my_begin_node) == my_end_node; }
+        bool empty() const { return my_begin_node == my_end_node; }
 
         bool is_divisible() const {
             return my_midpoint_node != my_end_node;

--- a/include/oneapi/tbb/detail/_concurrent_unordered_base.h
+++ b/include/oneapi/tbb/detail/_concurrent_unordered_base.h
@@ -703,7 +703,7 @@ public:
         using difference_type = typename concurrent_unordered_base::difference_type;
         using iterator = typename concurrent_unordered_base::const_iterator;
 
-        bool empty() const { return my_begin_node == my_end_node; }
+        bool empty() const { return my_instance.first_value_node(my_begin_node) == my_end_node; }
 
         bool is_divisible() const {
             return my_midpoint_node != my_end_node;
@@ -733,7 +733,7 @@ public:
         }
     private:
         void set_midpoint() const {
-            if (my_begin_node == my_end_node) {
+            if (empty()) {
                 my_midpoint_node = my_end_node;
             } else {
                 sokey_type invalid_key = ~sokey_type(0);

--- a/test/common/concurrent_associative_common.h
+++ b/test/common/concurrent_associative_common.h
@@ -425,6 +425,26 @@ void test_comparison_operators() {
     check_unequal(cont, cont6);
 }
 
+template <typename Range, typename Container>
+void test_empty_container_range(Container&& cont) {
+    REQUIRE(cont.empty());
+    Range r = cont.range();
+    REQUIRE_MESSAGE(r.empty(), "Empty container range should be empty");
+    REQUIRE_MESSAGE(!r.is_divisible(), "Empty container range should not be divisible");
+    REQUIRE_MESSAGE(r.begin() == r.end(), "Incorrect iterators on empty range");
+    REQUIRE_MESSAGE(r.begin() == cont.begin(), "Incorrect iterators on empty range");
+
+    Range r2(r, tbb::split{});
+    REQUIRE_MESSAGE(r.empty(), "Empty container range should be empty");
+    REQUIRE_MESSAGE(r2.empty(), "Empty container range should be empty");
+    REQUIRE_MESSAGE(!r.is_divisible(), "Empty container range should not be divisible");
+    REQUIRE_MESSAGE(!r2.is_divisible(), "Empty container range should not be divisible");
+    REQUIRE_MESSAGE(r.begin() == r.end(), "Incorrect iterators on empty range");
+    REQUIRE_MESSAGE(r2.begin() == r2.end(), "Incorrect iterators on empty range");
+    REQUIRE_MESSAGE(r.begin() == cont.begin(), "Incorrect iterators on empty range");
+    REQUIRE_MESSAGE(r2.begin() == cont.begin(), "Incorrect iterators on empty range");
+}
+
 template<typename T, typename CheckElementState>
 void test_basic_common()
 {
@@ -445,6 +465,25 @@ void test_basic_common()
     REQUIRE_MESSAGE(cont.begin() == cont.end(), "Concurrent container iterators are invalid after construction");
     REQUIRE_MESSAGE(ccont.begin() == ccont.end(), "Concurrent container iterators are invalid after construction");
     REQUIRE_MESSAGE(cont.cbegin() == cont.cend(), "Concurrent container iterators are invalid after construction");
+
+    // Test range for empty container
+    using range_type = typename T::range_type;
+    using const_range_type = typename T::const_range_type;
+    test_empty_container_range<range_type>(cont);
+    test_empty_container_range<const_range_type>(cont);
+    test_empty_container_range<const_range_type>(ccont);
+
+    T empty_cont;
+    const T& empty_ccont = empty_cont;
+
+    for (int i = 0; i < 1000; ++i) {
+        empty_cont.insert(Value<T>::make(i));
+    }
+    empty_cont.clear();
+
+    test_empty_container_range<range_type>(empty_cont);
+    test_empty_container_range<const_range_type>(empty_cont);
+    test_empty_container_range<const_range_type>(empty_ccont);
 
     //std::pair<iterator, bool> insert(const value_type& obj);
     std::pair<typename T::iterator, bool> ins = cont.insert(Value<T>::make(1));

--- a/test/common/concurrent_associative_common.h
+++ b/test/common/concurrent_associative_common.h
@@ -433,16 +433,6 @@ void test_empty_container_range(Container&& cont) {
     REQUIRE_MESSAGE(!r.is_divisible(), "Empty container range should not be divisible");
     REQUIRE_MESSAGE(r.begin() == r.end(), "Incorrect iterators on empty range");
     REQUIRE_MESSAGE(r.begin() == cont.begin(), "Incorrect iterators on empty range");
-
-    Range r2(r, tbb::split{});
-    REQUIRE_MESSAGE(r.empty(), "Empty container range should be empty");
-    REQUIRE_MESSAGE(r2.empty(), "Empty container range should be empty");
-    REQUIRE_MESSAGE(!r.is_divisible(), "Empty container range should not be divisible");
-    REQUIRE_MESSAGE(!r2.is_divisible(), "Empty container range should not be divisible");
-    REQUIRE_MESSAGE(r.begin() == r.end(), "Incorrect iterators on empty range");
-    REQUIRE_MESSAGE(r2.begin() == r2.end(), "Incorrect iterators on empty range");
-    REQUIRE_MESSAGE(r.begin() == cont.begin(), "Incorrect iterators on empty range");
-    REQUIRE_MESSAGE(r2.begin() == cont.begin(), "Incorrect iterators on empty range");
 }
 
 template<typename T, typename CheckElementState>


### PR DESCRIPTION
### Description 
Fix for empty ordered and unordered containers range_type and const_range_type (Was #673, but commit history was corrupted)

Fixes #641 

- [ ] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and for some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
