### PR TITLE
CMake: delete tbb_gen_vars

### DIFF
--- a/src/tbbbind/CMakeLists.txt
+++ b/src/tbbbind/CMakeLists.txt
@@ -90,9 +90,6 @@ function(tbbbind_build TBBBIND_NAME REQUIRED_HWLOC_TARGET)
 
     tbb_install_target(${TBBBIND_NAME})
 
-    if (COMMAND tbb_gen_vars)
-        tbb_gen_vars(${TBBBIND_NAME})
-    endif()
 endfunction()
 
 if (NOT DEFINED HWLOC_TARGET_EXPLICITLY_DEFINED AND TARGET PkgConfig::HWLOC)


### PR DESCRIPTION
Signed-off-by: Aleksey Oralov <alexey.oralov@intel.com>

### Description 
Duplication of vars generation in tbbbind may conflict during the concurrent build.

#469 was applied earlier to resolve the conflict, but in some cases it doesn't help: configure_file creates temporary file before creating final output file, conflict happens in concurrent creation of temporary file.

Fixes #
Conflict during the concurrent build.

- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add respective label(s) to PR if you have permissions_

- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
