### PR TITLE
Workaround conflict with _CRTDBG_MAP_ALLOC

### DIFF
--- a/include/oneapi/tbb/enumerable_thread_specific.h
+++ b/include/oneapi/tbb/enumerable_thread_specific.h
@@ -140,7 +140,7 @@ protected:
         std::memset( a + 1, 0, n * sizeof(slot) );
         return a;
     }
-    void free(array* a) {
+    void deallocate(array* a) {
         std::size_t n = std::size_t(1) << (a->lg_size);
         free_array( static_cast<void*>(a), std::size_t(sizeof(array) + n * sizeof(slot)) );
     }
@@ -197,7 +197,7 @@ template<ets_key_usage_type ETS_key_type>
 void ets_base<ETS_key_type>::table_clear() {
     while ( array* r = my_root.load(std::memory_order_relaxed) ) {
         my_root.store(r->next, std::memory_order_relaxed);
-        free(r);
+        deallocate(r);
     }
     my_count.store(0, std::memory_order_relaxed);
 }
@@ -251,7 +251,7 @@ void* ets_base<ETS_key_type>::table_lookup( bool& exists ) {
                 __TBB_ASSERT(new_r != nullptr, nullptr);
                 if( new_r->lg_size >= s ) {
                     // Another thread inserted an equal or  bigger array, so our array is superfluous.
-                    free(a);
+                    deallocate(a);
                     break;
                 }
                 r = new_r;

--- a/test/tbb/test_tbb_header_secondary.cpp
+++ b/test/tbb/test_tbb_header_secondary.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2020-2021 Intel Corporation
+    Copyright (c) 2020-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_tbb_header_secondary.cpp
+++ b/test/tbb/test_tbb_header_secondary.cpp
@@ -25,7 +25,7 @@
 #define NOMINMAX
 #endif // NOMINMAX
 
-#if _WIN32 && TBB_USE_DEBUG
+#if _MSC_VER && TBB_USE_DEBUG
 // Check that there is no conflict with _CRTDBG_MAP_ALLOC
 #define _CRTDBG_MAP_ALLOC
 #include "crtdbg.h"

--- a/test/tbb/test_tbb_header_secondary.cpp
+++ b/test/tbb/test_tbb_header_secondary.cpp
@@ -25,6 +25,12 @@
 #define NOMINMAX
 #endif // NOMINMAX
 
+#if _WIN32 && TBB_USE_DEBUG
+// Check that there is no conflict with _CRTDBG_MAP_ALLOC
+#define _CRTDBG_MAP_ALLOC
+#include "crtdbg.h"
+#endif
+
 #include <exception>
 
 #define CHECK(x) do { if (!(x)) { std::terminate(); } } while (false)


### PR DESCRIPTION
### Description 
The follwoing test fails because `free` is redefined to something else
```cpp
#define _CRTDBG_MAP_ALLOC
#include "crtdbg.h"
#include "tbb/tbb.h"

int main()
{
    return 0;
}
```
The patch renames the method to avoid the conflict.

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [x] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
