### PR TITLE
INSTALL.md: add example for multi-config generators

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -105,18 +105,18 @@ The following example demonstrates how to install oneTBB for multi-configuration
 
 Choose the configuration during the build and install steps:
 ```batch
-REM Do our experiments in C:\temp
-cd C:\temp
+REM Do our experiments in %TMP%
+cd %TMP%
 REM Clone oneTBB repository
 git clone https://github.com/oneapi-src/oneTBB.git
 cd oneTBB
 REM Create binary directory for out-of-source build
 mkdir build && cd build
 REM Configure: customize CMAKE_INSTALL_PREFIX and disable TBB_TEST to avoid tests build
-cmake -DCMAKE_INSTALL_PREFIX=C:\temp\my_installed_onetbb -DTBB_TEST=OFF ..
+cmake -DCMAKE_INSTALL_PREFIX=%TMP%\my_installed_onetbb -DTBB_TEST=OFF ..
 REM Build "release with debug information" configuration 
 cmake --build . --config relwithdebinfo
 REM Install "release with debug information" configuration 
 cmake --install . --config relwithdebinfo
-REM Well done! Your installed oneTBB is in C:\temp\my_installed_onetbb
+REM Well done! Your installed oneTBB is in %TMP%\my_installed_onetbb
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,7 +79,7 @@ cpack
 
 ## Example of Installation
 
-The following example demonstrates how to install oneTBB for single-configuration generators (e.g. GNU Make, Ninja, etc).
+The following example demonstrates how to install oneTBB for single-configuration generators (e.g. GNU Make, Ninja, etc.).
 ```bash
 # Do our experiments in /tmp
 cd /tmp
@@ -97,20 +97,22 @@ cmake --install .
 # Well done! Your installed oneTBB is in /tmp/my_installed_onetbb
 ```
 
-The following example demonstrates how to install oneTBB for multi-configuration generators (e.g. Visual Studio*), you should choose configuration on build and install steps:
+The following example demonstrates how to install oneTBB for multi-configuration generators such as Visual Studio*. 
+
+Choose the configuration during the build and install steps:
 ```batch
 REM Do our experiments in C:\temp
 cd C:\temp
 REM Clone oneTBB repository
 git clone https://github.com/oneapi-src/oneTBB.git
-REM cd oneTBB
+cd oneTBB
 REM Create binary directory for out-of-source build
 mkdir build && cd build
-REM Configure. Customize CMAKE_INSTALL_PREFIX and disable TBB_TEST to avoid tests build
+REM Configure: customize CMAKE_INSTALL_PREFIX and disable TBB_TEST to avoid tests build
 cmake -DCMAKE_INSTALL_PREFIX=C:\temp\my_installed_onetbb -DTBB_TEST=OFF ..
-REM Build configuration "release with debug information"
+REM Build "release with debug information" configuration 
 cmake --build . --config relwithdebinfo
-REM Install configuration "release with debug information"
+REM Install "release with debug information" configuration 
 cmake --install . --config relwithdebinfo
 REM Well done! Your installed oneTBB is in C:\temp\my_installed_onetbb
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,6 +79,8 @@ cpack
 
 ## Example of Installation
 
+### Single-configuration generators
+
 The following example demonstrates how to install oneTBB for single-configuration generators (e.g. GNU Make, Ninja, etc.).
 ```bash
 # Do our experiments in /tmp
@@ -88,7 +90,7 @@ git clone https://github.com/oneapi-src/oneTBB.git
 cd oneTBB
 # Create binary directory for out-of-source build
 mkdir build && cd build
-# Configure. Customize CMAKE_INSTALL_PREFIX and disable TBB_TEST to avoid tests build
+# Configure: customize CMAKE_INSTALL_PREFIX and disable TBB_TEST to avoid tests build
 cmake -DCMAKE_INSTALL_PREFIX=/tmp/my_installed_onetbb -DTBB_TEST=OFF ..
 # Build
 cmake --build .
@@ -96,6 +98,8 @@ cmake --build .
 cmake --install .
 # Well done! Your installed oneTBB is in /tmp/my_installed_onetbb
 ```
+
+### Multi-configuration generators
 
 The following example demonstrates how to install oneTBB for multi-configuration generators such as Visual Studio*. 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,7 +79,7 @@ cpack
 
 ## Example of Installation
 
-The following example demonstrates how to install oneTBB.
+The following example demonstrates how to install oneTBB for single-configuration generators (e.g. GNU Make, Ninja, etc).
 ```bash
 # Do our experiments in /tmp
 cd /tmp
@@ -95,4 +95,22 @@ cmake --build .
 # Install
 cmake --install .
 # Well done! Your installed oneTBB is in /tmp/my_installed_onetbb
+```
+
+The following example demonstrates how to install oneTBB for multi-configuration generators (e.g. Visual Studio*), you should choose configuration on build and install steps:
+```batch
+REM Do our experiments in C:\temp
+cd C:\temp
+REM Clone oneTBB repository
+git clone https://github.com/oneapi-src/oneTBB.git
+REM cd oneTBB
+REM Create binary directory for out-of-source build
+mkdir build && cd build
+REM Configure. Customize CMAKE_INSTALL_PREFIX and disable TBB_TEST to avoid tests build
+cmake -DCMAKE_INSTALL_PREFIX=C:\temp\my_installed_onetbb -DTBB_TEST=OFF ..
+REM Build configuration "release with debug information"
+cmake --build . --config relwithdebinfo
+REM Install configuration "release with debug information"
+cmake --install . --config relwithdebinfo
+REM Well done! Your installed oneTBB is in C:\temp\my_installed_onetbb
 ```


### PR DESCRIPTION
Signed-off-by: Veprev, Alexey <alexey.veprev@intel.com>

### Description 
_Add comprehensive description of proposed changes_

Inspired by #708. Multi-config generators have some differences on build/install steps.

Fixes # - _issue number(s) if exists_

- [X] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [ ] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [X] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

@zheltovs @alexandraepan @omalyshe 

### Other information
