### PR TITLE
mallinfo is only defined on glibc and android

### DIFF
--- a/src/tbbmalloc_proxy/proxy.cpp
+++ b/src/tbbmalloc_proxy/proxy.cpp
@@ -260,6 +260,7 @@ int mallopt(int /*param*/, int /*value*/) __THROW
     return 1;
 }
 
+#if defined(__GLIBC__) || defined(__ANDROID__)
 struct mallinfo mallinfo() __THROW
 {
     struct mallinfo m;
@@ -267,6 +268,7 @@ struct mallinfo mallinfo() __THROW
 
     return m;
 }
+#endif
 
 #if __ANDROID__
 // Android doesn't have malloc_usable_size, provide it to be compatible


### PR DESCRIPTION
### Description 

The fact that the `mallinfo` structure isn't defined in musl means that it doesn't compile there:

```
[ 90%] Building CXX object src/tbbmalloc_proxy/CMakeFiles/tbbmalloc_proxy.dir/proxy.cpp.o
/__w/mimalloc-bench/mimalloc-bench/extern/tbb/src/tbbmalloc_proxy/proxy.cpp:263:26: error: return type 'struct mallinfo' is incomplete
  263 | struct mallinfo mallinfo() __THROW
      |                          ^
compilation terminated due to -Wfatal-errors.
```

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
- @daanx

### Other information
