### PR TITLE
Fix race in `conformance_task_arena`

### DIFF
--- a/test/common/utils_concurrency_limit.h
+++ b/test/common/utils_concurrency_limit.h
@@ -257,7 +257,9 @@ public:
         is_pinned = true;
     }
 
-    ~pinning_observer() { }
+    ~pinning_observer() {
+        observe(false);
+    }
 };
 
 #if __unix__

--- a/test/conformance/conformance_task_arena.cpp
+++ b/test/conformance/conformance_task_arena.cpp
@@ -86,6 +86,10 @@ public:
         observe(true); // activate the observer
     }
 
+    ~conformance_observer() {
+        observe(false);
+    }
+
     void on_scheduler_entry(bool) override {
         is_entry_called.store(true, std::memory_order_relaxed);
     }

--- a/test/tbb/test_task.cpp
+++ b/test/tbb/test_task.cpp
@@ -799,7 +799,6 @@ TEST_CASE("Test with priority inversion") {
     for (std::size_t i = 0; i < thread_number - 1; ++i) {
         high_priority_threads[i].join();
     }
-    obsr.observe(false);
 }
 
 // Explicit test for raii_guard move ctor because of copy elision optimization

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -138,6 +138,7 @@ public:
         observe(true);
     }
     ~ArenaObserver () {
+        observe(false);
         CHECK_MESSAGE(!old_id.local(), "inconsistent observer state");
     }
 };
@@ -173,6 +174,9 @@ void TestConcurrentArenasFunc(int idx) {
         LocalObserver() : tbb::task_scheduler_observer() { observe(true); }
         LocalObserver(tbb::task_arena& a) : tbb::task_scheduler_observer(a) {
             observe(true);
+        }
+        ~LocalObserver() {
+            observe(false);
         }
     };
 
@@ -508,6 +512,9 @@ struct TestMandatoryConcurrencyObserver : public tbb::task_scheduler_observer {
         : tbb::task_scheduler_observer(a), m_barrier(barrier) {
         observe(true);
     }
+    ~TestMandatoryConcurrencyObserver() {
+        observe(false);
+    }
     void on_scheduler_exit(bool worker) override {
         if (worker) {
             m_barrier.wait();
@@ -545,7 +552,6 @@ void TestMandatoryConcurrency() {
                 exit_barrier.wait();
             } while (num_tasks < n_threads * 5);
         }
-        observer.observe(false);
     });
 }
 
@@ -1344,6 +1350,9 @@ struct MyObserver: public tbb::task_scheduler_observer {
         my_failure_counter(failure_counter), my_counter(counter), m_barrier(barrier) {
         observe(true);
     }
+    ~MyObserver(){
+        observe(false);
+    }
     void on_scheduler_entry(bool worker) override {
         if (worker) {
             ++my_counter;
@@ -1549,6 +1558,10 @@ public:
         , myMaxConcurrency(maxConcurrency)
         , myNumReservedSlots(numReservedSlots) {
         observe(true);
+    }
+
+    ~simple_observer(){
+        observe(false);
     }
 
     friend bool operator<(const simple_observer& lhs, const simple_observer& rhs) {


### PR DESCRIPTION
### Description 
`conformance_observer` does not call `observe(false)` in it's destructor (nor the test does call it explicitly). "ThreadSanitizer – data race detection in practice" has a chapter "6.3.10 Race on vptr" which describes almost exactly this case.

Solution is to call observe(false) in the derived observer destructor to avoid the race

Signed-off-by: Anton Potapov <anton.potapov@intel.com>


Fixes #717 

- [x] - git commit message contains appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change
- [x] bug fix - _change which fixes an issue_
- [ ] new feature - _change which adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and for some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@alexey-katranov, @pavelkumbrasev 

### Other information
