### PR TITLE
changed TBB_EXPORT to use gcc visibility attribute

### DIFF
--- a/cmake/compilers/Clang.cmake
+++ b/cmake/compilers/Clang.cmake
@@ -61,5 +61,8 @@ endif()
 set(TBB_IPO_COMPILE_FLAGS $<$<NOT:$<CONFIG:Debug>>:-flto>)
 set(TBB_IPO_LINK_FLAGS $<$<NOT:$<CONFIG:Debug>>:-flto>)
 
+# TODO: remove 
+list (APPEND TBB_COMMON_COMPILE_FLAGS -fvisibility=hidden)
+
 # TBB malloc settings
 set(TBBMALLOC_LIB_COMPILE_FLAGS -fno-rtti -fno-exceptions)

--- a/cmake/compilers/GNU.cmake
+++ b/cmake/compilers/GNU.cmake
@@ -68,6 +68,8 @@ if (MINGW AND CMAKE_SYSTEM_PROCESSOR MATCHES "i.86")
     list (APPEND TBB_COMMON_COMPILE_FLAGS -msse2)
 endif ()
 
+# TODO: remove 
+list (APPEND TBB_COMMON_COMPILE_FLAGS -fvisibility=hidden)
 # TBB malloc settings
 set(TBBMALLOC_LIB_COMPILE_FLAGS -fno-rtti -fno-exceptions)
 set(TBB_OPENMP_FLAG -fopenmp)

--- a/include/oneapi/tbb/detail/_export.h
+++ b/include/oneapi/tbb/detail/_export.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -19,28 +19,30 @@
 
 #if defined(__MINGW32__)
     #define _EXPORT __declspec(dllexport)
-#elif defined(_WIN32) || defined(__unix__) || defined(__APPLE__) // Use .def files for these
+#elif defined(_WIN32)
     #define _EXPORT
+#elif defined(__unix__) || defined(__APPLE__) // Use .def files for these
+    #define _EXPORT __attribute__ ((visibility ("default")))
 #else
     #error "Unknown platform/compiler"
 #endif
 
-#if __TBB_BUILD
+//#if __TBB_BUILD
     #define TBB_EXPORT _EXPORT
-#else
-    #define TBB_EXPORT
-#endif
+//#else
+//    #define TBB_EXPORT
+//#endif
 
-#if __TBBMALLOC_BUILD
+//#if __TBBMALLOC_BUILD
     #define TBBMALLOC_EXPORT _EXPORT
-#else
-    #define TBBMALLOC_EXPORT
-#endif
+//#else
+//    #define TBBMALLOC_EXPORT
+//#endif
 
-#if __TBBBIND_BUILD
+//#if __TBBBIND_BUILD
     #define TBBBIND_EXPORT _EXPORT
-#else
-    #define TBBBIND_EXPORT
-#endif
+//#else
+//    #define TBBBIND_EXPORT
+//#endif
 
 #endif

--- a/src/tbbmalloc_proxy/proxy.cpp
+++ b/src/tbbmalloc_proxy/proxy.cpp
@@ -184,23 +184,23 @@ inline void InitOrigPointers() {}
 
 #endif // MALLOC_UNIXLIKE_OVERLOAD_ENABLED and MALLOC_ZONE_OVERLOAD_ENABLED
 
-void *PREFIX(malloc)(ZONE_ARG size_t size) __THROW
+TBBMALLOC_EXPORT void *PREFIX(malloc)(ZONE_ARG size_t size) __THROW
 {
     return scalable_malloc(size);
 }
 
-void *PREFIX(calloc)(ZONE_ARG size_t num, size_t size) __THROW
+TBBMALLOC_EXPORT void *PREFIX(calloc)(ZONE_ARG size_t num, size_t size) __THROW
 {
     return scalable_calloc(num, size);
 }
 
-void PREFIX(free)(ZONE_ARG void *object) __THROW
+TBBMALLOC_EXPORT void PREFIX(free)(ZONE_ARG void *object) __THROW
 {
     InitOrigPointers();
     __TBB_malloc_safer_free(object, (void (*)(void*))orig_free);
 }
 
