### PR TITLE
Remove suspend_callback_wrapper struct

### DIFF
--- a/src/tbb/thread_data.h
+++ b/src/tbb/thread_data.h
@@ -166,18 +166,6 @@ public:
 
     context_list* my_context_list;
 #if __TBB_RESUMABLE_TASKS
-    //! The callback to call the user callback passed to tbb::suspend.
-    struct suspend_callback_wrapper {
-        suspend_callback_type suspend_callback;
-        void* user_callback;
-        suspend_point_type* sp;
-
-        void operator()() {
-            __TBB_ASSERT(suspend_callback && user_callback && sp, nullptr);
-            suspend_callback(user_callback, sp);
-        }
-    };
-
     //! Suspends the current coroutine (task_dispatcher).
     void suspend(void* suspend_callback, void* user_callback);
 


### PR DESCRIPTION
### Description 
Removed suspend_callback_wrapper  due ty it is unnecessary after [PR#727](https://github.com/oneapi-src/oneTBB/pull/727).

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@alexey-katranov 

### Other information
