### PR TITLE
Fix test_collaborative_call_once SIGABRT on armhf/armel

### DIFF
--- a/test/tbb/test_collaborative_call_once.cpp
+++ b/test/tbb/test_collaborative_call_once.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2021 Intel Corporation
+    Copyright (c) 2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -211,7 +211,7 @@ TEST_CASE("only calls once - move only argument") {
 TEST_CASE("only calls once - stress test") {
 #if TBB_TEST_LOW_WORKLOAD
     constexpr std::size_t N = 32;
-#elif __TBB_x86_32 || __aarch32__  || __ANDROID__
+#elif __TBB_x86_32 || __arm__  || __ANDROID__
     // Some C++ implementations allocate 8MB stacks for std::thread on 32 bit platforms
     // that makes impossible to create more than ~500 threads.
     // Android has been added to decrease testing time.
@@ -282,7 +282,7 @@ TEST_CASE("handles exceptions - state reset") {
 TEST_CASE("handles exceptions - stress test") {
 #if TBB_TEST_LOW_WORKLOAD
     constexpr std::size_t N = 32;
-#elif __TBB_x86_32 || __aarch32__ || __ANDROID__
+#elif __TBB_x86_32 || __arm__ || __ANDROID__
     // Some C++ implementations allocate 8MB stacks for std::thread on 32 bit platforms
     // that makes impossible to create more than ~500 threads.
     // Android has been added to decrease testing time.


### PR DESCRIPTION
### Description 
32 bit arm configurations such as armhf/armel are not detected in `test_collaborative_call_once` due to wrong macro, which leads to a crash because some tests start using more resources than available. This patch replace incorrect \_\_aarch32\_\_ macro to correct \_\_arm\_\_. 
See https://developer.arm.com/documentation/dui0774/g/chr1383660321827


Fixes #783 

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@cdluminate @alexey-katranov 

### Other information
