### PR TITLE
CI: replace testing on Windows Server 2016 + VS2017 with Server 2022 + VS2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,22 +190,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2016
-            generator: Visual Studio 15 2017
+          - os: windows-2019
+            generator: Visual Studio 16 2019
             c_compiler: cl
             cxx_compiler: cl
             std: 14
             build_type: relwithdebinfo
             preview: 'ON'
-            job_name: windows_cl2017_cxx14_relwithdebinfo_preview=ON
-          - os: windows-2019
-            generator: Visual Studio 16 2019
+            job_name: windows_cl2019_cxx14_relwithdebinfo_preview=ON
+          - os: windows-2022
+            generator: Visual Studio 17 2022
             c_compiler: cl
             cxx_compiler: cl
             std: 17
             build_type: relwithdebinfo
             preview: 'OFF'
-            job_name: windows_cl2019_cxx17_relwithdebinfo_preview=OFF
+            job_name: windows_cl2022_cxx17_relwithdebinfo_preview=OFF
     steps:
       - uses: actions/checkout@v2
       - name: Run testing
@@ -290,22 +290,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2016
-            generator: Visual Studio 15 2017
+          - os: windows-2019
+            generator: Visual Studio 16 2019
             c_compiler: cl
             cxx_compiler: cl
             std: 14
             build_type: relwithdebinfo
             preview: 'ON'
-            job_name: examples_windows_cl2017_cxx14_relwithdebinfo_preview=ON
-          - os: windows-2019
-            generator: Visual Studio 16 2019
+            job_name: examples_windows_cl2019_cxx14_relwithdebinfo_preview=ON
+          - os: windows-2022
+            generator: Visual Studio 17 2022
             c_compiler: cl
             cxx_compiler: cl
             std: 17
             build_type: relwithdebinfo
             preview: 'OFF'
-            job_name: examples_windows_cl2019_cxx17_relwithdebinfo_preview=OFF
+            job_name: examples_windows_cl2022_cxx17_relwithdebinfo_preview=OFF
     steps:
       - uses: actions/checkout@v2
       - name: Run testing


### PR DESCRIPTION
Signed-off-by: Zheltov, Sergey1 <sergey1.zheltov@intel.com>

### Description 
Windows Server 2016 image is deprecated, so we decided to replace it with Windows Server 2022.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
