### PR TITLE
Missed part of task_group_exptensions unpreview

### DIFF
--- a/include/oneapi/tbb/task_arena.h
+++ b/include/oneapi/tbb/task_arena.h
@@ -398,12 +398,10 @@ public:
 
     //! Enqueues a task into the arena to process a functor wrapped in task_handle, and immediately returns.
     //! Does not require the calling thread to join the arena
-#if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
     void enqueue(d2::task_handle&& th) {
         initialize();
         d2::enqueue_impl(std::move(th), this);
     }
-#endif //__TBB_PREVIEW_TASK_GROUP_EXTENSIONS
 
     //! Joins the arena and executes a mutable functor, then returns
     //! If not possible to join, wraps the functor into a task, enqueues it and waits for task completion


### PR DESCRIPTION
### Description 
`task_group` exptensions unpreview (#668) for some reason missed this part, so catch up.


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [x] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@alexey-katranov @aleksei-fedotov 

### Other information
