### PR TITLE
Fix incorrect assertion in test_eh_algorithms

### DIFF
--- a/test/common/exception_handling.h
+++ b/test/common/exception_handling.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/common/exception_handling.h
+++ b/test/common/exception_handling.h
@@ -173,9 +173,11 @@ inline void ThrowTestException ( intptr_t threshold ) {
 
 #define CATCH()     \
     } catch ( PropagatedException& e ) { \
-        intptr_t exprected = 0;\
-        g_ExecutedAtFirstCatch.compare_exchange_strong(exprected, g_CurExecuted); \
-        g_ExecutedAtLastCatch = g_CurExecuted.load(); \
+        intptr_t expected = 0;\
+        g_ExecutedAtFirstCatch.compare_exchange_strong(expected , g_CurExecuted); \
+        intptr_t curExecuted = g_CurExecuted.load(); \
+        expected = g_ExecutedAtLastCatch.load();\
+        while (expected < curExecuted) g_ExecutedAtLastCatch.compare_exchange_strong(expected, curExecuted); \
         REQUIRE_MESSAGE(e.what(), "Empty what() string" );  \
         REQUIRE_MESSAGE((strcmp(EXCEPTION_NAME(e), (g_SolitaryException ? typeid(solitary_test_exception) : typeid(test_exception)).name() ) == 0), "Unexpected original exception name"); \
         REQUIRE_MESSAGE((strcmp(e.what(), EXCEPTION_DESCR) == 0), "Unexpected original exception info"); \

--- a/test/tbb/test_eh_algorithms.cpp
+++ b/test/tbb/test_eh_algorithms.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_eh_algorithms.cpp
+++ b/test/tbb/test_eh_algorithms.cpp
@@ -371,7 +371,7 @@ void Test4 () {
         // to do the solitary throw swaps out after registering its intent to throw but before it
         // actually does so. As a result, the number of extra tasks cannot exceed the number of thread
         // for each nested pfor invication)
-        REQUIRE_MESSAGE (g_CurExecuted <= minExecuted + (g_NumThreads-1)*g_NumThreads/2, "Too many tasks survived exception");
+        REQUIRE_MESSAGE (g_CurExecuted <= minExecuted + (g_ExecutedAtLastCatch + g_NumThreads), "Too many tasks survived exception");
     }
     else {
         REQUIRE_MESSAGE (((g_NumExceptionsCaught >= 1 && g_NumExceptionsCaught <= outerCalls) || okayNoExceptionsCaught), "Unexpected actual number of exceptions");


### PR DESCRIPTION
### Description 

The patch fixes the assertion that uses incorrect approach to estimate the number of possibly executed tasks. Additionally, the fixes the last executed counter update because it should only grow (but due to race condition it might be updated from previous epoch)

Fixes of one the issues mentioned in #317

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users


### Other information
