### PR TITLE
Fix concurrent_[bounded_]queue correctness on weak memory models

### DIFF
--- a/include/oneapi/tbb/concurrent_queue.h
+++ b/include/oneapi/tbb/concurrent_queue.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/concurrent_queue.h
+++ b/include/oneapi/tbb/concurrent_queue.h
@@ -183,7 +183,7 @@ private:
     bool internal_try_pop( void* dst ) {
         ticket_type k;
         do {
-            // Bassicaly, we need to read `head` before `tail`. To achive it we build happens-before on `head`
+            // Basically, we need to read `head` before `tail`. To achieve it we build happens-before on `head`
             k = my_queue_representation->head_counter.load(std::memory_order_acquire);
             do {
                 if (static_cast<std::ptrdiff_t>(my_queue_representation->tail_counter.load(std::memory_order_relaxed) - k) <= 0) {
@@ -515,7 +515,7 @@ private:
     bool internal_pop_if_present( void* dst ) {
         ticket_type ticket;
         do {
-            // Bassicaly, we need to read `head` before `tail`. To achive it we build happens-before on `head`
+            // Basically, we need to read `head` before `tail`. To achieve it we build happens-before on `head`
             ticket = my_queue_representation->head_counter.load(std::memory_order_acquire);
             do {
                 if (static_cast<std::ptrdiff_t>(my_queue_representation->tail_counter.load(std::memory_order_relaxed) - ticket) <= 0) { // queue is empty

--- a/include/oneapi/tbb/concurrent_queue.h
+++ b/include/oneapi/tbb/concurrent_queue.h
@@ -28,6 +28,24 @@ namespace tbb {
 namespace detail {
 namespace d2 {
 
+template <typename QueueRep, typename Allocator>
+std::pair<bool, ticket_type> internal_try_pop_impl(void* dst, QueueRep& queue, Allocator& alloc ) {
+    ticket_type ticket{};
+    do {
+        // Basically, we need to read `head` before `tail`. To achieve it we build happens-before on `head`
+        ticket = queue.head_counter.load(std::memory_order_acquire);
+        do {
+            if (static_cast<std::ptrdiff_t>(queue.tail_counter.load(std::memory_order_relaxed) - ticket) <= 0) { // queue is empty
+                // Queue is empty
+                return { false, ticket };
+            }
+            // Queue had item with ticket k when we looked.  Attempt to get that item.
+            // Another thread snatched the item, retry.
+        } while (!queue.head_counter.compare_exchange_strong(ticket, ticket + 1));
+    } while (!queue.choose(ticket).pop(dst, ticket, queue, alloc));
+    return { true, ticket };
+}
+
 // A high-performance thread-safe non-blocking concurrent queue.
 // Multiple threads may each push and pop concurrently.
 // Assignment construction is not allowed.
@@ -181,21 +199,7 @@ private:
     }
 
     bool internal_try_pop( void* dst ) {
-        ticket_type k;
-        do {
-            // Basically, we need to read `head` before `tail`. To achieve it we build happens-before on `head`
-            k = my_queue_representation->head_counter.load(std::memory_order_acquire);
-            do {
-                if (static_cast<std::ptrdiff_t>(my_queue_representation->tail_counter.load(std::memory_order_relaxed) - k) <= 0) {
-                    // Queue is empty
-                    return false;
-                }
-
-                // Queue had item with ticket k when we looked. Attempt to get that item.
-                // Another thread snatched the item, retry.
-            } while (!my_queue_representation->head_counter.compare_exchange_strong(k, k + 1));
-        } while (!my_queue_representation->choose(k).pop(dst, k, *my_queue_representation, my_allocator));
-        return true;
+        return internal_try_pop_impl(dst, *my_queue_representation, my_allocator).first;
     }
 
     template <typename Container, typename Value, typename A>
@@ -513,22 +517,14 @@ private:
     }
 
     bool internal_pop_if_present( void* dst ) {
-        ticket_type ticket;
-        do {
-            // Basically, we need to read `head` before `tail`. To achieve it we build happens-before on `head`
-            ticket = my_queue_representation->head_counter.load(std::memory_order_acquire);
-            do {
-                if (static_cast<std::ptrdiff_t>(my_queue_representation->tail_counter.load(std::memory_order_relaxed) - ticket) <= 0) { // queue is empty
-                    // Queue is empty
-                    return false;
-                }
-                // Queue had item with ticket k when we looked.  Attempt to get that item.
-                // Another thread snatched the item, retry.
-            } while (!my_queue_representation->head_counter.compare_exchange_strong(ticket, ticket + 1));
-        } while (!my_queue_representation->choose(ticket).pop(dst, ticket, *my_queue_representation, my_allocator));
+        bool present{};
+        ticket_type ticket{};
+        std::tie(present, ticket) = internal_try_pop_impl(dst, *my_queue_representation, my_allocator);
 
-        r1::notify_bounded_queue_monitor(my_monitors, cbq_slots_avail_tag, ticket);
-        return true;
+        if (present) {
+            r1::notify_bounded_queue_monitor(my_monitors, cbq_slots_avail_tag, ticket);
+        }
+        return present;
     }
 
     void internal_abort() {

--- a/include/oneapi/tbb/concurrent_queue.h
+++ b/include/oneapi/tbb/concurrent_queue.h
@@ -32,7 +32,7 @@ template <typename QueueRep, typename Allocator>
 std::pair<bool, ticket_type> internal_try_pop_impl(void* dst, QueueRep& queue, Allocator& alloc ) {
     ticket_type ticket{};
     do {
-        // Basically, we need to read `head` before `tail`. To achieve it we build happens-before on `head`
+        // Basically, we need to read `head_counter` before `tail_counter`. To achieve it we build happens-before on `head_counter`
         ticket = queue.head_counter.load(std::memory_order_acquire);
         do {
             if (static_cast<std::ptrdiff_t>(queue.tail_counter.load(std::memory_order_relaxed) - ticket) <= 0) { // queue is empty

--- a/include/oneapi/tbb/concurrent_queue.h
+++ b/include/oneapi/tbb/concurrent_queue.h
@@ -183,7 +183,8 @@ private:
     bool internal_try_pop( void* dst ) {
         ticket_type k;
         do {
-            k = my_queue_representation->head_counter.load(std::memory_order_relaxed);
+            // Bassicaly, we need to read `head` before `tail`. To achive it we build happens-before on `head`
+            k = my_queue_representation->head_counter.load(std::memory_order_acquire);
             do {
                 if (static_cast<std::ptrdiff_t>(my_queue_representation->tail_counter.load(std::memory_order_relaxed) - k) <= 0) {
                     // Queue is empty
@@ -514,7 +515,8 @@ private:
     bool internal_pop_if_present( void* dst ) {
         ticket_type ticket;
         do {
-            ticket = my_queue_representation->head_counter.load(std::memory_order_relaxed);
+            // Bassicaly, we need to read `head` before `tail`. To achive it we build happens-before on `head`
+            ticket = my_queue_representation->head_counter.load(std::memory_order_acquire);
             do {
                 if (static_cast<std::ptrdiff_t>(my_queue_representation->tail_counter.load(std::memory_order_relaxed) - ticket) <= 0) { // queue is empty
                     // Queue is empty

--- a/include/oneapi/tbb/detail/_concurrent_queue_base.h
+++ b/include/oneapi/tbb/detail/_concurrent_queue_base.h
@@ -123,7 +123,7 @@ public:
             page_allocator_traits::construct(page_allocator, p);
         }
 
-        if (tail_counter.load(std::memory_order_relaxed) != k) spin_wait_until_my_turn(tail_counter, k, base);
+        spin_wait_until_my_turn(tail_counter, k, base);
         d1::call_itt_notify(d1::acquired, &tail_counter);
 
         if (p) {
@@ -134,9 +134,9 @@ public:
             } else {
                 head_page.store(p, std::memory_order_relaxed);
             }
-            tail_page.store(p, std::memory_order_release);
+            tail_page.store(p, std::memory_order_relaxed);
         } else {
-            p = tail_page.load(std::memory_order_acquire); // TODO may be relaxed ?
+            p = tail_page.load(std::memory_order_relaxed);
         }
         return index;
     }
@@ -179,7 +179,7 @@ public:
         d1::call_itt_notify(d1::acquired, &head_counter);
         spin_wait_while_eq(tail_counter, k);
         d1::call_itt_notify(d1::acquired, &tail_counter);
-        padded_page *p = head_page.load(std::memory_order_acquire);
+        padded_page *p = head_page.load(std::memory_order_relaxed);
         __TBB_ASSERT( p, nullptr );
         size_type index = modulo_power_of_two( k/queue_rep_type::n_queue, items_per_page );
         bool success = false;
@@ -337,7 +337,7 @@ private:
 
     void spin_wait_until_my_turn( std::atomic<ticket_type>& counter, ticket_type k, queue_rep_type& rb ) const {
         for (atomic_backoff b(true);; b.pause()) {
-            ticket_type c = counter;
+            ticket_type c = counter.load(std::memory_order_acquire);
             if (c == k) return;
             else if (c & 1) {
                 ++rb.n_invalid_entries;
@@ -378,9 +378,9 @@ public:
         if( is_valid_page(p) ) {
             spin_mutex::scoped_lock lock( my_queue.page_mutex );
             padded_page* q = p->next;
-            my_queue.head_page.store(q, std::memory_order_release);
+            my_queue.head_page.store(q, std::memory_order_relaxed);
             if( !is_valid_page(q) ) {
-                my_queue.tail_page.store(nullptr, std::memory_order_release);
+                my_queue.tail_page.store(nullptr, std::memory_order_relaxed);
             }
         }
         my_queue.head_counter.store(my_ticket_type, std::memory_order_release);

--- a/include/oneapi/tbb/detail/_concurrent_queue_base.h
+++ b/include/oneapi/tbb/detail/_concurrent_queue_base.h
@@ -336,7 +336,7 @@ private:
     }
 
     void spin_wait_until_my_turn( std::atomic<ticket_type>& counter, ticket_type k, queue_rep_type& rb ) const {
-        for (atomic_backoff b(true);; b.pause()) {
+        for (atomic_backoff b{};; b.pause()) {
             ticket_type c = counter.load(std::memory_order_acquire);
             if (c == k) return;
             else if (c & 1) {

--- a/test/tbb/test_concurrent_queue_whitebox.cpp
+++ b/test/tbb/test_concurrent_queue_whitebox.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_concurrent_queue_whitebox.cpp
+++ b/test/tbb/test_concurrent_queue_whitebox.cpp
@@ -51,7 +51,8 @@ public:
         value_type elem = value_type(thread_id);
         for (std::size_t i = 0; i < elem_num; ++i) {
             q.push(elem);
-            q.try_pop(elem);
+            bool res = q.try_pop(elem);
+            CHECK_FAST(res);
         }
     }
 
@@ -83,20 +84,18 @@ void test_flogger_help( Q& q, std::size_t items_per_page ) {
     REQUIRE_MESSAGE(q.my_queue_representation->head_counter < hack_val, "Failed wraparound test");
 }
 
-template <typename T>
-void test_flogger() {
-    {
-        tbb::concurrent_queue<T> q;
-        test_flogger_help(q, q.my_queue_representation->items_per_page);
-    }
-    {
-        tbb::concurrent_bounded_queue<T> q;
+//! \brief \ref error_guessing
+TEST_CASE("Test CQ Wrapparound") {
+    for (int i = 0; i < 1000; ++i) {
+        tbb::concurrent_queue<int> q;
         test_flogger_help(q, q.my_queue_representation->items_per_page);
     }
 }
 
 //! \brief \ref error_guessing
-TEST_CASE("Test Wrapparound") {
-    test_flogger<int>();
-    // TODO: add test with unsigned char
+TEST_CASE("Test CBQ Wrapparound") {
+    for (int i = 0; i < 1000; ++i) {
+        tbb::concurrent_bounded_queue<int> q;
+        test_flogger_help(q, q.my_queue_representation->items_per_page);
+    }
 }


### PR DESCRIPTION
### Description 
The patch fixes two issues:
1. Memory corruption over micro_queue page allocation. `tail_counter` is serialization atomic that synchronizes memory related to micro_queue pages. Hence, we need to build happens-before over `tail_counter` (not to read it with `relaxed`)
2. Enforce user expected happens-before relation for concurrent `push` and `try_pop` operations. Consider the example:
```cpp
// thread 1
q.push()
q.try_pop()

// thread 2
q.push()
q.try_pop()
```
The expected global order of operation is either `push->try_pop->push->try_pop` or `push->push->try_pop->try_pop`. However, the current implementation allows `push->try_pop->try_pop->push` that is not intuitively expected by humans. So, set the constraint between `head` and `tail` loads to enforce visibility of `push` if `try_pop` is already happened.

The both issues are not reproducible on x86 and affect only systems with weak memory model, e.g. ARM.

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users

### Other information