-void *PREFIX(realloc)(ZONE_ARG void* ptr, size_t sz) __THROW
+TBBMALLOC_EXPORT void *PREFIX(realloc)(ZONE_ARG void* ptr, size_t sz) __THROW
 {
     InitOrigPointers();
     return __TBB_malloc_safer_realloc(ptr, sz, orig_realloc);
@@ -209,13 +209,13 @@ void *PREFIX(realloc)(ZONE_ARG void* ptr, size_t sz) __THROW
 /* The older *NIX interface for aligned allocations;
    it's formally substituted by posix_memalign and deprecated,
    so we do not expect it to cause cyclic dependency with C RTL. */
-void *PREFIX(memalign)(ZONE_ARG size_t alignment, size_t size) __THROW
+TBBMALLOC_EXPORT void *PREFIX(memalign)(ZONE_ARG size_t alignment, size_t size) __THROW
 {
     return scalable_aligned_malloc(size, alignment);
 }
 
 /* valloc allocates memory aligned on a page boundary */
-void *PREFIX(valloc)(ZONE_ARG size_t size) __THROW
+TBBMALLOC_EXPORT void *PREFIX(valloc)(ZONE_ARG size_t size) __THROW
 {
     if (! memoryPageSize) initPageSize();
 
@@ -229,23 +229,23 @@ void *PREFIX(valloc)(ZONE_ARG size_t size) __THROW
 
 // match prototype from system headers
 #if __ANDROID__
-size_t malloc_usable_size(const void *ptr) __THROW
+TBBMALLOC_EXPORT size_t malloc_usable_size(const void *ptr) __THROW
 #else
-size_t malloc_usable_size(void *ptr) __THROW
+TBBMALLOC_EXPORT size_t malloc_usable_size(void *ptr) __THROW
 #endif
 {
     InitOrigPointers();
     return __TBB_malloc_safer_msize(const_cast<void*>(ptr), (size_t (*)(void*))orig_msize);
 }
 
-int posix_memalign(void **memptr, size_t alignment, size_t size) __THROW
+TBBMALLOC_EXPORT int posix_memalign(void **memptr, size_t alignment, size_t size) __THROW
 {
     return scalable_posix_memalign(memptr, alignment, size);
 }
 
 /* pvalloc allocates smallest set of complete pages which can hold
    the requested number of bytes. Result is aligned on page boundary. */
-void *pvalloc(size_t size) __THROW
+TBBMALLOC_EXPORT void *pvalloc(size_t size) __THROW
 {
     if (! memoryPageSize) initPageSize();
     // align size up to the page size,
@@ -255,13 +255,13 @@ void *pvalloc(size_t size) __THROW
     return scalable_aligned_malloc(size, memoryPageSize);
 }
 
-int mallopt(int /*param*/, int /*value*/) __THROW
+TBBMALLOC_EXPORT int mallopt(int /*param*/, int /*value*/) __THROW
 {
     return 1;
 }
 
 #if defined(__GLIBC__) || defined(__ANDROID__)
-struct mallinfo mallinfo() __THROW
+TBBMALLOC_EXPORT struct mallinfo mallinfo() __THROW
 {
     struct mallinfo m;
     memset(&m, 0, sizeof(struct mallinfo));
@@ -274,30 +274,30 @@ struct mallinfo mallinfo() __THROW
 // Android doesn't have malloc_usable_size, provide it to be compatible
 // with Linux, in addition overload dlmalloc_usable_size() that presented
 // under Android.
-size_t dlmalloc_usable_size(const void *ptr) __TBB_ALIAS_ATTR_COPY(malloc_usable_size);
+TBBMALLOC_EXPORT size_t dlmalloc_usable_size(const void *ptr) __TBB_ALIAS_ATTR_COPY(malloc_usable_size);
 #else // __ANDROID__
 // TODO: consider using __typeof__ to guarantee the correct declaration types
 // C11 function, supported starting GLIBC 2.16
-void *aligned_alloc(size_t alignment, size_t size) __TBB_ALIAS_ATTR_COPY(memalign);
+TBBMALLOC_EXPORT void *aligned_alloc(size_t alignment, size_t size) __TBB_ALIAS_ATTR_COPY(memalign);
 // Those non-standard functions are exported by GLIBC, and might be used
 // in conjunction with standard malloc/free, so we must overload them.
 // Bionic doesn't have them. Not removing from the linker scripts,
 // as absent entry points are ignored by the linker.
 
-void *__libc_malloc(size_t size) __TBB_ALIAS_ATTR_COPY(malloc);
-void *__libc_calloc(size_t num, size_t size) __TBB_ALIAS_ATTR_COPY(calloc);
-void *__libc_memalign(size_t alignment, size_t size) __TBB_ALIAS_ATTR_COPY(memalign);
-void *__libc_pvalloc(size_t size) __TBB_ALIAS_ATTR_COPY(pvalloc);
-void *__libc_valloc(size_t size) __TBB_ALIAS_ATTR_COPY(valloc);
+TBBMALLOC_EXPORT void *__libc_malloc(size_t size) __TBB_ALIAS_ATTR_COPY(malloc);
+TBBMALLOC_EXPORT void *__libc_calloc(size_t num, size_t size) __TBB_ALIAS_ATTR_COPY(calloc);
+TBBMALLOC_EXPORT void *__libc_memalign(size_t alignment, size_t size) __TBB_ALIAS_ATTR_COPY(memalign);
+TBBMALLOC_EXPORT void *__libc_pvalloc(size_t size) __TBB_ALIAS_ATTR_COPY(pvalloc);
+TBBMALLOC_EXPORT void *__libc_valloc(size_t size) __TBB_ALIAS_ATTR_COPY(valloc);
 
 // call original __libc_* to support naive replacement of free via __libc_free etc
-void __libc_free(void *ptr)
+TBBMALLOC_EXPORT void __libc_free(void *ptr)
 {
     InitOrigPointers();
     __TBB_malloc_safer_free(ptr, (void (*)(void*))orig_libc_free);
 }
 
-void *__libc_realloc(void *ptr, size_t size)
+TBBMALLOC_EXPORT void *__libc_realloc(void *ptr, size_t size)
 {
     InitOrigPointers();
     return __TBB_malloc_safer_realloc(ptr, size, orig_libc_realloc);

--- a/src/tbbmalloc_proxy/proxy.h
+++ b/src/tbbmalloc_proxy/proxy.h
@@ -37,7 +37,7 @@ extern "C" {
     TBBMALLOC_EXPORT size_t __TBB_malloc_safer_aligned_msize( void *ptr, size_t, size_t, size_t (*orig_msize_crt80d)(void*,size_t,size_t));
 
 #if MALLOC_ZONE_OVERLOAD_ENABLED
-    void   __TBB_malloc_free_definite_size(void *object, size_t size);
+    TBBMALLOC_EXPORT void   __TBB_malloc_free_definite_size(void *object, size_t size);
 #endif
 } // extern "C"
 

--- a/test/tbb/test_dynamic_link.cpp
+++ b/test/tbb/test_dynamic_link.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ enum FOO_TYPE {
 #if _WIN32 || _WIN64
 #define TEST_EXPORT
 #else
-#define TEST_EXPORT extern "C"
+#define TEST_EXPORT extern "C"  TBB_EXPORT
 #endif /* _WIN32 || _WIN64 */
 
 // foo "implementations".

--- a/test/tbbmalloc/test_malloc_atexit.cpp
+++ b/test/tbbmalloc/test_malloc_atexit.cpp
@@ -33,6 +33,8 @@
 #if _USRDLL
 #if _WIN32||_WIN64
 extern __declspec(dllexport)
+#else
+TBBMALLOC_EXPORT
 #endif
 bool dll_isMallocOverloaded()
 #else
@@ -143,6 +145,8 @@ int main() {}
 #include "tbb/tbbmalloc_proxy.h"
 
 extern __declspec(dllimport)
+#else
+TBBMALLOC_EXPORT
 #endif
 bool dll_isMallocOverloaded();
 

--- a/test/tbbmalloc/test_malloc_lib_unload.cpp
+++ b/test/tbbmalloc/test_malloc_lib_unload.cpp
@@ -40,6 +40,23 @@ extern "C" {
     extern __declspec(dllexport) size_t safer_scalable_msize (void *, size_t (*)(void*));
     extern __declspec(dllexport) int anchor();
 }
+#else
+extern "C" {
+    extern TBBMALLOC_EXPORT void *scalable_malloc(size_t);
+    extern TBBMALLOC_EXPORT void scalable_free (void *);
+    extern TBBMALLOC_EXPORT void safer_scalable_free (void *, void (*)(void*));
+    extern TBBMALLOC_EXPORT void *scalable_realloc(void *, size_t);
+    extern TBBMALLOC_EXPORT void *safer_scalable_realloc(void *, size_t, void *);
+    extern TBBMALLOC_EXPORT void *scalable_calloc(size_t, size_t);
+    extern TBBMALLOC_EXPORT int scalable_posix_memalign(void **, size_t, size_t);
+    extern TBBMALLOC_EXPORT void *scalable_aligned_malloc(size_t, size_t);
+    extern TBBMALLOC_EXPORT void *scalable_aligned_realloc(void *, size_t, size_t);
+    extern TBBMALLOC_EXPORT void *safer_scalable_aligned_realloc(void *, size_t, size_t, void *);
+    extern TBBMALLOC_EXPORT void scalable_aligned_free(void *);
+    extern TBBMALLOC_EXPORT size_t scalable_msize(void *);
+    extern TBBMALLOC_EXPORT size_t safer_scalable_msize (void *, size_t (*)(void*));
+    extern TBBMALLOC_EXPORT int anchor();
+}
 #endif
 
 extern "C" int anchor() {
@@ -137,6 +154,8 @@ extern "C" {
 
 #if _WIN32||_WIN64
     extern __declspec(dllimport)
+#else
+    TBBMALLOC_EXPORT
 #endif
     int anchor();
 }

--- a/test/tbbmalloc/test_malloc_used_by_lib.cpp
+++ b/test/tbbmalloc/test_malloc_used_by_lib.cpp
@@ -23,11 +23,11 @@
 #include "common/utils_assert.h"
 #include "tbb/scalable_allocator.h"
 
-#if _WIN32||_WIN64
+//#if _WIN32||_WIN64
 extern "C" {
-    extern __declspec(dllexport) void callDll();
+    extern _EXPORT void callDll();
 }
-#endif
+//#endif
 
 extern "C" void callDll()
 {


### PR DESCRIPTION

### Description 
according to [GCC symbols visibility wiki page](https://gcc.gnu.org/wiki/Visibility) as such (with `__attribute__((visibility ("default"))`) exported symbols should be explicitly marked, to allow compilating with `-fvisibility=hidden` flag. 


Fixes #779

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@alexey-katranov 

### Other information
