### PR TITLE
Fix concurrent-queue pop comment

### DIFF
--- a/include/oneapi/tbb/concurrent_queue.h
+++ b/include/oneapi/tbb/concurrent_queue.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/concurrent_queue.h
+++ b/include/oneapi/tbb/concurrent_queue.h
@@ -375,12 +375,12 @@ public:
     }
 
     // Attempt to dequeue an item from head of queue.
-    /** Does not wait for item to become available.
-        Returns true if successful; false otherwise. */
     bool pop( T& result ) {
         return internal_pop(&result);
     }
 
+    /** Does not wait for item to become available.
+        Returns true if successful; false otherwise. */
     bool try_pop( T& result ) {
         return internal_pop_if_present(&result);
     }


### PR DESCRIPTION
### Description 
Move `does-not-wait` comment to operation which actually does not wait (`try_pop`).

