### PR TITLE
making `task_group_context::is_proxy` race free

### DIFF
--- a/include/oneapi/tbb/task_group.h
+++ b/include/oneapi/tbb/task_group.h
@@ -31,7 +31,6 @@
 #include "profiling.h"
 
 #include <type_traits>
-#include <limits>
 
 #if _MSC_VER && !defined(__INTEL_COMPILER)
     // Suppress warning: structure was padded due to alignment specifier
@@ -184,8 +183,7 @@ private:
 
     //! Versioning for run-time checks and behavioral traits of the context.
     enum class task_group_context_version : std::uint8_t {
-        gold_2021U1   = 0,      // version of task_group_context released in oneTBB 2021.1 GOLD
-        proxy_support = 1       // backward compatible support for 'this' context to act as a proxy
+        unused = 1       // ensure that new versions, if any, will not clash with previously used ones
     };
     task_group_context_version my_version;
 
@@ -264,14 +262,14 @@ private:
     ];
 
     task_group_context(context_traits t, string_resource_index name)
-        : my_version{task_group_context_version::proxy_support}, my_name{name}
+        : my_version{task_group_context_version::unused}, my_name{name}
     {
         my_traits = t; // GCC4.8 issues warning list initialization for bitset (missing-field-initializers)
         r1::initialize(*this);
     }
 
     task_group_context(task_group_context* actual_context)
-        : my_version{task_group_context_version::proxy_support}
+        : my_version{task_group_context_version::unused}
         , my_lifetime_state{lifetime_state::proxy}
         , my_actual_context{actual_context}
     {

--- a/include/oneapi/tbb/task_group.h
+++ b/include/oneapi/tbb/task_group.h
@@ -213,7 +213,7 @@ private:
         isolated,
         bound,
         dead,
-        proxy = std::numeric_limits<std::underlying_type<lifetime_state>::type>::max()
+        proxy = std::uint8_t(-1)
     };
 
     //! The synchronization machine state to manage lifetime.

