### PR TITLE
Improve code readability in private_worker

### DIFF
--- a/src/tbb/private_server.cpp
+++ b/src/tbb/private_server.cpp
@@ -233,10 +233,18 @@ void private_worker::release_handle(thread_handle handle, bool join) {
 }
 
 void private_worker::start_shutdown() {
-    state_t expected_state = my_state.load(std::memory_order_acquire);
-    __TBB_ASSERT( expected_state!=st_quit, NULL );
-
-    while( !my_state.compare_exchange_strong( expected_state, st_quit ) );
+    // The state can be transfered only in one direction: st_init -> st_starting -> st_normal.
+    // So we do not need more than three CAS attempts.
+    state_t expected_state = my_state.load(std::memory_order_relaxed);
+    __TBB_ASSERT(expected_state != st_quit, "The quit state is expected to be set only once");
+    if (!my_state.compare_exchange_strong(expected_state, st_quit)) {
+        __TBB_ASSERT(expected_state == st_starting || expected_state == st_normal, "We failed once so the init state is not expected");
+        if (!my_state.compare_exchange_strong(expected_state, st_quit)) {
+            __TBB_ASSERT(expected_state == st_normal, "We failed twice so only the normal state is expected");
+            bool res = my_state.compare_exchange_strong(expected_state, st_quit);
+            __TBB_ASSERT_EX(res, "We cannot fail in the normal state");
+        }
+    }
 
     if( expected_state==st_normal || expected_state==st_starting ) {
         // May have invalidated invariant for sleeping, so wake up the thread.

--- a/src/tbb/private_server.cpp
+++ b/src/tbb/private_server.cpp
@@ -233,7 +233,7 @@ void private_worker::release_handle(thread_handle handle, bool join) {
 }
 
 void private_worker::start_shutdown() {
-    // The state can be transfered only in one direction: st_init -> st_starting -> st_normal.
+    // The state can be transferred only in one direction: st_init -> st_starting -> st_normal.
     // So we do not need more than three CAS attempts.
     state_t expected_state = my_state.load(std::memory_order_relaxed);
     __TBB_ASSERT(expected_state != st_quit, "The quit state is expected to be set only once");


### PR DESCRIPTION
### Description 

Refactored shutdown path in `private_worker` to improve code readability.

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
