### PR TITLE
Fix for full LTO build

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,11 +40,13 @@ function(tbb_add_test)
         ${TBB_COMMON_COMPILE_FLAGS}
     )
 
+    if (UNIX)
+        target_link_libraries(${_tbb_test_TARGET_NAME} PRIVATE -rdynamic) # for the test_dynamic_link
+    endif()
     if (ANDROID_PLATFORM)
         # Expand the linker rpath by the CMAKE_LIBRARY_OUTPUT_DIRECTORY path since clang compiler from Android SDK
         # doesn't respect the -L flag.
         target_link_libraries(${_tbb_test_TARGET_NAME} PRIVATE "-Wl,--rpath-link,${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
-        target_link_libraries(${_tbb_test_TARGET_NAME} PRIVATE -rdynamic) # for the test_dynamic_link
         add_test(NAME ${_tbb_test_TARGET_NAME}
                  COMMAND ${CMAKE_COMMAND}
                          -DBINARIES_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
@@ -93,8 +95,10 @@ function(tbb_add_c_test)
     add_executable(${_tbb_test_NAME} ${_tbb_test_SUBDIR}/${_tbb_test_NAME}.c)
     target_include_directories(${_tbb_test_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_SOURCE_DIR})
 
-    if (ANDROID_PLATFORM)
+    if (UNIX)
         target_link_libraries(${_tbb_test_NAME} PRIVATE -rdynamic) # for the test_dynamic_link
+    endif()
+    if (ANDROID_PLATFORM)
         add_test(NAME ${_tbb_test_NAME}
                 COMMAND ${CMAKE_COMMAND}
                         -DBINARIES_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
@@ -574,8 +578,10 @@ if (TARGET TBB::tbbmalloc)
             ${TBB_COMMON_COMPILE_FLAGS}
             ${TBBMALLOC_LIB_COMPILE_FLAGS}
         )
-        if (ANDROID_PLATFORM)
+        if (UNIX)
             target_link_libraries(test_malloc_whitebox PRIVATE -rdynamic) # for the test_dynamic_link
+        endif()
+        if (ANDROID_PLATFORM)
             add_test(NAME test_malloc_whitebox
                     COMMAND ${CMAKE_COMMAND}
                             -DBINARIES_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,9 +40,6 @@ function(tbb_add_test)
         ${TBB_COMMON_COMPILE_FLAGS}
     )
 
-    if (UNIX)
-        target_link_libraries(${_tbb_test_TARGET_NAME} PRIVATE -rdynamic) # for the test_dynamic_link
-    endif()
     if (ANDROID_PLATFORM)
         # Expand the linker rpath by the CMAKE_LIBRARY_OUTPUT_DIRECTORY path since clang compiler from Android SDK
         # doesn't respect the -L flag.
@@ -95,9 +92,6 @@ function(tbb_add_c_test)
     add_executable(${_tbb_test_NAME} ${_tbb_test_SUBDIR}/${_tbb_test_NAME}.c)
     target_include_directories(${_tbb_test_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_SOURCE_DIR})
 
-    if (UNIX)
-        target_link_libraries(${_tbb_test_NAME} PRIVATE -rdynamic) # for the test_dynamic_link
-    endif()
     if (ANDROID_PLATFORM)
         add_test(NAME ${_tbb_test_NAME}
                 COMMAND ${CMAKE_COMMAND}
@@ -373,6 +367,9 @@ if (TARGET TBB::tbb)
     tbb_add_test(SUBDIR tbb NAME test_allocators DEPENDENCIES TBB::tbb)
     tbb_add_test(SUBDIR tbb NAME test_arena_priorities DEPENDENCIES TBB::tbb)
     tbb_add_test(SUBDIR tbb NAME test_dynamic_link DEPENDENCIES TBB::tbb)
+    if (APPLE OR ANDROID_PLATFORM)
+        target_link_libraries(test_dynamic_link PRIVATE -rdynamic) # for the test_dynamic_link
+    endif()
     tbb_add_test(SUBDIR tbb NAME test_collaborative_call_once DEPENDENCIES TBB::tbb)
     tbb_add_test(SUBDIR tbb NAME test_concurrent_lru_cache DEPENDENCIES TBB::tbb)
     tbb_add_test(SUBDIR tbb NAME test_concurrent_unordered_map DEPENDENCIES TBB::tbb)
@@ -578,9 +575,6 @@ if (TARGET TBB::tbbmalloc)
             ${TBB_COMMON_COMPILE_FLAGS}
             ${TBBMALLOC_LIB_COMPILE_FLAGS}
         )
-        if (UNIX)
-            target_link_libraries(test_malloc_whitebox PRIVATE -rdynamic) # for the test_dynamic_link
-        endif()
         if (ANDROID_PLATFORM)
             add_test(NAME test_malloc_whitebox
                     COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
Signed-off-by: Vladislav Shchapov <phprus@gmail.com>

### Description 
Fix for full LTO build (library and tests) on UNIX systems.


CMake:

```
cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON ../..
```

Before - macOS error:

```
phprus@mbp osx_arm64-lto % ctest --rerun-failed --output-on-failure
Test project /Users/phprus/Devel/oneapi-src/oneTBB/build/osx_arm64-lto
    Start 4: test_dynamic_link
1/1 Test #4: test_dynamic_link ................***Failed    0.00 sec
[doctest] doctest version is "2.4.7"
[doctest] run with "--help" for options
===============================================================================
/Users/phprus/Devel/oneapi-src/oneTBB/test/tbb/test_dynamic_link.cpp:94:
TEST CASE:  Test dynamic_link with non-existing library

/Users/phprus/Devel/oneapi-src/oneTBB/test/common/utils_dynamic_libs.h:116: FATAL ERROR: REQUIRE( func ) is NOT correct!
  values: REQUIRE( NULL )
  logged: The executable doesn't export its symbols. Is the -rdynamic switch set during linking?
          Can't find required symbol in dynamic library

/Users/phprus/Devel/oneapi-src/oneTBB/test/tbb/test_dynamic_link.cpp:73: FATAL ERROR: REQUIRE( (utils::GetAddress(utils::OpenLibrary(nullptr), "foo1") && utils::GetAddress(utils::OpenLibrary(nullptr), "foo2")) ) THREW exception: "unknown exception"
  logged: The executable doesn't export its symbols. Is the -rdynamic switch set during linking?

===============================================================================
/Users/phprus/Devel/oneapi-src/oneTBB/test/tbb/test_dynamic_link.cpp:100:
TEST CASE:  Test dynamic_link

/Users/phprus/Devel/oneapi-src/oneTBB/test/common/utils_dynamic_libs.h:116: FATAL ERROR: REQUIRE( func ) is NOT correct!
  values: REQUIRE( NULL )
  logged: The executable doesn't export its symbols. Is the -rdynamic switch set during linking?
          Can't find required symbol in dynamic library

/Users/phprus/Devel/oneapi-src/oneTBB/test/tbb/test_dynamic_link.cpp:73: FATAL ERROR: REQUIRE( (utils::GetAddress(utils::OpenLibrary(nullptr), "foo1") && utils::GetAddress(utils::OpenLibrary(nullptr), "foo2")) ) THREW exception: "unknown exception"
  logged: The executable doesn't export its symbols. Is the -rdynamic switch set during linking?

===============================================================================
[doctest] test cases: 2 | 0 passed | 2 failed | 0 skipped
[doctest] assertions: 4 | 0 passed | 4 failed |
[doctest] Status: FAILURE!


0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.01 sec

The following tests FAILED:
	  4 - test_dynamic_link (Failed)
Errors while running CTest
phprus@mbp osx_arm64-lto %
```

After - all tests passed.


Fixes

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
