### PR TITLE
Fix incorrect synchronization in private server

### DIFF
--- a/src/tbb/private_server.cpp
+++ b/src/tbb/private_server.cpp
@@ -278,6 +278,8 @@ void private_worker::run() noexcept {
             // Prepare to wait
             my_thread_monitor.prepare_wait(c);
             // Check/set the invariant for sleeping
+            // We need memory_order_seq_cst to enforce ordering with prepare_wait
+            // (note that a store in prepare_wait should be with memory_order_seq_cst as well)
             if( my_state.load(std::memory_order_seq_cst)!=st_quit && my_server.try_insert_in_asleep_list(*this) ) {
                 my_thread_monitor.commit_wait(c);
                 __TBB_ASSERT( my_state==st_quit || !my_next, "Thread monitor missed a spurious wakeup?" );

--- a/src/tbb/private_server.cpp
+++ b/src/tbb/private_server.cpp
@@ -53,8 +53,6 @@ private:
         st_starting,
         //! Associated thread is doing normal life sequence.
         st_normal,
-        //! Associated thread is going to sleep on monitor.
-        st_sleeping,
         //! Associated thread has ended normal life sequence and promises to never touch *this again.
         st_quit
     };
@@ -85,14 +83,14 @@ private:
     //! Actions executed by the associated thread
     void run() noexcept;
 
-    //! Send to sleep thread on associated monitor
-    void send_to_sleep();
-
     //! Wake up associated thread (or launch a thread if there is none)
     void wake_or_launch();
 
     //! Called by a thread (usually not the associated thread) to commence termination.
-    void start_shutdown();
+    state_t start_shutdown();
+
+    //! Called by a thread (usually not the associated thread) to finish termination.
+    void finish_shutdown(private_worker::state_t prev_state);
 
     static __RML_DECL_THREAD_ROUTINE thread_routine( void* arg );
 
@@ -189,9 +187,22 @@ public:
     }
 
     void request_close_connection( bool /*exiting*/ ) override {
-        for( std::size_t i=0; i<my_n_thread; ++i )
-            my_thread_array[i].start_shutdown();
+        private_worker::state_t* workers_state = tbb::cache_aligned_allocator<private_worker::state_t>().allocate(my_n_thread);
+
+        {
+            // Lock ability to insert in a sleep list
+            asleep_list_mutex_type::scoped_lock lock(my_asleep_list_mutex);
+            for (std::size_t i = 0; i < my_n_thread; ++i) {
+                workers_state[i] = my_thread_array[i].start_shutdown();
+            }
+        }
+
+        for (std::size_t i = 0; i < my_n_thread; ++i) {
+            my_thread_array[i].finish_shutdown(workers_state[i]);
+        }
         remove_server_ref();
+
+        tbb::cache_aligned_allocator<private_worker::state_t>().deallocate(workers_state, my_n_thread);
     }
 
     void yield() override { d0::yield(); }
@@ -237,7 +248,7 @@ void private_worker::release_handle(thread_handle handle, bool join) {
         thread_monitor::detach_thread(handle);
 }
 
-void private_worker::start_shutdown() {
+private_worker::state_t private_worker::start_shutdown() {
     // The state can be transferred only in one direction: st_init -> st_starting -> st_normal.
     // So we do not need more than three CAS attempts.
     state_t expected_state = my_state.load(std::memory_order_relaxed);
@@ -251,42 +262,25 @@ void private_worker::start_shutdown() {
         }
     }
 
-    if (expected_state == st_normal || expected_state == st_sleeping || expected_state == st_starting) {
+    return expected_state;
+}
+
+
+void private_worker::finish_shutdown(private_worker::state_t prev_state) {
+    if (prev_state == st_normal || prev_state == st_starting) {
         // May have invalidated invariant for sleeping, so wake up the thread.
         // Note that the notify() here occurs without maintaining invariants for my_slack.
         // It does not matter, because my_state==st_quit overrides checking of my_slack.
-        if (expected_state == st_sleeping) {
-            my_thread_monitor.notify();
-        }
+        my_thread_monitor.notify();
         // Do not need release handle in st_init state,
         // because in this case the thread wasn't started yet.
         // For st_starting release is done at launch site.
-        if (expected_state == st_normal || expected_state == st_sleeping) {
+        if (prev_state == private_worker::st_normal) {
             release_handle(my_handle, governor::does_client_join_workers(my_client));
         }
-    } else if( expected_state==st_init ) {
+    } else if (prev_state == st_init) {
         // Perform action that otherwise would be performed by associated thread when it quits.
         my_server.remove_server_ref();
-    }
-}
-
-void private_worker::send_to_sleep() {
-
-    thread_monitor::cookie c;
-    my_thread_monitor.prepare_wait(c);
-
-    state_t expected = st_normal;
-    if (my_state.compare_exchange_strong(expected, st_sleeping) && my_server.try_insert_in_asleep_list(*this)) {
-        my_thread_monitor.commit_wait(c);
-        __TBB_ASSERT(my_state.load(std::memory_order_relaxed) == st_quit || !my_next, "Thread monitor missed a spurious wakeup?");
-        my_server.propagate_chain_reaction();
-    } else {
-        my_thread_monitor.cancel_wait();
-    }
-
-    expected = my_state.load(std::memory_order_acquire);
-    if (expected == st_sleeping) {
-        my_state.compare_exchange_strong(expected, st_normal);
     }
 }
 
@@ -302,8 +296,18 @@ void private_worker::run() noexcept {
         if( my_server.my_slack.load(std::memory_order_acquire)>=0 ) {
             my_client.process(j);
         } else {
-            send_to_sleep();
-            __TBB_ASSERT(my_state.load(std::memory_order_relaxed) != st_sleeping, nullptr);
+            thread_monitor::cookie c;
+            // Prepare to wait
+            my_thread_monitor.prepare_wait(c);
+            // Check/set the invariant for sleeping
+            if( my_state.load(std::memory_order_acquire)!=st_quit && my_server.try_insert_in_asleep_list(*this) ) {
+                my_thread_monitor.commit_wait(c);
+                __TBB_ASSERT( my_state==st_quit || !my_next, "Thread monitor missed a spurious wakeup?" );
+                my_server.propagate_chain_reaction();
+            } else {
+                // Invariant broken
+                my_thread_monitor.cancel_wait();
+            }
         }
     }
     my_client.cleanup(j);


### PR DESCRIPTION
Signed-off-by: pavelkumbrasev <pavel.kumbrasev@intel.com>

### Description 

Patch fixes incorrect happens-before between worker thread and finalize.
There was data race between commit_wait on worker thread and thread that calls finalize -> start_shutdown for worker thread.
Because there was no happens-before shutdowning thread reads incorrect private_worker data and that leads to hang on join() of private_worker.

Current patch fixes test_global_control for [#771 issue](https://github.com/oneapi-src/oneTBB/issues/711).

- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@alexey-katranov @phprus @anton-potapov 

### Other information
