### PR TITLE
Fix: ld: warning: cannot export hidden symbol typeinfo for tbb::detail::r1::unsafe_wait…

### DIFF
--- a/include/oneapi/tbb/detail/_exception.h
+++ b/include/oneapi/tbb/detail/_exception.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ public:
 class TBB_EXPORT unsafe_wait : public std::runtime_error {
 public:
     unsafe_wait(const char* msg) : std::runtime_error(msg) {}
+    const char* __TBB_EXPORTED_METHOD what() const noexcept(true) override;
 };
 
 //! Gathers all throw operators in one place.

--- a/src/tbb/def/win32-tbb.def
+++ b/src/tbb/def/win32-tbb.def
@@ -1,4 +1,4 @@
-; Copyright (c) 2005-2021 Intel Corporation
+; Copyright (c) 2005-2022 Intel Corporation
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");
 ; you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ EXPORTS
 ?what@bad_last_alloc@r1@detail@tbb@@UBEPBDXZ
 ?what@user_abort@r1@detail@tbb@@UBEPBDXZ
 ?what@missing_wait@r1@detail@tbb@@UBEPBDXZ
+?what@unsafe_wait@r1@detail@tbb@@UBEPBDXZ
 
 ; RTM Mutex (rtm_mutex.cpp)
 ?acquire@r1@detail@tbb@@YAXAAVrtm_mutex@d1@23@AAVscoped_lock@4523@_N@Z

--- a/src/tbb/def/win64-tbb.def
+++ b/src/tbb/def/win64-tbb.def
@@ -1,4 +1,4 @@
-; Copyright (c) 2005-2021 Intel Corporation
+; Copyright (c) 2005-2022 Intel Corporation
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");
 ; you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ EXPORTS
 ?what@bad_last_alloc@r1@detail@tbb@@UEBAPEBDXZ
 ?what@user_abort@r1@detail@tbb@@UEBAPEBDXZ
 ?what@missing_wait@r1@detail@tbb@@UEBAPEBDXZ
+?what@unsafe_wait@r1@detail@tbb@@UEBAPEBDXZ
 
 ; RTM Mutex (rtm_mutex.cpp)
 ?try_acquire@r1@detail@tbb@@YA_NAEAVrtm_mutex@d1@23@AEAVscoped_lock@4523@@Z

--- a/src/tbb/exception.cpp
+++ b/src/tbb/exception.cpp
@@ -39,6 +39,7 @@ namespace r1 {
 const char* bad_last_alloc::what() const noexcept(true) { return "bad allocation in previous or concurrent attempt"; }
 const char* user_abort::what() const noexcept(true) { return "User-initiated abort has terminated this operation"; }
 const char* missing_wait::what() const noexcept(true) { return "wait() was not called on the structured_task_group"; }
+const char* unsafe_wait::what() const noexcept(true) { return std::runtime_error::what(); }
 
 #if TBB_USE_EXCEPTIONS
     template <typename F>


### PR DESCRIPTION
… from CMakeFiles/tbb.dir/exception.cpp.o

Signed-off-by: Vladislav Shchapov <phprus@gmail.com>

### Description 
macOS 12.1
Xcode 13.2.1

Linker warning:
```
ld: warning: cannot export hidden symbol typeinfo for tbb::detail::r1::unsafe_wait from CMakeFiles/tbb.dir/exception.cpp.o
```


Fixes #713

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
