### PR TITLE
haiku: Add initial platform support

### DIFF
--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -195,7 +195,8 @@
 
 /** __TBB_WEAK_SYMBOLS_PRESENT denotes that the system supports the weak symbol mechanism **/
 #ifndef __TBB_WEAK_SYMBOLS_PRESENT
-    #define __TBB_WEAK_SYMBOLS_PRESENT ( !_WIN32 && !__APPLE__ && !__sun && (__TBB_GCC_VERSION >= 40000 || __INTEL_COMPILER ) )
+    #define __TBB_WEAK_SYMBOLS_PRESENT ( !_WIN32 && !__APPLE__ && !__sun && !__HAIKU__ \
+        && (__TBB_GCC_VERSION >= 40000 || __INTEL_COMPILER ) )
 #endif
 
 /** Presence of compiler features **/

--- a/include/oneapi/tbb/detail/_export.h
+++ b/include/oneapi/tbb/detail/_export.h
@@ -21,6 +21,9 @@
     #define _EXPORT __declspec(dllexport)
 #elif defined(_WIN32) || defined(__unix__) || defined(__APPLE__) // Use .def files for these
     #define _EXPORT
+#elif defined(__HAIKU__)
+    // Haiku defines _EXPORT
+    #include <BeBuild.h>
 #else
     #error "Unknown platform/compiler"
 #endif

--- a/src/tbb/allocator.cpp
+++ b/src/tbb/allocator.cpp
@@ -119,7 +119,7 @@ static const dynamic_link_descriptor MallocLinkTable[] = {
 #define MALLOCLIB_NAME "tbbmalloc" DEBUG_SUFFIX ".dll"
 #elif __APPLE__
 #define MALLOCLIB_NAME "libtbbmalloc" DEBUG_SUFFIX ".dylib"
-#elif __FreeBSD__ || __NetBSD__ || __OpenBSD__ || __sun || _AIX || __ANDROID__
+#elif __FreeBSD__ || __NetBSD__ || __OpenBSD__ || __sun || _AIX || __ANDROID__ || __HAIKU__
 #define MALLOCLIB_NAME "libtbbmalloc" DEBUG_SUFFIX ".so"
 #elif __unix__  // Note that order of these #elif's is important!
 #define MALLOCLIB_NAME "libtbbmalloc" DEBUG_SUFFIX ".so.2"

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -387,7 +387,11 @@ namespace r1 {
     #endif /* !__TBB_DYNAMIC_LOAD_ENABLED */
         // RTLD_GLOBAL - to guarantee that old TBB will find the loaded library
         // RTLD_NOLOAD - not to load the library without the full path
+        #ifdef __HAIKU__
+        library_handle = dlopen(library, RTLD_LAZY | RTLD_GLOBAL);
+        #else
         library_handle = dlopen(library, RTLD_LAZY | RTLD_GLOBAL | RTLD_NOLOAD);
+        #endif
 #endif /* _WIN32 */
         if (library_handle) {
             if (!resolve_symbols(library_handle, descriptors, required)) {

--- a/src/tbb/rml_tbb.cpp
+++ b/src/tbb/rml_tbb.cpp
@@ -50,7 +50,7 @@ namespace rml {
 #define RML_SERVER_NAME "irml" DEBUG_SUFFIX ".dll"
 #elif __APPLE__
 #define RML_SERVER_NAME "libirml" DEBUG_SUFFIX ".dylib"
-#elif __FreeBSD__ || __NetBSD__ || __OpenBSD__ || __sun || _AIX
+#elif __FreeBSD__ || __NetBSD__ || __OpenBSD__ || __sun || _AIX || __HAIKU__
 #define RML_SERVER_NAME "libirml" DEBUG_SUFFIX ".so"
 #elif __unix__
 #define RML_SERVER_NAME "libirml" DEBUG_SUFFIX ".so.1"


### PR DESCRIPTION
### Description 

Adds initial platform support for Haiku.

Fixes https://github.com/rui314/mold/pull/369

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [X] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users

@rui314 

### Other information

This is enough to get oneTBB functional under Haiku when used within the meld linker.  However, oneTBB needs some refactoring around  the outdated ucontext code https://github.com/oneapi-src/oneTBB/issues/795 as it is not POSIX compliant.