### PR TITLE
Fix incorrect resize behavior with first_block

### DIFF
--- a/include/oneapi/tbb/concurrent_vector.h
+++ b/include/oneapi/tbb/concurrent_vector.h
@@ -645,12 +645,10 @@ private:
     }
 
     segment_type nullify_segment( segment_table_type table, size_type segment_index ) {
-        segment_type target_segment{nullptr};
+        segment_type target_segment = table[segment_index].load(std::memory_order_relaxed);
         if (segment_index >= this->my_first_block) {
-            target_segment = table[segment_index].load(std::memory_order_relaxed);
             table[segment_index].store(nullptr, std::memory_order_relaxed);
         } else {
-            target_segment = table[segment_index].load(std::memory_order_relaxed);
             if (segment_index == 0) {
                 for (size_type i = 0; i < this->my_first_block; ++i) {
                     table[i].store(nullptr, std::memory_order_relaxed);

--- a/include/oneapi/tbb/concurrent_vector.h
+++ b/include/oneapi/tbb/concurrent_vector.h
@@ -647,7 +647,8 @@ private:
     segment_type nullify_segment( segment_table_type table, size_type segment_index ) {
         segment_type target_segment{nullptr};
         if (segment_index >= this->my_first_block) {
-            target_segment = table[segment_index].exchange(nullptr);
+            target_segment = table[segment_index].load(std::memory_order_relaxed);
+            table[segment_index].store(nullptr, std::memory_order_relaxed);
         } else {
             target_segment = table[segment_index].load(std::memory_order_relaxed);
             if (segment_index == 0) {

--- a/include/oneapi/tbb/concurrent_vector.h
+++ b/include/oneapi/tbb/concurrent_vector.h
@@ -644,6 +644,22 @@ private:
         }
     }
 
+    segment_type nullify_segment( segment_table_type table, size_type segment_index ) {
+        segment_type target_segment{nullptr};
+        if (segment_index >= this->my_first_block) {
+            target_segment = table[segment_index].exchange(nullptr);
+        } else {
+            target_segment = table[segment_index].load(std::memory_order_relaxed);
+            if (segment_index == 0) {
+                for (size_type i = 0; i < this->my_first_block; ++i) {
+                    table[i].store(nullptr, std::memory_order_relaxed);
+                }
+            }
+        }
+
+        return target_segment;
+    }
+
     void deallocate_segment( segment_type address, segment_index_type seg_index ) {
         segment_element_allocator_type segment_allocator(base_type::get_allocator());
         size_type first_block = this->my_first_block.load(std::memory_order_relaxed);

--- a/include/oneapi/tbb/detail/_concurrent_unordered_base.h
+++ b/include/oneapi/tbb/detail/_concurrent_unordered_base.h
@@ -831,6 +831,10 @@ private:
             return new_segment;
         }
 
+        segment_type nullify_segment( typename base_type::segment_table_type table, size_type segment_index ) {
+            return table[segment_index].exchange(nullptr);
+        }
+
         // deallocate_segment is required by the segment_table base class, but
         // in unordered, it is also necessary to call the destructor during deallocation
         void deallocate_segment( segment_type address, size_type index ) {

--- a/include/oneapi/tbb/detail/_concurrent_unordered_base.h
+++ b/include/oneapi/tbb/detail/_concurrent_unordered_base.h
@@ -832,7 +832,9 @@ private:
         }
 
         segment_type nullify_segment( typename base_type::segment_table_type table, size_type segment_index ) {
-            return table[segment_index].exchange(nullptr);
+            segment_type target_segment = table[segment_index].load(std::memory_order_relaxed);
+            table[segment_index].store(nullptr, std::memory_order_relaxed);
+            return target_segment;
         }
 
         // deallocate_segment is required by the segment_table base class, but

--- a/include/oneapi/tbb/detail/_segment_table.h
+++ b/include/oneapi/tbb/detail/_segment_table.h
@@ -184,9 +184,7 @@ public:
     }
 
     void delete_segment( segment_index_type seg_index ) {
-        segment_type disabled_segment = nullptr;
-        // Set the pointer to the segment to NULL in the table
-        segment_type segment_to_delete = get_table()[seg_index].exchange(disabled_segment);
+        segment_type segment_to_delete = self()->nullify_segment(get_table(), seg_index);
         if (segment_to_delete == segment_allocation_failure_tag) {
             return;
         }

--- a/test/tbb/test_concurrent_vector.cpp
+++ b/test/tbb/test_concurrent_vector.cpp
@@ -711,28 +711,42 @@ TEST_CASE("container_range concept for concurrent_vector ranges") {
 }
 #endif // __TBB_CPP20_CONCEPTS_PRESENT
 
-//! Test concurrent and unsafe operations
+// There was a bug in concurrent_vector that was reproduced when resize marked
+// segment (that owned by my_first_block) as deleted and
+// on segment allocation thread is stuck waiting this segment to be published by other thread that allocated first block.
+//! Testing resize behavior for case when new size lesser than old size.
 //! \brief \ref regression
 TEST_CASE("testing resize on sequantual mode") {
     tbb::concurrent_vector<int> v;
 
     v.resize(382);
+    CHECK(v.size() == 382);
     while (v.size() < 737) {
         v.emplace_back();
     }
+    CHECK(v.size() == 737);
 
     v.resize(27);
+    CHECK(v.size() == 27);
     while (v.size() < 737) {
         v.emplace_back();
     }
+    CHECK(v.size() == 737);
 
     v.resize(1);
+    CHECK(v.size() == 1);
     while (v.size() < 40) {
         v.emplace_back();
     }
+    CHECK(v.size() == 40);
 
     v.resize(2222);
+    CHECK(v.size() == 2222);
     while (v.size() < 4444) {
         v.emplace_back();
     }
+    CHECK(v.size() == 4444);
+
+    v.clear();
+    CHECK(v.size() == 0);
 }

--- a/test/tbb/test_concurrent_vector.cpp
+++ b/test/tbb/test_concurrent_vector.cpp
@@ -710,3 +710,29 @@ TEST_CASE("container_range concept for concurrent_vector ranges") {
     static_assert(test_concepts::container_range<typename tbb::concurrent_vector<int>::const_range_type>);
 }
 #endif // __TBB_CPP20_CONCEPTS_PRESENT
+
+//! Test concurrent and unsafe operations
+//! \brief \ref regression
+TEST_CASE("testing resize on sequantual mode") {
+    tbb::concurrent_vector<int> v;
+
+    v.resize(382);
+    while (v.size() < 737) {
+        v.emplace_back();
+    }
+
+    v.resize(27);
+    while (v.size() < 737) {
+        v.emplace_back();
+    }
+
+    v.resize(1);
+    while (v.size() < 40) {
+        v.emplace_back();
+    }
+
+    v.resize(2222);
+    while (v.size() < 4444) {
+        v.emplace_back();
+    }
+}


### PR DESCRIPTION
### Description 
Fixed `resize` behavior for case when new size lesser than old size. There is a bug in `concurrent_vector` that was reproduced when `resize `marked segment (that owned by `my_first_block`) as deleted ([code](https://github.com/oneapi-src/oneTBB/blob/f1ba69bde9e948594dde5d2d9dd094550bd81099/include/oneapi/tbb/detail/_segment_table.h#L189)) and segment allocation thread is stuck waiting this segment to be published by other thread that allocated first block ([code](https://github.com/oneapi-src/oneTBB/blob/f1ba69bde9e948594dde5d2d9dd094550bd81099/include/oneapi/tbb/concurrent_vector.h#L575)). 

Fixes # - 733
- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and for some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@kboyarinov @anton-potapov 
