### PR TITLE
Fix overeager stripping of compile flag

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -18,7 +18,7 @@ macro(tbb_remove_compile_flag flag)
     set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY COMPILE_OPTIONS ${_tbb_compile_options})
     unset(_tbb_compile_options)
     if (CMAKE_CXX_FLAGS)
-        string(REGEX REPLACE ${flag} "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+        string(REGEX REPLACE "(^|[ \t\r\n]+)${flag}($|[ \t\r\n]+)" " " CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
     endif()
 endmacro()
 


### PR DESCRIPTION
### Description 
The existing regex strips all occurrences of the given string from `${CMAKE_CXX_FLAGS}`, regardless of whether it is just a substring of a flag. For instance, `-Werror=format-security` gets truncated to `=format-security`.

The new regex proposed in this pull request makes sure that only whole words get replaced.

- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
