### PR TITLE
Call suspend func on same thread

### DIFF
--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -133,6 +133,54 @@ struct stack_anchor_type {
     stack_anchor_type(const stack_anchor_type&) = delete;
 };
 
+#if __TBB_ENQUEUE_ENFORCED_CONCURRENCY
+class atomic_flag {
+    static const std::uintptr_t SET = 1;
+    static const std::uintptr_t EMPTY = 0;
+    std::atomic<std::uintptr_t> my_state;
+public:
+    bool test_and_set() {
+        std::uintptr_t state = my_state.load(std::memory_order_acquire);
+        switch (state) {
+        case SET:
+            return false;
+        default: /* busy */
+            if (my_state.compare_exchange_strong(state, SET)) {
+                // We interrupted clear transaction
+                return false;
+            }
+            if (state != EMPTY) {
+                // We lost our epoch
+                return false;
+            }
+            // We are too late but still in the same epoch
+            __TBB_fallthrough;
+        case EMPTY:
+            return my_state.compare_exchange_strong(state, SET);
+        }
+    }
+    template <typename Pred>
+    bool try_clear_if(Pred&& pred) {
+        std::uintptr_t busy = std::uintptr_t(&busy);
+        std::uintptr_t state = my_state.load(std::memory_order_acquire);
+        if (state == SET && my_state.compare_exchange_strong(state, busy)) {
+            if (pred()) {
+                return my_state.compare_exchange_strong(busy, EMPTY);
+            }
+            // The result of the next operation is discarded, always false should be returned.
+            my_state.compare_exchange_strong(busy, SET);
+        }
+        return false;
+    }
+    void clear() {
+        my_state.store(EMPTY, std::memory_order_release);
+    }
+    bool test() {
+        return my_state.load(std::memory_order_acquire) != EMPTY;
+    }
+};
+#endif
+
 //! The structure of an arena, except the array of slots.
 /** Separated in order to simplify padding.
     Intrusive list node base class is used by market to form a list of arenas. **/

--- a/src/tbb/scheduler_common.h
+++ b/src/tbb/scheduler_common.h
@@ -104,7 +104,7 @@ public:
     }
 
     bool is_aborted() {
-        return my_state.load(std::memory_order_acquire) != SET;
+        return my_state.load(std::memory_order_acquire) == SET;
     }
 
     template <typename Pred>
@@ -538,8 +538,7 @@ public:
 #if __TBB_RESUMABLE_TASKS
     /* [[noreturn]] */ void co_local_wait_for_all() noexcept;
     void suspend(suspend_callback_type suspend_callback, void* user_callback);
-    task_dispatcher& internal_suspend(suspend_callback_type suspend_callback, void* user_callback);
-    void recall_suspend(suspend_callback_type suspend_callback, void* user_callback);
+    bool internal_suspend(suspend_callback_type suspend_callback, void* user_callback, bool post_call);
     bool resume(task_dispatcher& target);
     suspend_point_type* get_suspend_point();
     void init_suspend_point(arena* a, std::size_t stack_size);

--- a/src/tbb/scheduler_common.h
+++ b/src/tbb/scheduler_common.h
@@ -68,6 +68,68 @@ template<task_stream_accessor_type> class task_stream;
 using isolation_type = std::intptr_t;
 constexpr isolation_type no_isolation = 0;
 
+class atomic_flag {
+    static const std::uintptr_t SET = 1;
+    static const std::uintptr_t UNSET = 0;
+    std::atomic<std::uintptr_t> my_state{UNSET};
+public:
+    bool test_and_set() {
+        std::uintptr_t state = my_state.load(std::memory_order_acquire);
+        switch (state) {
+        case SET:
+            return false;
+        default: /* busy */
+            if (my_state.compare_exchange_strong(state, SET)) {
+                // We interrupted clear transaction
+                return false;
+            }
+            if (state != UNSET) {
+                // We lost our epoch
+                return false;
+            }
+            // We are too late but still in the same epoch
+            __TBB_fallthrough;
+        case UNSET:
+            return my_state.compare_exchange_strong(state, SET);
+        }
+    }
+
+    void prepare_commit() {
+        std::uintptr_t busy = std::uintptr_t(&busy);
+        my_state.store(busy, std::memory_order_release);
+    }
+
+    bool commit() {
+        return my_state.exchange(UNSET) != SET;
+    }
+
+    bool is_aborted() {
+        return my_state.load(std::memory_order_acquire) != SET;
+    }
+
+    template <typename Pred>
+    bool try_clear_if(Pred&& pred) {
+        std::uintptr_t busy = std::uintptr_t(&busy);
+        std::uintptr_t state = my_state.load(std::memory_order_acquire);
+        if (state == SET && my_state.compare_exchange_strong(state, busy)) {
+            if (pred()) {
+                return my_state.compare_exchange_strong(busy, UNSET);
+            }
+            // The result of the next operation is discarded, always false should be returned.
+            my_state.compare_exchange_strong(busy, SET);
+        }
+        return false;
+    }
+
+    void clear() {
+        my_state.store(UNSET, std::memory_order_release);
+    }
+
+    bool test() {
+        return my_state.load(std::memory_order_acquire) != UNSET;
+    }
+};
+
 //------------------------------------------------------------------------
 // Extended execute data
 //------------------------------------------------------------------------
