### PR TITLE
Build tbbmalloc also on mips

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -216,18 +216,16 @@ else()
     if (TBB_BUILD)
         add_subdirectory(src/tbb)
     endif()
-    if (NOT "${CMAKE_SYSTEM_PROCESSOR}" MATCHES "mips")
-        if (TBBMALLOC_BUILD)
-            add_subdirectory(src/tbbmalloc)
-            if(TBBMALLOC_PROXY_BUILD AND NOT "${MSVC_CXX_ARCHITECTURE_ID}" MATCHES "ARM64")
-                add_subdirectory(src/tbbmalloc_proxy)
-            endif()
+    if (TBBMALLOC_BUILD)
+        add_subdirectory(src/tbbmalloc)
+        if(TBBMALLOC_PROXY_BUILD AND NOT "${MSVC_CXX_ARCHITECTURE_ID}" MATCHES "ARM64")
+            add_subdirectory(src/tbbmalloc_proxy)
         endif()
-        if (APPLE OR NOT BUILD_SHARED_LIBS)
-            message(STATUS "TBBBind build targets are disabled due to unsupported environment")
-        else()
-            add_subdirectory(src/tbbbind)
-        endif()
+    endif()
+    if (APPLE OR NOT BUILD_SHARED_LIBS)
+        message(STATUS "TBBBind build targets are disabled due to unsupported environment")
+    else()
+        add_subdirectory(src/tbbbind)
     endif()
 
     # -------------------------------------------------------------------


### PR DESCRIPTION
Commit 51c0b2f742920535178560f31c6e91065bf87b41 does not give any information why tbbmalloc is not being built on mips, it would be useful if someone could check the rationale in the original git tree.

There is an (unused/obsolete?) https://github.com/oneapi-src/oneTBB/blob/master/cmake/toolchains/mips.cmake and I wonder whether not building tbbmalloc might have been for this toolchain instead of the processor.

On Debian tbbmalloc builds with gcc for both 32bit and 64bit (little endian) mips.
Enabling all currently disabled tests in `test/CMakeLists.txt` resulted in 133 passes for 64bit and only `test_malloc_pools` failing on 32bit, mips tests will be a separate pull request.

Signed-off-by: Adrian Bunk <bunk@debian.org>