### PR TITLE
Rework incorrect assert in try_destroy_arena

### DIFF
--- a/src/tbb/market.h
+++ b/src/tbb/market.h
@@ -146,6 +146,9 @@ private:
     //! Constructor
     market ( unsigned workers_soft_limit, unsigned workers_hard_limit, std::size_t stack_size );
 
+    //! Destructor
+    ~market();
+
     //! Destroys and deallocates market object created by market::create()
     void destroy ();
 


### PR DESCRIPTION
### Description 
`market` can be finalized while we are trying to destroy arena because all arenas can be already destroyed. However, it is not a problem because `market` is still alive (the current thread holds the reference to the server)

Fixes #745

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@phprus 

### Other information
