### PR TITLE
CMake: fix ANDROID_STL handling (issue #710)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,7 @@ if (TBB_BENCH)
 endif()
 
 if (ANDROID_PLATFORM)
-    if (${ANDROID_STL} STREQUAL "c++_shared")
+    if ("${ANDROID_STL}" STREQUAL "c++_shared")
         configure_file(
         "${ANDROID_NDK}/sources/cxx-stl/llvm-libc++/libs/${ANDROID_ABI}/libc++_shared.so"
         "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libc++_shared.so"


### PR DESCRIPTION
`ANDROID_STL` variable is optional, it may be empty. `${ANDROID_STL}` should be enclosed in quotation marks.

Reference:
https://developer.android.com/ndk/guides/cmake#android_stl

### Description 
_Add comprehensive description of proposed changes_


Fixes #710

- [ ] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [X] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
