### PR TITLE
Rectifing testing of some preview features controlled by __TBB_CPF_BUILD

### DIFF
--- a/test/tbb/test_scheduler_mix.cpp
+++ b/test/tbb/test_scheduler_mix.cpp
@@ -14,8 +14,6 @@
     limitations under the License.
 */
 
-#define TBB_PREVIEW_TASK_GROUP_EXTENSIONS 1
-
 #include "common/config.h"
 
 #include <oneapi/tbb/task_arena.h>

--- a/test/tbb/test_task_group.cpp
+++ b/test/tbb/test_task_group.cpp
@@ -14,11 +14,6 @@
     limitations under the License.
 */
 
-#if __TBB_CPF_BUILD
-#define TBB_PREVIEW_ISOLATED_TASK_GROUP 1
-#define TBB_PREVIEW_TASK_GROUP_EXTENSIONS 1
-#endif
-
 #include "common/test.h"
 #include "common/utils.h"
 #include "oneapi/tbb/detail/_config.h"


### PR DESCRIPTION
### Description 
Explicit enabling of `task_group` related preview features was removed, in favor of  logic in[ `test/common/config.h`](https://github.com/oneapi-src/oneTBB/blob/ec39c5463d5fbfe01150bcd8cbfe60b5e064d693/test/common/config.h#L20-L45)


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users


### Other information