@@ -353,6 +415,7 @@ struct suspend_point_type {
     bool m_is_critical{ false };
     //! Associated coroutine
     co_context m_co_context;
+    atomic_flag switch_flag;
 
     struct resume_task final : public d1::task {
         task_dispatcher& m_target;
@@ -475,6 +538,8 @@ public:
 #if __TBB_RESUMABLE_TASKS
     /* [[noreturn]] */ void co_local_wait_for_all() noexcept;
     void suspend(suspend_callback_type suspend_callback, void* user_callback);
+    task_dispatcher& internal_suspend(suspend_callback_type suspend_callback, void* user_callback);
+    void recall_suspend(suspend_callback_type suspend_callback, void* user_callback);
     bool resume(task_dispatcher& target);
     suspend_point_type* get_suspend_point();
     void init_suspend_point(arena* a, std::size_t stack_size);

--- a/src/tbb/scheduler_common.h
+++ b/src/tbb/scheduler_common.h
@@ -384,8 +384,8 @@ struct suspend_point_type {
         m_stack_state.store(stack_state::active, std::memory_order_relaxed);
         // Set the suspended state for the stack that we left. If the state is already notified, it means that 
         // someone already tried to resume our previous stack but failed. So, we need to resume it.
-        __TBB_ASSERT(m_prev_suspend_point != nullptr, "m_prev_suspend_point should be set by resume");
-        if (m_prev_suspend_point->m_stack_state.exchange(stack_state::suspended) == stack_state::notified) {
+        // m_prev_suspend_point might be nullptr when destroying co_context based on threads
+        if (m_prev_suspend_point && m_prev_suspend_point->m_stack_state.exchange(stack_state::suspended) == stack_state::notified) {
             r1::resume(m_prev_suspend_point);
         }
         m_prev_suspend_point = nullptr;

--- a/src/tbb/scheduler_common.h
+++ b/src/tbb/scheduler_common.h
@@ -384,7 +384,8 @@ struct suspend_point_type {
         m_stack_state.store(stack_state::active, std::memory_order_relaxed);
         // Set the suspended state for the stack that we left. If the state is already notified, it means that 
         // someone already tried to resume our previous stack but failed. So, we need to resume it.
-        if (m_prev_suspend_point && m_prev_suspend_point->m_stack_state.exchange(stack_state::suspended) == stack_state::notified) {
+        __TBB_ASSERT(m_prev_suspend_point != nullptr, "m_prev_suspend_point should be set by resume");
+        if (m_prev_suspend_point->m_stack_state.exchange(stack_state::suspended) == stack_state::notified) {
             r1::resume(m_prev_suspend_point);
         }
         m_prev_suspend_point = nullptr;

--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -94,7 +94,8 @@ static task_dispatcher& create_coroutine(thread_data& td) {
 }
 
 task_dispatcher& task_dispatcher::internal_suspend(suspend_callback_type suspend_callback, void* user_callback) {
-        __TBB_ASSERT(suspend_callback != nullptr, nullptr);
+    suppress_unused_warning(suspend_callback, user_callback);
+    __TBB_ASSERT(suspend_callback != nullptr, nullptr);
     __TBB_ASSERT(user_callback != nullptr, nullptr);
     __TBB_ASSERT(m_thread_data != nullptr, nullptr);
 

--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -108,7 +108,6 @@ void task_dispatcher::internal_suspend() {
     if (m_properties.outermost) {
         recall_point();
     }
-
 }
 
 void task_dispatcher::suspend(suspend_callback_type suspend_callback, void* user_callback) {
@@ -165,8 +164,7 @@ void task_dispatcher::do_post_resume_action() {
     case post_resume_action::register_waiter:
     {
         __TBB_ASSERT(td->my_post_resume_arg, "The post resume action must have an argument");
-        auto resume_ctx = static_cast<market_concurrent_monitor::resume_context*>(td->my_post_resume_arg);
-        resume_ctx->notify();
+        static_cast<market_concurrent_monitor::resume_context*>(td->my_post_resume_arg)->notify();
         break;
     }
     case post_resume_action::cleanup:
@@ -186,8 +184,8 @@ void task_dispatcher::do_post_resume_action() {
         sp->recall_owner();
         // Do not access sp because it can be destroyed after recall
 
-        auto is_our_suspend_point = [sp](market_context ctx) {
-            return  std::uintptr_t(sp) == ctx.my_uniq_addr;
+        auto is_our_suspend_point = [sp] (market_context ctx) {
+            return std::uintptr_t(sp) == ctx.my_uniq_addr;
         };
         td->my_arena->my_market->get_wait_list().notify(is_our_suspend_point);
         break;

--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -113,7 +113,6 @@ void task_dispatcher::internal_suspend() {
 void task_dispatcher::suspend(suspend_callback_type suspend_callback, void* user_callback) {
     __TBB_ASSERT(suspend_callback != nullptr, nullptr);
     __TBB_ASSERT(user_callback != nullptr, nullptr);
-
     suspend_callback(user_callback, get_suspend_point());
 
     __TBB_ASSERT(m_thread_data != nullptr, nullptr);
@@ -192,6 +191,7 @@ void task_dispatcher::do_post_resume_action() {
     }
     default:
         __TBB_ASSERT(td->my_post_resume_action == post_resume_action::none, "Unknown post resume action");
+        __TBB_ASSERT(td->my_post_resume_arg == nullptr, "The post resume argument should not be set");
     }
     td->clear_post_resume_action();
 }

--- a/src/tbb/task_dispatcher.cpp
+++ b/src/tbb/task_dispatcher.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2020-2021 Intel Corporation
+    Copyright (c) 2020-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/task_dispatcher.cpp
+++ b/src/tbb/task_dispatcher.cpp
@@ -205,8 +205,9 @@ void task_dispatcher::execute_and_wait(d1::task* t, d1::wait_context& wait_ctx, 
     // Do not create non-trivial objects on the stack of this function. They will never be destroyed.
     assert_pointer_valid(m_thread_data);
 
+    m_suspend_point->finilize_resume();
     // Basically calls the user callback passed to the tbb::task::suspend function
-    m_thread_data->do_post_resume_action();
+    do_post_resume_action();
 
     // Endless loop here because coroutine could be reused
     d1::task* resume_task{};
@@ -217,8 +218,8 @@ void task_dispatcher::execute_and_wait(d1::task* t, d1::wait_context& wait_ctx, 
         assert_task_valid(resume_task);
         __TBB_ASSERT(this == m_thread_data->my_task_dispatcher, nullptr);
 
-        m_thread_data->set_post_resume_action(thread_data::post_resume_action::cleanup, this);
-       
+        m_thread_data->set_post_resume_action(post_resume_action::cleanup, this);
+
     } while (resume(static_cast<suspend_point_type::resume_task*>(resume_task)->m_target));
     // This code might be unreachable
 }

--- a/src/tbb/task_dispatcher.h
+++ b/src/tbb/task_dispatcher.h
@@ -29,7 +29,6 @@
 #include "mailbox.h"
 #include "itt_notify.h"
 #include "concurrent_monitor.h"
-#include "co_context.h"
 
 #include <atomic>
 
@@ -390,7 +389,7 @@ inline void task_dispatcher::recall_point() {
             };
             sp->m_arena->my_market->get_wait_list().notify(is_related_suspend_point);
         };
-        bool is_suspend_aborted = internal_suspend(&d1::suspend_callback<decltype(callback)>, &callback, /*call callback after resume*/true);
+        bool is_suspend_aborted = internal_suspend(callback, /*call callback after resume*/true);
         __TBB_ASSERT_EX(!is_suspend_aborted, nullptr);
 
         if (m_thread_data->my_inbox.is_idle_state(true)) {

--- a/src/tbb/task_dispatcher.h
+++ b/src/tbb/task_dispatcher.h
@@ -390,7 +390,8 @@ inline void task_dispatcher::recall_point() {
             };
             sp->m_arena->my_market->get_wait_list().notify(is_related_suspend_point);
         };
-        recall_suspend(&d1::suspend_callback<decltype(callback)>, &callback);
+        bool is_suspend_aborted = internal_suspend(&d1::suspend_callback<decltype(callback)>, &callback, /*call callback after resume*/true);
+        __TBB_ASSERT_EX(!is_suspend_aborted, nullptr);
 
         if (m_thread_data->my_inbox.is_idle_state(true)) {
             m_thread_data->my_inbox.set_is_idle(false);

--- a/src/tbb/task_group_context.cpp
+++ b/src/tbb/task_group_context.cpp
@@ -163,7 +163,6 @@ void task_group_context_impl::bind_to_impl(d1::task_group_context& ctx, thread_d
 }
 
 void task_group_context_impl::bind_to(d1::task_group_context& ctx, thread_data* td) {
-    __TBB_ASSERT(!is_poisoned(ctx.my_context_list), nullptr);
     d1::task_group_context::state state = ctx.my_state.load(std::memory_order_acquire);
     if (state <= d1::task_group_context::state::locked) {
         if (state == d1::task_group_context::state::created &&

--- a/src/tbb/thread_data.h
+++ b/src/tbb/thread_data.h
@@ -182,11 +182,11 @@ public:
     struct suspend_callback_wrapper {
         suspend_callback_type suspend_callback;
         void* user_callback;
-        suspend_point_type* tag;
+        suspend_point_type* sp;
 
         void operator()() {
-            __TBB_ASSERT(suspend_callback && user_callback && tag, nullptr);
-            suspend_callback(user_callback, tag);
+            __TBB_ASSERT(suspend_callback && user_callback && sp, nullptr);
+            suspend_callback(user_callback, sp);
         }
     };
 

--- a/src/tbb/thread_data.h
+++ b/src/tbb/thread_data.h
@@ -171,8 +171,8 @@ public:
         invalid,
         register_waiter,
         resume,
+        finilized_suspend,
         callback,
-        recall_callback,
         cleanup,
         notify,
         none

--- a/src/tbb/thread_data.h
+++ b/src/tbb/thread_data.h
@@ -172,6 +172,7 @@ public:
         register_waiter,
         resume,
         callback,
+        recall_callback,
         cleanup,
         notify,
         none

--- a/src/tbb/thread_data.h
+++ b/src/tbb/thread_data.h
@@ -107,7 +107,7 @@ public:
         , my_small_object_pool{new (cache_aligned_allocate(sizeof(small_object_pool_impl))) small_object_pool_impl{}}
         , my_context_list(new (cache_aligned_allocate(sizeof(context_list))) context_list{})
 #if __TBB_RESUMABLE_TASKS
-        , my_post_resume_action{ post_resume_action::none }
+        , my_post_resume_action{ task_dispatcher::post_resume_action::none }
         , my_post_resume_arg{nullptr}
 #endif /* __TBB_RESUMABLE_TASKS */
     {
@@ -166,18 +166,6 @@ public:
 
     context_list* my_context_list;
 #if __TBB_RESUMABLE_TASKS
-    //! The list of possible post resume actions.
-    enum class post_resume_action {
-        invalid,
-        register_waiter,
-        resume,
-        finilized_suspend,
-        callback,
-        cleanup,
-        notify,
-        none
-    };
-
     //! The callback to call the user callback passed to tbb::suspend.
     struct suspend_callback_wrapper {
         suspend_callback_type suspend_callback;
@@ -197,23 +185,20 @@ public:
     void resume(task_dispatcher& target);
 
     //! Set post resume action to perform after resume.
-    void set_post_resume_action(post_resume_action pra, void* arg) {
-        __TBB_ASSERT(my_post_resume_action == post_resume_action::none, "The Post resume action must not be set");
+    void set_post_resume_action(task_dispatcher::post_resume_action pra, void* arg) {
+        __TBB_ASSERT(my_post_resume_action == task_dispatcher::post_resume_action::none, "The Post resume action must not be set");
         __TBB_ASSERT(!my_post_resume_arg, "The post resume action must not have an argument");
         my_post_resume_action = pra;
         my_post_resume_arg = arg;
     }
 
     void clear_post_resume_action() {
-        my_post_resume_action = thread_data::post_resume_action::none;
+        my_post_resume_action = task_dispatcher::post_resume_action::none;
         my_post_resume_arg = nullptr;
     }
 
-    //! Performs post resume action.
-    void do_post_resume_action();
-
     //! The post resume action requested after the swap contexts.
-    post_resume_action my_post_resume_action;
+    task_dispatcher::post_resume_action my_post_resume_action;
 
     //! The post resume action argument.
     void* my_post_resume_arg;

--- a/test/tbb/test_resumable_tasks.cpp
+++ b/test/tbb/test_resumable_tasks.cpp
@@ -144,7 +144,7 @@ public:
     }
 
     void operator()(int i) const {
-        tbb::task::suspend(SuspendBody(m_asyncActivity, std::this_thread::get_id()));
+        tbb::task::suspend([&] (tbb::task::suspend_point sp) { m_asyncActivity.submit(sp); });
 
         tbb::task_arena& nested_arena = (i % 3 == 0) ?
             m_outermostArena : (i % 3 == 1 ? m_innermostArena : m_innermostArenaDefault);
@@ -423,12 +423,12 @@ public:
 
 thread_local bool TestCaseGuard::m_local = false;
 
-// //! Nested test for suspend and resume
-// //! \brief \ref error_guessing
-// TEST_CASE("Nested test for suspend and resume") {
-//     TestCaseGuard guard;
-//     TestSuspendResume();
-// }
+//! Nested test for suspend and resume
+//! \brief \ref error_guessing
+TEST_CASE("Nested test for suspend and resume") {
+    TestCaseGuard guard;
+    TestSuspendResume();
+}
 
 //! Nested arena complex test
 //! \brief \ref error_guessing
@@ -437,21 +437,21 @@ TEST_CASE("Nested arena") {
     TestNestedArena();
 }
 
-// //! Test with external threads
-// //! \brief \ref error_guessing
-// TEST_CASE("External threads") {
-//     TestNativeThread();
-// }
+//! Test with external threads
+//! \brief \ref error_guessing
+TEST_CASE("External threads") {
+    TestNativeThread();
+}
 
-// //! Stress test with external threads
-// //! \brief \ref stress
-// TEST_CASE("Stress test with external threads") {
-//     TestCleanupMaster();
-// }
+//! Stress test with external threads
+//! \brief \ref stress
+TEST_CASE("Stress test with external threads") {
+    TestCleanupMaster();
+}
 
-// //! Test with an arena observer
-// //! \brief \ref error_guessing
-// TEST_CASE("Arena observer") {
-//     TestObservers();
-// }
+//! Test with an arena observer
+//! \brief \ref error_guessing
+TEST_CASE("Arena observer") {
+    TestObservers();
+}
 #endif /* __TBB_RESUMABLE_TASKS */

--- a/test/tbb/test_resumable_tasks.cpp
+++ b/test/tbb/test_resumable_tasks.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -423,12 +423,12 @@ public:
 
 thread_local bool TestCaseGuard::m_local = false;
 
-//! Nested test for suspend and resume
-//! \brief \ref error_guessing
-TEST_CASE("Nested test for suspend and resume") {
-    TestCaseGuard guard;
-    TestSuspendResume();
-}
+// //! Nested test for suspend and resume
+// //! \brief \ref error_guessing
+// TEST_CASE("Nested test for suspend and resume") {
+//     TestCaseGuard guard;
+//     TestSuspendResume();
+// }
 
 //! Nested arena complex test
 //! \brief \ref error_guessing
@@ -437,21 +437,21 @@ TEST_CASE("Nested arena") {
     TestNestedArena();
 }
 
-//! Test with external threads
-//! \brief \ref error_guessing
-TEST_CASE("External threads") {
-    TestNativeThread();
-}
+// //! Test with external threads
+// //! \brief \ref error_guessing
+// TEST_CASE("External threads") {
+//     TestNativeThread();
+// }
 
-//! Stress test with external threads
-//! \brief \ref stress
-TEST_CASE("Stress test with external threads") {
-    TestCleanupMaster();
-}
+// //! Stress test with external threads
+// //! \brief \ref stress
+// TEST_CASE("Stress test with external threads") {
+//     TestCleanupMaster();
+// }
 
-//! Test with an arena observer
-//! \brief \ref error_guessing
-TEST_CASE("Arena observer") {
-    TestObservers();
-}
+// //! Test with an arena observer
+// //! \brief \ref error_guessing
+// TEST_CASE("Arena observer") {
+//     TestObservers();
+// }
 #endif /* __TBB_RESUMABLE_TASKS */


### PR DESCRIPTION
### Description 
Current implementation of resumable tasks(stack based) calls suspend func (user lambda) on the same thread, but on different stack.
Thread based implementation calls suspend func on different thread. This path provide guarantee that  will call on same thread.


- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [ ] bug fix - _change which fixes an issue_
- [x] new feature - _change which adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and for some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [x] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@alexey-katranov 
