### PR TITLE
Actualize documentation about proportional splitting constructor in Range

### DIFF
--- a/doc/main/tbb_userguide/Advanced_Topic_Other_Kinds_of_Iteration_Spaces.rst
+++ b/doc/main/tbb_userguide/Advanced_Topic_Other_Kinds_of_Iteration_Spaces.rst
@@ -4,15 +4,13 @@ Advanced Topic: Other Kinds of Iteration Spaces
 ===============================================
 
 
-The examples so far have used the class ``blocked_range<T>`` to specify
-ranges. This class is useful in many situations, but it does not fit
-every situation. You can use |full_name|
-to define your own iteration space objects. The object must specify how
-it can be split into subspaces by providing a basic splitting
-constructor, an optional proportional splitting constructor (accompanied
-with a trait value that enables its usage), and two predicate methods.
-If your class is called ``R``, the methods and constructors should be as
-follows:
+The examples so far have used the class ``blocked_range<T>`` to specify ranges.
+This class is useful in many situations, but it does not fit every situation.
+You can use |full_name| to define your own iteration space objects. The object
+must specify how it can be split into subspaces by providing a basic splitting
+constructor, an optional proportional splitting constructor, and two predicate
+methods. If your class is called ``R``, the methods and constructors should be
+as follows:
 
 
 ::
@@ -25,10 +23,8 @@ follows:
        bool is_divisible() const;
        // Splits r into subranges r and *this
        R( R& r, split );
-       // Splits r into subranges r and *this in proportion p
+       // (optional) Splits r into subranges r and *this in proportion p
        R( R& r, proportional_split p );
-       // Allows usage of proportional splitting constructor
-       static const bool is_splittable_in_proportion = true;
        ...
    };
        
@@ -60,9 +56,7 @@ constructor is optional and takes the second argument of type
 that return the values of the proportion. These values should be used to
 split ``r`` accordingly, so that the updated ``r`` corresponds to the
 left part of the proportion, and the constructed object corresponds to
-the right part. The proportional splitting constructor will be used only
-if the static constant ``is_splittable_in_proportion`` is defined in the
-class and assigned the value of ``true``.
+the right part.
 
 
 Both splitting constructors should guarantee that the updated ``r`` part

--- a/test/tbb/test_partitioner.h
+++ b/test/tbb/test_partitioner.h
@@ -481,50 +481,6 @@ public:
     }
 };
 
-/*
- * Possible use cases are:
- * -------------------------------------------------------------------------------------------------------------
- * Range#  is_splittable_in_proportion   Range proportional ctor      Used partitioner          Result Effect
- * -------------------------------------------------------------------------------------------------------------
- *   1           true                       available                proportional             pMN, r(p), part(p)
- * -------------------------------------------------------------------------------------------------------------
- *   2           false                      available                proportional             p11, r(p), part(p)
- * -------------------------------------------------------------------------------------------------------------
- *   3        not defined                   available                proportional             p11, r(p), part(p)
- * -------------------------------------------------------------------------------------------------------------
- *   4           true                     not available              proportional             pMN, r(s), part(p)  *
- * -------------------------------------------------------------------------------------------------------------
- *   5           false                    not available              proportional             p11, r(s), part(p)
- * -------------------------------------------------------------------------------------------------------------
- *   6        not defined                 not available              proportional             p11, r(s), part(p)
- * -------------------------------------------------------------------------------------------------------------
- *   1           true                       available                   simple                s, r(s), part(s)
- * -------------------------------------------------------------------------------------------------------------
- *   2           false                      available                   simple                s, r(s), part(s)
- * -------------------------------------------------------------------------------------------------------------
- *   3        not defined                   available                   simple                s, r(s), part(s)
- * -------------------------------------------------------------------------------------------------------------
- *   4           true                     not available                 simple                s, r(s), part(s)
- * -------------------------------------------------------------------------------------------------------------
- *   5           false                    not available                 simple                s, r(s), part(s)
- * -------------------------------------------------------------------------------------------------------------
- *   6        not defined                 not available                 simple                s, r(s), part(s)
- * -------------------------------------------------------------------------------------------------------------
- *
- * Legend:
- *   proportional - with proportional splits (e.g. affinity_partitioner)
- *   simple  - without proportional splits (e.g. simple_partitioner, auto_partitioner)
- *   pMN     - proportional_split object with proportion M to N is created. (p11 - proportion 1 to 1)
- *   s       - split object is created
- *   r(p)    - range's proportional split constructor is called
- *   r(s)    - range's ordinary split constructor is called
- *   part(p) - partitioner's proportional split constructor is called
- *   part(s) - partitioner's ordinary split constructor is called
- *      *    - incorrect split behavior is possible (e.g. partitioner divides at an arbitrary ratio while
- *             range divides into halves)
- */
-
-
 // proportional_split ctor defined
 class Range1: public SplitConstructorAssertedRange {
 public:


### PR DESCRIPTION
### Description 
Current state of the oneTBB docs about interface for proportional splitting is not 100% correct. They mention `is_splittable_in_proportion` static boolean constant flag, which was actual in the version of TBB library before its revision.

As of oneTBB the library utilizes C++11 features that allows detection of support for proportional splitting in ranges directly. The only left over is in the docs and a comment in the test. So these are cleaned up by this patch.

- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown
