### PR TITLE
Simplify private worker synchronization mechanism

### DIFF
--- a/python/rml/ipc_server.cpp
+++ b/python/rml/ipc_server.cpp
@@ -562,26 +562,21 @@ void ipc_worker::run() {
     // complications in handle management on Windows.
 
     ::rml::job& j = *my_client.create_one_job();
-    // TODO: reconsider if memory_order_acquire is required here and other places
     state_t state = my_state.load(std::memory_order_acquire);
     while( state!=st_quit && state!=st_stop ) {
         if( my_server.my_slack>=0 ) {
             my_client.process(j);
         } else {
-            // Prepare to wait
-            my_thread_monitor.prepare_wait();
             // Check/set the invariant for sleeping
             state = my_state.load(std::memory_order_seq_cst);
             if( state!=st_quit && state!=st_stop && my_server.try_insert_in_asleep_list(*this) ) {
                 if( my_server.my_n_thread > 1 ) my_server.release_active_thread();
-                my_thread_monitor.commit_wait();
+                my_thread_monitor.wait();
                 my_server.propagate_chain_reaction();
-            } else {
-                // Invariant broken
-                my_thread_monitor.cancel_wait();
             }
         }
-        state = my_state.load(std::memory_order_acquire);
+        // memory_order_seq_cst to be strictly ordered after thread_monitor::wait
+        state = my_state.load(std::memory_order_seq_cst);
     }
     my_client.cleanup(j);
 
@@ -663,7 +658,8 @@ void ipc_waker::run() {
     // which would create race with the launching thread and
     // complications in handle management on Windows.
 
-    while( my_state.load(std::memory_order_acquire)!=st_quit ) {
+    // memory_order_seq_cst to be strictly ordered after thread_monitor::wait on the next iteration
+    while( my_state.load(std::memory_order_seq_cst)!=st_quit ) {
         bool have_to_sleep = false;
         if( my_server.my_slack.load(std::memory_order_acquire)>0 ) {
             if( my_server.wait_active_thread() ) {
@@ -678,14 +674,9 @@ void ipc_waker::run() {
             have_to_sleep = true;
         }
         if( have_to_sleep ) {
-            // Prepare to wait
-            my_thread_monitor.prepare_wait();
             // Check/set the invariant for sleeping
-            if( my_state.load(std::memory_order_seq_cst)!=st_quit && my_server.my_slack.load(std::memory_order_acquire)<0 ) {
-                my_thread_monitor.commit_wait();
-            } else {
-                // Invariant broken
-                my_thread_monitor.cancel_wait();
+            if( my_server.my_slack.load(std::memory_order_acquire)<0 ) {
+                my_thread_monitor.wait();
             }
         }
     }

--- a/python/rml/ipc_server.cpp
+++ b/python/rml/ipc_server.cpp
@@ -562,19 +562,19 @@ void ipc_worker::run() {
     // complications in handle management on Windows.
 
     ::rml::job& j = *my_client.create_one_job();
+    // TODO: reconsider if memory_order_acquire is requred here and other places
     state_t state = my_state.load(std::memory_order_acquire);
     while( state!=st_quit && state!=st_stop ) {
         if( my_server.my_slack>=0 ) {
             my_client.process(j);
         } else {
-            ipc_thread_monitor::cookie c;
             // Prepare to wait
-            my_thread_monitor.prepare_wait(c);
+            my_thread_monitor.prepare_wait();
             // Check/set the invariant for sleeping
-            state = my_state.load(std::memory_order_acquire);
+            state = my_state.load(std::memory_order_seq_cst);
             if( state!=st_quit && state!=st_stop && my_server.try_insert_in_asleep_list(*this) ) {
                 if( my_server.my_n_thread > 1 ) my_server.release_active_thread();
-                my_thread_monitor.commit_wait(c);
+                my_thread_monitor.commit_wait();
                 my_server.propagate_chain_reaction();
             } else {
                 // Invariant broken
@@ -678,12 +678,11 @@ void ipc_waker::run() {
             have_to_sleep = true;
         }
         if( have_to_sleep ) {
-            ipc_thread_monitor::cookie c;
             // Prepare to wait
-            my_thread_monitor.prepare_wait(c);
+            my_thread_monitor.prepare_wait();
             // Check/set the invariant for sleeping
-            if( my_state.load(std::memory_order_acquire)!=st_quit && my_server.my_slack.load(std::memory_order_acquire)<0 ) {
-                my_thread_monitor.commit_wait(c);
+            if( my_state.load(std::memory_order_seq_cst)!=st_quit && my_server.my_slack.load(std::memory_order_acquire)<0 ) {
+                my_thread_monitor.commit_wait();
             } else {
                 // Invariant broken
                 my_thread_monitor.cancel_wait();

--- a/python/rml/ipc_server.cpp
+++ b/python/rml/ipc_server.cpp
@@ -562,7 +562,7 @@ void ipc_worker::run() {
     // complications in handle management on Windows.
 
     ::rml::job& j = *my_client.create_one_job();
-    // TODO: reconsider if memory_order_acquire is requred here and other places
+    // TODO: reconsider if memory_order_acquire is required here and other places
     state_t state = my_state.load(std::memory_order_acquire);
     while( state!=st_quit && state!=st_stop ) {
         if( my_server.my_slack>=0 ) {

--- a/src/tbb/private_server.cpp
+++ b/src/tbb/private_server.cpp
@@ -275,14 +275,13 @@ void private_worker::run() noexcept {
         if( my_server.my_slack.load(std::memory_order_acquire)>=0 ) {
             my_client.process(j);
         } else {
-            thread_monitor::cookie c;
             // Prepare to wait
-            my_thread_monitor.prepare_wait(c);
+            my_thread_monitor.prepare_wait();
             // Check/set the invariant for sleeping
             // We need memory_order_seq_cst to enforce ordering with prepare_wait
             // (note that a store in prepare_wait should be with memory_order_seq_cst as well)
             if( my_state.load(std::memory_order_seq_cst)!=st_quit && my_server.try_insert_in_asleep_list(*this) ) {
-                my_thread_monitor.commit_wait(c);
+                my_thread_monitor.commit_wait();
                 __TBB_ASSERT( my_state==st_quit || !my_next, "Thread monitor missed a spurious wakeup?" );
                 my_server.propagate_chain_reaction();
             } else {

--- a/src/tbb/private_server.cpp
+++ b/src/tbb/private_server.cpp
@@ -234,7 +234,7 @@ void private_worker::release_handle(thread_handle handle, bool join) {
 }
 
 void private_worker::start_shutdown() {
-    __TBB_ASSERT(my_state.load(std::memory_order_relaxed) != st_quit, "The thread has alredy been requested to quit");
+    __TBB_ASSERT(my_state.load(std::memory_order_relaxed) != st_quit, "The quit state is expected to be set only once");
 
     // memory_order_acquire to acquire my_handle
     state_t prev_state = my_state.exchange(st_quit, std::memory_order_acquire);

--- a/src/tbb/rml_thread_monitor.h
+++ b/src/tbb/rml_thread_monitor.h
@@ -228,7 +228,7 @@ inline void thread_monitor::prepare_wait() {
         my_sema.P(); // does not really wait on the semaphore
     }
     // std::memory_order_seq_cst is required because prepare_wait
-    // should be ordered before futher operations (that are suppose to
+    // should be ordered before further operations (that are suppose to
     // use memory_order_seq_cst where required)
     in_wait.store( true, std::memory_order_seq_cst );
 }

--- a/src/tbb/rml_thread_monitor.h
+++ b/src/tbb/rml_thread_monitor.h
@@ -216,7 +216,7 @@ inline void thread_monitor::notify() {
 inline void thread_monitor::wait() {
     my_sema.P();
     // memory_order_seq_cst is required here to be ordered with
-    // futher loads checking shutdown state
+    // further load checking shutdown state
     my_notified.store(false, std::memory_order_seq_cst);
 }
 


### PR DESCRIPTION
### Description 
 - Simplify `thread_monitor` implementation because we do not need `epoch`-based protection
 - Simplify private worker shutdown mechanism
 - Fix IPC server (missed part of #739)

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
