### PR TITLE
Improve task arena test coverage

### DIFF
--- a/test/conformance/conformance_task_arena.cpp
+++ b/test/conformance/conformance_task_arena.cpp
@@ -50,6 +50,8 @@ TEST_CASE("Arena interfaces") {
         //! Attach interface
         oneapi::tbb::task_arena attached_arena{oneapi::tbb::task_arena::attach()};
         CHECK(attached_arena.is_active());
+        oneapi::tbb::task_arena attached_arena2{oneapi::tbb::attach()};
+        CHECK(attached_arena2.is_active());
     });
     while (!done) {
         utils::yield();

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -626,6 +626,11 @@ struct TestAttachBody : utils::NoAssign {
         tbb::task_arena arena2{tbb::task_arena::attach()};
         ValidateAttachedArena( arena2, true, default_threads, 1 );
 
+        tbb::task_arena arena3;
+        arena3.initialize(tbb::attach());
+        ValidateAttachedArena( arena3, true, default_threads, 1 );
+
+
         // attach to another task_arena
         arena.initialize( maxthread, std::min(maxthread,idx) );
         arena.execute( *this );


### PR DESCRIPTION
Signed-off-by: Alexei Katranov <alexei.katranov@intel.com>

### Description 
#566 added two functions into `task_arena` class that are not covered with tests:
```
tbb::detail::d1::task_arena::initialize(d1::attach)
tbb::detail::d1::task_arena::task_arena(d1::attach)
```
Cover these functions with tests.

- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and for some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@anton-potapov 

### Other information
