### PR TITLE
Do not store in LargeObjectCache objects whose sizes align to maxHugeSize

### DIFF
--- a/src/tbbmalloc/large_objects.cpp
+++ b/src/tbbmalloc/large_objects.cpp
@@ -63,7 +63,7 @@ void LargeObjectCache::setHugeSizeThreshold(size_t value)
 
 bool LargeObjectCache::sizeInCacheRange(size_t size)
 {
-    return size <= maxHugeSize && (size <= defaultMaxHugeSize || size >= hugeSizeThreshold);
+    return size < maxHugeSize && (size <= defaultMaxHugeSize || size >= hugeSizeThreshold);
 }
 
 /* ----------------------------------------------------------------------------------------------------- */

--- a/test/tbbmalloc/test_malloc_whitebox.cpp
+++ b/test/tbbmalloc/test_malloc_whitebox.cpp
@@ -1632,6 +1632,12 @@ void TestHugeSizeThreshold() {
     // Unit testing for scalable_allocation_command
     scalable_allocation_mode(TBBMALLOC_SET_HUGE_SIZE_THRESHOLD, 56 * MByte);
     TestHugeSizeThresholdImpl(loc, 56 * MByte, true);
+    // Verify that objects whose sizes align to maxHugeSize are not cached.
+    size_t sz = LargeObjectCache::maxHugeSize;
+    size_t aligned_sz = LargeObjectCache::alignToBin(sz);
+    REQUIRE_MESSAGE(sz == aligned_sz, "maxHugeSize should be aligned.");
+    REQUIRE_MESSAGE(!loc->sizeInCacheRange(sz), "Upper bound sized object shouldn't be cached.");
+    REQUIRE_MESSAGE(loc->get(sz) == nullptr, "Upper bound sized object shouldn't be cached.");
 }
 
 //! \brief \ref error_guessing


### PR DESCRIPTION
### Description 

The following test seg faults on a 64-bit system, because the requested allocation is aligned to 1TB and erroneously attempted to be cached:

```cpp
#include <tbb/scalable_allocator.h>

int main() { void *p = scalable_aligned_malloc(1030792150873, 64); }
```

This patch updates `sizeInCacheRange` to reject `maxHugeSize` (i.e., any size aligned to it will not be cached), which is just outside the last huge bin:

```cpp
class LargeObjectCache {
private:
    // Large bins [minLargeSize, maxLargeSize)
    // Huge bins [maxLargeSize, maxHugeSize)
```

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
