### PR TITLE
Code coverage for overwrite_node

### DIFF
--- a/test/tbb/test_overwrite_node.cpp
+++ b/test/tbb/test_overwrite_node.cpp
@@ -230,3 +230,33 @@ TEST_CASE("try_release"){
 
     CHECK_MESSAGE ((on.try_release()== true), "try_release should return true");
 }
+
+template< typename Type >
+struct fake_receiver : public tbb::flow::receiver<Type>, utils::NoAssign {
+    tbb::flow::graph& my_graph;
+
+    fake_receiver(tbb::flow::graph& g) : my_graph(g) {}
+
+    tbb::detail::d1::graph_task* try_put_task(const Type&) override {
+        return nullptr;
+    }
+
+    tbb::flow::graph& graph_reference() const override {
+        return my_graph;
+    }
+};
+
+//! Test for cancel register_predecessor_task
+//! \brief \ref error_guessing
+TEST_CASE("Cancel register_predecessor_task") {
+    tbb::flow::graph g;
+
+    fake_receiver<size_t> r(g);
+    oneapi::tbb::flow::overwrite_node<size_t> node(g);
+
+    node.try_put(1);
+    tbb::flow::make_edge(node, r);
+
+    g.cancel();
+    g.wait_for_all();
+}

--- a/test/tbb/test_overwrite_node.cpp
+++ b/test/tbb/test_overwrite_node.cpp
@@ -231,31 +231,16 @@ TEST_CASE("try_release"){
     CHECK_MESSAGE ((on.try_release()== true), "try_release should return true");
 }
 
-template< typename Type >
-struct fake_receiver : public tbb::flow::receiver<Type>, utils::NoAssign {
-    tbb::flow::graph& my_graph;
-
-    fake_receiver(tbb::flow::graph& g) : my_graph(g) {}
-
-    tbb::detail::d1::graph_task* try_put_task(const Type&) override {
-        return nullptr;
-    }
-
-    tbb::flow::graph& graph_reference() const override {
-        return my_graph;
-    }
-};
-
 //! Test for cancel register_predecessor_task
 //! \brief \ref error_guessing
 TEST_CASE("Cancel register_predecessor_task") {
     tbb::flow::graph g;
 
-    fake_receiver<size_t> r(g);
     oneapi::tbb::flow::overwrite_node<size_t> node(g);
+    tbb::flow::join_node<std::tuple<size_t>, tbb::flow::reserving> j_node(g);
 
     node.try_put(1);
-    tbb::flow::make_edge(node, r);
+    tbb::flow::make_edge(node, tbb::flow::input_port<0>(j_node));
 
     g.cancel();
     g.wait_for_all();

--- a/test/tbb/test_overwrite_node.cpp
+++ b/test/tbb/test_overwrite_node.cpp
@@ -251,6 +251,6 @@ TEST_CASE("Cancel register_predecessor_task") {
     // overwrite_node successor and spanw register_predecessor_task
     tbb::flow::make_edge(node, tbb::flow::input_port<0>(j_node));
 
-    // Wait for cancellation spawned tasks
+    // Wait for cancellation of spawned tasks
     g.wait_for_all();
 }

--- a/test/tbb/test_overwrite_node.cpp
+++ b/test/tbb/test_overwrite_node.cpp
@@ -239,16 +239,18 @@ TEST_CASE("Cancel register_predecessor_task") {
     // calling cancel method of spawned tasks
     g.cancel();
 
-    // To spanw register_predecessor_task internal buffer of overwrite_node
+    // To spawn register_predecessor_task internal buffer of overwrite_node
     // should be valid and successor should failed during putting an item to it
     oneapi::tbb::flow::overwrite_node<size_t> node(g);
-    // join_node always fails during putting an item to it
+    // Reserving join_node always fails during putting an item to it
     tbb::flow::join_node<std::tuple<size_t>, tbb::flow::reserving> j_node(g);
 
     // Make internal buffer of overwrite_node valid
     node.try_put(1);
-    // Make edge between overwrite_node and join_node, register join_node as
-    // overwrite_node successor and spanw register_predecessor_task
+    // Making an edge attempts pushing an item to join_node
+    // that immediately fails and tries to reverse an edge into PULL state
+    // by spawning register_predecessor_task, which will be cancelled
+    // during execution
     tbb::flow::make_edge(node, tbb::flow::input_port<0>(j_node));
 
     // Wait for cancellation of spawned tasks


### PR DESCRIPTION
### Description 
Test for coverage cancel function of `oneapi::tbb::flow::overwrite_node::register_predecessor_task`

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@aleksei-fedotov

### Other information
