### PR TITLE
Check if getcontext() exists to enable resumable tasks

### DIFF
--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -268,7 +268,7 @@
     #define __TBB_CPP20_COMPARISONS_PRESENT __TBB_CPP20_PRESENT
 #endif
 
-#define __TBB_RESUMABLE_TASKS                           (!__TBB_WIN8UI_SUPPORT && !__ANDROID__ && !__QNXNTO__)
+#define __TBB_RESUMABLE_TASKS                           (!__TBB_WIN8UI_SUPPORT && !__ANDROID__ && !__QNXNTO__ && (!__linux__ || __GLIBC__))
 
 /* This macro marks incomplete code or comments describing ideas which are considered for the future.
  * See also for plain comment with TODO and FIXME marks for small improvement opportunities.


### PR DESCRIPTION
getcontext/setcontext functions are deprecated in the recent versions
of POSIX and may not exist. musl libc does not provide these functions.

Signed-off-by: Rui Ueyama <ruiu@cs.stanford.edu>

### Description 
Currently, if you build libtbb.so with musl libc, the resulting libtbb.so is not loadable because `getcontext` and `setcontext` are undefined. These functions are deprecated POSIX functions and because of that reason, musl indeed doesn't define them.

This patch disables resumable tasks so that libtbb.so built with musl become usable.

### Type of change

Bug fix though the bug has not been filed.

### Tests

Not needed

### Documentation

Not needed

### Breaks backward compatibility

No

### Other information

Related to https://github.com/rui314/mold/issues/281 and https://github.com/rui314/mold/issues/295