### PR TITLE
Fix build failure for s390x and hppa architectures.

### DIFF
--- a/src/tbb/tools_api/ittnotify_config.h
+++ b/src/tbb/tools_api/ittnotify_config.h
@@ -163,6 +163,14 @@
 #  define ITT_ARCH_ARM64  6
 #endif /* ITT_ARCH_ARM64 */
 
+#ifndef ITT_ARCH_S390X
+#  define ITT_ARCH_S390X  7
+#endif /* ITT_ARCH_S390X */
+
+#ifndef ITT_ARCH_HPPA
+#  define ITT_ARCH_HPPA  8
+#endif /* ITT_ARCH_HPPA */
+
 #ifndef ITT_ARCH
 #  if defined _M_IX86 || defined __i386__
 #    define ITT_ARCH ITT_ARCH_IA32
@@ -176,6 +184,10 @@
 #    define ITT_ARCH ITT_ARCH_ARM64
 #  elif defined __powerpc64__
 #    define ITT_ARCH ITT_ARCH_PPC64
+#  elif defined __s390__ || defined __s390x__
+#    define ITT_ARCH ITT_ARCH_S390X
+#  elif defined __hppa__
+#    define ITT_ARCH ITT_ARCH_HPPA
 #  endif
 #endif
 


### PR DESCRIPTION
### Description 

Fix build failure for s390x and hppa.

Fixes https://github.com/oneapi-src/oneTBB/issues/776

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
