### PR TITLE
Resolve doxygen class naming conflicts

### DIFF
--- a/test/conformance/conformance_combinable.cpp
+++ b/test/conformance/conformance_combinable.cpp
@@ -55,16 +55,16 @@ const double EXPECTED_SUM = (REPETITIONS + 1) * N;
 // also operator=
 //
 
-class minimal {
+class minimalCombinable {
 private:
     int my_value;
 public:
-    minimal(int val=0) : my_value(val) { ++construction_counter; }
-    minimal( const minimal &m ) : my_value(m.my_value) { ++construction_counter; }
-    minimal& operator=(const minimal& other) { my_value = other.my_value; return *this; }
-    minimal& operator+=(const minimal& other) { my_value += other.my_value; return *this; }
+    minimalCombinable(int val=0) : my_value(val) { ++construction_counter; }
+    minimalCombinable( const minimalCombinable&m ) : my_value(m.my_value) { ++construction_counter; }
+    minimalCombinable& operator=(const minimalCombinable& other) { my_value = other.my_value; return *this; }
+    minimalCombinable& operator+=(const minimalCombinable& other) { my_value += other.my_value; return *this; }
     operator int() const { return my_value; }
-    ~minimal() { ++destruction_counter; }
+    ~minimalCombinable() { ++destruction_counter; }
     void set_value( const int i ) { my_value = i; }
     int value( ) const { return my_value; }
 };
@@ -340,7 +340,7 @@ RunParallelTests() {
     // REMARK("Running RunParallelTests\n");
     RunParallelScalarTests<int>("int");
     RunParallelScalarTests<double>("double");
-    RunParallelScalarTests<minimal>("minimal");
+    RunParallelScalarTests<minimalCombinable>("minimalCombinable");
     RunParallelVectorTests<int>("std::vector<int, oneapi::tbb::tbb_allocator<int> >");
     RunParallelVectorTests<double>("std::vector<double, oneapi::tbb::tbb_allocator<double> >");
 }
@@ -382,7 +382,7 @@ void RunAssignmentAndCopyConstructorTests() {
     // REMARK("Running assignment and copy constructor tests:\n");
     RunAssignmentAndCopyConstructorTest<int>("int");
     RunAssignmentAndCopyConstructorTest<double>("double");
-    RunAssignmentAndCopyConstructorTest<minimal>("minimal");
+    RunAssignmentAndCopyConstructorTest<minimalCombinable>("minimalCombinable");
 }
 
 void RunMoveSemanticsForStateTrackableObjectTest() {

--- a/test/tbb/test_eh_flow_graph.cpp
+++ b/test/tbb/test_eh_flow_graph.cpp
@@ -288,14 +288,6 @@ struct sequencer_body {
     }
 };
 
-// --------- body to compare the "priorities" of objects for priority_queue_node  five priority levels 0-4.
-template<class T>
-struct myLess {
-    bool operator()(const T &t1, const T &t2) {
-        return (int(t1) % 5) < (int(t2) % 5);
-    }
-};
-
 // --------- type for < comparison in priority_queue_node.
 template<class ItemType>
 struct less_body {

--- a/test/tbb/test_enumerable_thread_specific.cpp
+++ b/test/tbb/test_enumerable_thread_specific.cpp
@@ -54,15 +54,15 @@ const int VALID_NUMBER_OF_KEYS = 100;
 //! A minimal class that occupies N bytes.
 /** Defines default and copy constructor, and allows implicit operator&. Hides operator=. */
 template<size_t N = tbb::detail::max_nfs_size>
-class minimal: utils::NoAssign {
+class minimalN: utils::NoAssign {
 private:
     int my_value;
     bool is_constructed;
     char pad[N-sizeof(int) - sizeof(bool)];
 public:
-    minimal() : utils::NoAssign(), my_value(0) { ++construction_counter; is_constructed = true; }
-    minimal( const minimal &m ) : utils::NoAssign(), my_value(m.my_value) { ++construction_counter; is_constructed = true; }
-    ~minimal() { ++destruction_counter; REQUIRE(is_constructed); is_constructed = false; }
+    minimalN() : utils::NoAssign(), my_value(0) { ++construction_counter; is_constructed = true; }
+    minimalN( const minimalN&m ) : utils::NoAssign(), my_value(m.my_value) { ++construction_counter; is_constructed = true; }
+    ~minimalN() { ++destruction_counter; REQUIRE(is_constructed); is_constructed = false; }
     void set_value( const int i ) { REQUIRE(is_constructed); my_value = i; }
     int value( ) const { REQUIRE(is_constructed); return my_value; }
 };
@@ -88,13 +88,13 @@ const T& check_alignment(const T& t, const char *aname) {
 }
 
 //
-// A helper class that simplifies writing the tests since minimal does not
+// A helper class that simplifies writing the tests since minimalN does not
 // define = or + operators.
 //
 
 const size_t line_size = tbb::detail::max_nfs_size;
 
-typedef tbb::enumerable_thread_specific<minimal<line_size> > flogged_ets;
+typedef tbb::enumerable_thread_specific<minimalN<line_size> > flogged_ets;
 
 class set_body {
     flogged_ets *a;


### PR DESCRIPTION
### Description 
Doxygen does not support multiple definition of the classes with the same name. Renamed a several classes in the test to avoid name conflicts.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@leeks-int 

### Other information