--- a/src/tbb/task_dispatcher.h
+++ b/src/tbb/task_dispatcher.h
@@ -300,8 +300,8 @@ d1::task* task_dispatcher::local_wait_for_all(d1::task* t, Waiter& waiter ) {
                 while (t != nullptr) {
                     assert_task_valid(t);
                     assert_pointer_valid</*alignment = */alignof(void*)>(ed.context);
-                    __TBB_ASSERT(ed.context->my_lifetime_state == d1::task_group_context::lifetime_state::bound ||
-                        ed.context->my_lifetime_state == d1::task_group_context::lifetime_state::isolated, nullptr);
+                    __TBB_ASSERT(ed.context->my_state == d1::task_group_context::state::bound ||
+                        ed.context->my_state == d1::task_group_context::state::isolated, nullptr);
                     __TBB_ASSERT(m_thread_data->my_inbox.is_idle_state(false), nullptr);
                     __TBB_ASSERT(task_accessor::is_resume_task(*t) || isolation == no_isolation || isolation == ed.isolation, nullptr);
                     // Check premature leave

--- a/src/tbb/task_group_context.cpp
+++ b/src/tbb/task_group_context.cpp
@@ -55,7 +55,7 @@ void task_group_context_impl::destroy(d1::task_group_context& ctx) {
     __TBB_ASSERT(!is_poisoned(ctx.my_context_list), nullptr);
     
     if (ctx.my_context_list != nullptr) {
-        __TBB_ASSERT(ctx.my_lifetime_state.load(std::memory_order_relaxed) == d1::task_group_context::lifetime_state::bound, nullptr);
+        __TBB_ASSERT(ctx.my_state.load(std::memory_order_relaxed) == d1::task_group_context::state::bound, nullptr);
         // The owner can be destroyed at any moment. Access the associate data with caution.
         ctx.my_context_list->remove(ctx.my_node);
     }
@@ -78,7 +78,7 @@ void task_group_context_impl::destroy(d1::task_group_context& ctx) {
     poison_pointer(ctx.my_exception);
     poison_pointer(ctx.my_itt_caller);
 
-    ctx.my_lifetime_state.store(d1::task_group_context::lifetime_state::dead, std::memory_order_release);
+    ctx.my_state.store(d1::task_group_context::state::dead, std::memory_order_release);
 }
 
 void task_group_context_impl::initialize(d1::task_group_context& ctx) {
@@ -88,9 +88,9 @@ void task_group_context_impl::initialize(d1::task_group_context& ctx) {
     ctx.my_node.my_prev_node = &ctx.my_node;
     ctx.my_cpu_ctl_env = 0;
     ctx.my_cancellation_requested = 0;
-    ctx.my_state.store(0, std::memory_order_relaxed);
+    ctx.my_may_have_children.store(0, std::memory_order_relaxed);
     // Set the created state to bound at the first usage.
-    ctx.my_lifetime_state.store(d1::task_group_context::lifetime_state::created, std::memory_order_relaxed);
+    ctx.my_state.store(d1::task_group_context::state::created, std::memory_order_relaxed);
     ctx.my_parent = nullptr;
     ctx.my_context_list = nullptr;
     ctx.my_exception.store(nullptr, std::memory_order_relaxed);
@@ -112,7 +112,7 @@ void task_group_context_impl::register_with(d1::task_group_context& ctx, thread_
 
 void task_group_context_impl::bind_to_impl(d1::task_group_context& ctx, thread_data* td) {
     __TBB_ASSERT(!is_poisoned(ctx.my_context_list), nullptr);
-    __TBB_ASSERT(ctx.my_lifetime_state.load(std::memory_order_relaxed) == d1::task_group_context::lifetime_state::locked, "The context can be bound only under the lock.");
+    __TBB_ASSERT(ctx.my_state.load(std::memory_order_relaxed) == d1::task_group_context::state::locked, "The context can be bound only under the lock.");
     __TBB_ASSERT(!ctx.my_parent, "Parent is set before initial binding");
 
     ctx.my_parent = td->my_task_dispatcher->m_execute_data_ext.context;
@@ -123,8 +123,8 @@ void task_group_context_impl::bind_to_impl(d1::task_group_context& ctx, thread_d
         copy_fp_settings(ctx, *ctx.my_parent);
 
     // Condition below prevents unnecessary thrashing parent context's cache line
-    if (ctx.my_parent->my_state.load(std::memory_order_relaxed) != d1::task_group_context::may_have_children) {
-        ctx.my_parent->my_state.store(d1::task_group_context::may_have_children, std::memory_order_relaxed); // full fence is below
+    if (ctx.my_parent->my_may_have_children.load(std::memory_order_relaxed) != d1::task_group_context::may_have_children) {
+        ctx.my_parent->my_may_have_children.store(d1::task_group_context::may_have_children, std::memory_order_relaxed); // full fence is below
     }
     if (ctx.my_parent->my_parent) {
         // Even if this context were made accessible for state change propagation
@@ -164,38 +164,38 @@ void task_group_context_impl::bind_to_impl(d1::task_group_context& ctx, thread_d
 
 void task_group_context_impl::bind_to(d1::task_group_context& ctx, thread_data* td) {
     __TBB_ASSERT(!is_poisoned(ctx.my_context_list), nullptr);
-    d1::task_group_context::lifetime_state state = ctx.my_lifetime_state.load(std::memory_order_acquire);
-    if (state <= d1::task_group_context::lifetime_state::locked) {
-        if (state == d1::task_group_context::lifetime_state::created &&
+    d1::task_group_context::state state = ctx.my_state.load(std::memory_order_acquire);
+    if (state <= d1::task_group_context::state::locked) {
+        if (state == d1::task_group_context::state::created &&
 #if defined(__INTEL_COMPILER) && __INTEL_COMPILER <= 1910
-            ((std::atomic<typename std::underlying_type<d1::task_group_context::lifetime_state>::type>&)ctx.my_lifetime_state).compare_exchange_strong(
-                (typename std::underlying_type<d1::task_group_context::lifetime_state>::type&)state,
-                (typename std::underlying_type<d1::task_group_context::lifetime_state>::type)d1::task_group_context::lifetime_state::locked)
+            ((std::atomic<typename std::underlying_type<d1::task_group_context::state>::type>&)ctx.my_state).compare_exchange_strong(
+                (typename std::underlying_type<d1::task_group_context::state>::type&)state,
+                (typename std::underlying_type<d1::task_group_context::state>::type)d1::task_group_context::state::locked)
 #else
-            ctx.my_lifetime_state.compare_exchange_strong(state, d1::task_group_context::lifetime_state::locked)
+            ctx.my_state.compare_exchange_strong(state, d1::task_group_context::state::locked)
 #endif
             ) {
             // If we are in the outermost task dispatch loop of an external thread, then
             // there is nothing to bind this context to, and we skip the binding part
             // treating the context as isolated.
             __TBB_ASSERT(td->my_task_dispatcher->m_execute_data_ext.context != nullptr, nullptr);
-            d1::task_group_context::lifetime_state release_state{};
+            d1::task_group_context::state release_state{};
             if (td->my_task_dispatcher->m_execute_data_ext.context == td->my_arena->my_default_ctx || !ctx.my_traits.bound) {
                 if (!ctx.my_traits.fp_settings) {
                     copy_fp_settings(ctx, *td->my_arena->my_default_ctx);
                 }
-                release_state = d1::task_group_context::lifetime_state::isolated;
+                release_state = d1::task_group_context::state::isolated;
             } else {
                 bind_to_impl(ctx, td);
-                release_state = d1::task_group_context::lifetime_state::bound;
+                release_state = d1::task_group_context::state::bound;
             }
             ITT_STACK_CREATE(ctx.my_itt_caller);
-            ctx.my_lifetime_state.store(release_state, std::memory_order_release);
+            ctx.my_state.store(release_state, std::memory_order_release);
         }
-        spin_wait_while_eq(ctx.my_lifetime_state, d1::task_group_context::lifetime_state::locked);
+        spin_wait_while_eq(ctx.my_state, d1::task_group_context::state::locked);
     }
-    __TBB_ASSERT(ctx.my_lifetime_state.load(std::memory_order_relaxed) != d1::task_group_context::lifetime_state::created, nullptr);
-    __TBB_ASSERT(ctx.my_lifetime_state.load(std::memory_order_relaxed) != d1::task_group_context::lifetime_state::locked, nullptr);
+    __TBB_ASSERT(ctx.my_state.load(std::memory_order_relaxed) != d1::task_group_context::state::created, nullptr);
+    __TBB_ASSERT(ctx.my_state.load(std::memory_order_relaxed) != d1::task_group_context::state::locked, nullptr);
 }
 
 template <typename T>
@@ -243,7 +243,7 @@ void thread_data::propagate_task_group_state(std::atomic<T> d1::task_group_conte
 
 template <typename T>
 bool market::propagate_task_group_state(std::atomic<T> d1::task_group_context::* mptr_state, d1::task_group_context& src, T new_state) {
-    if (src.my_state.load(std::memory_order_relaxed) != d1::task_group_context::may_have_children)
+    if (src.my_may_have_children.load(std::memory_order_relaxed) != d1::task_group_context::may_have_children)
         return true;
     // The whole propagation algorithm is under the lock in order to ensure correctness
     // in case of concurrent state changes at the different levels of the context tree.


### PR DESCRIPTION
### Description 
Current implementation of `task_group_context::is_proxy` has a race on `task_group_context::my_traits` member:
- it is read by the `is_proxy()` member during task spawning
- it is written to in `bind_to()` function on first task spawning

This patch  proposes using special value of `task_group_context::my_lifetime_state` (which is `std::atomic`) instead of `task_group_context::my_traits` to avoid the race


- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change
- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@alexey-katranov @aleksei-fedotov 

### Other information
