### PR TITLE
Fix external thread termination

### DIFF
--- a/src/tbb/governor.cpp
+++ b/src/tbb/governor.cpp
@@ -196,8 +196,7 @@ void governor::init_external_thread() {
     stack_size = a.my_market->worker_stack_size();
     std::uintptr_t stack_base = get_stack_base(stack_size);
     task_dispatcher& task_disp = td.my_arena_slot->default_task_dispatcher();
-    task_disp.set_stealing_threshold(calculate_stealing_threshold(stack_base, stack_size));
-    td.attach_task_dispatcher(task_disp);
+    td.enter_task_dispatcher(task_disp, calculate_stealing_threshold(stack_base, stack_size));
 
     td.my_arena_slot->occupy();
     a.my_market->add_external_thread(td);
@@ -234,7 +233,7 @@ void governor::auto_terminate(void* tls) {
 
             a->my_observers.notify_exit_observers(td->my_last_observer, td->my_is_worker);
 
-            td->detach_task_dispatcher();
+            td->leave_task_dispatcher();
             td->my_arena_slot->release();
             // Release an arena
             a->on_thread_leaving<arena::ref_external>();

--- a/src/tbb/governor.cpp
+++ b/src/tbb/governor.cpp
@@ -220,6 +220,12 @@ void governor::auto_terminate(void* tls) {
             arena* a = td->my_arena;
             market* m = a->my_market;
 
+            // If the TLS slot is already cleared by OS or underlying concurrency
+            // runtime, restore its value to properly clean up arena
+            if (!is_thread_data_set(td)) {
+                set_thread_data(*td);
+            }
+
             a->my_observers.notify_exit_observers(td->my_last_observer, td->my_is_worker);
 
             td->my_task_dispatcher->m_stealing_threshold = 0;

--- a/src/tbb/governor.h
+++ b/src/tbb/governor.h
@@ -118,11 +118,9 @@ public:
         return theTLS.get();
     }
 
-#if TBB_USE_ASSERT
     static bool is_thread_data_set(thread_data* td) {
         return theTLS.get() == td;
     }
-#endif
 
     //! Undo automatic initialization if necessary; call when a thread exits.
     static void terminate_external_thread() {

--- a/src/tbb/thread_data.h
+++ b/src/tbb/thread_data.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2020-2021 Intel Corporation
+    Copyright (c) 2020-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/thread_data.h
+++ b/src/tbb/thread_data.h
@@ -132,7 +132,8 @@ public:
     bool is_attached_to(arena*);
     void attach_task_dispatcher(task_dispatcher&);
     void detach_task_dispatcher();
-    void context_list_cleanup();
+    void enter_task_dispatcher(task_dispatcher& task_disp, std::uintptr_t stealing_threshold);
+    void leave_task_dispatcher();
     template <typename T>
     void propagate_task_group_state(std::atomic<T> d1::task_group_context::* mptr_state, d1::task_group_context& src, T new_state);
 
@@ -245,6 +246,16 @@ inline void thread_data::detach_task_dispatcher() {
     __TBB_ASSERT(my_task_dispatcher->m_thread_data == this, nullptr);
     my_task_dispatcher->m_thread_data = nullptr;
     my_task_dispatcher = nullptr;
+}
+
+inline void thread_data::enter_task_dispatcher(task_dispatcher& task_disp, std::uintptr_t stealing_threshold) {
+    task_disp.set_stealing_threshold(stealing_threshold);
+    attach_task_dispatcher(task_disp);
+}
+
+inline void thread_data::leave_task_dispatcher() {
+    my_task_dispatcher->set_stealing_threshold(0);
+    detach_task_dispatcher();
 }
 
 } // namespace r1

--- a/test/tbb/test_scheduler_mix.cpp
+++ b/test/tbb/test_scheduler_mix.cpp
@@ -650,7 +650,7 @@ void global_actor() {
 TEST_CASE("Stress test with mixing functionality") {
     // TODO add thread recreation
     // TODO: Enable statistics
-    // tbb::task_scheduler_handle handle = tbb::task_scheduler_handle::get();
+    tbb::task_scheduler_handle handle{ tbb::attach{} };
 
     const std::size_t numExtraThreads = 16;
     utils::SpinBarrier startBarrier{numExtraThreads};
@@ -661,7 +661,7 @@ TEST_CASE("Stress test with mixing functionality") {
 
     arenaTable.shutdown();
 
-    // tbb::finalize(handle, std::nothrow_t{});
+    tbb::finalize(handle);
 
     // gStats.report();
 }


### PR DESCRIPTION
### Description 
During the external thread termination, it might require to access thread data that is set to null by Linux (and some other OSes).  So, set the thread data back to the tls to avoid reinitialization during termination, e.g. to avoid similar callstacks:

```cpp
---> #0  tbb::detail::r1::governor::init_external_thread () at /mnt/c/github/oneTBB/src/tbb/governor.cpp:190
#1  0x00007f31d07fab65 in tbb::detail::r1::governor::get_thread_data () at /mnt/c/github/oneTBB/src/tbb/governor.h:107
#2  0x00007f31d085b431 in tbb::detail::r1::deallocate (allocator=..., ptr=0x7f31ccbaf200, number_of_bytes=128) at /mnt/c/github/oneTBB/src/tbb/small_object_pool.cpp:75
#3  0x00007f31d08033db in tbb::detail::d1::small_object_allocator::deallocate<tbb::detail::r1::task_proxy> (this=0x7f31cc1fd8c0, ptr=0x7f31ccbaf200)
    at /mnt/c/github/oneTBB/src/tbb/../../include/oneapi/tbb/detail/../detail/_small_object_pool.h:98
#4  0x00007f31d0803126 in tbb::detail::d1::small_object_allocator::delete_object<tbb::detail::r1::task_proxy> (this=0x7f31ccbaf260, object=0x7f31ccbaf200)
    at /mnt/c/github/oneTBB/src/tbb/../../include/oneapi/tbb/detail/../detail/_small_object_pool.h:82
#5  0x00007f31d07f4bae in tbb::detail::r1::mail_outbox::drain (this=0x7f31ccbaae00) at /mnt/c/github/oneTBB/src/tbb/mailbox.h:193
#6  0x00007f31d07f441b in tbb::detail::r1::arena::free_arena (this=0x7f31ccbaaf00) at /mnt/c/github/oneTBB/src/tbb/arena.cpp:247
#7  0x00007f31d07fbc0c in tbb::detail::r1::arena::on_thread_leaving<1u> (this=0x7f31ccbaaf00) at /mnt/c/github/oneTBB/src/tbb/arena.h:572
---> #8  0x00007f31d0821b3d in tbb::detail::r1::governor::auto_terminate (tls=0x7f31ccbafe00) at /mnt/c/github/oneTBB/src/tbb/governor.cpp:240
#9  0x00007f31d04365a1 in __nptl_deallocate_tsd () at pthread_create.c:301
#10 0x00007f31d043762a in __nptl_deallocate_tsd () at pthread_create.c:256
#11 start_thread (arg=<optimized out>) at pthread_create.c:488
#12 0x00007f31d0336293 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

It might lead to memory leaks when user create and destroys a lot of threads working with oneTBB. Additionally, blocking terminate might throw an unexpected exception that further wait is unsafe.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
