### PR TITLE
fix for mac universal compilation

### DIFF
--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -330,7 +330,7 @@
 #define __TBB_TSX_INTRINSICS_PRESENT (__RTM__ || __INTEL_COMPILER || (_MSC_VER>=1700 && (__TBB_x86_64 || __TBB_x86_32)))
 
 #define __TBB_WAITPKG_INTRINSICS_PRESENT ((__INTEL_COMPILER >= 1900 || __TBB_GCC_VERSION >= 110000 || __TBB_CLANG_VERSION >= 120000) \
-                                         && (_WIN32 || _WIN64 || __unix__ || __APPLE__) && (__TBB_x86_32 || __TBB_x86_64) && !__ANDROID__)
+                                         && (_WIN32 || _WIN64 || __unix__) && (__TBB_x86_32 || __TBB_x86_64) && !__ANDROID__)
 
 /** Internal TBB features & modes **/
 


### PR DESCRIPTION
### Description 
This is a compilation fix for Mac OS Universal, where AppleClang complaints about the usage of `_tpause` referred at https://github.com/oneapi-src/oneTBB/blob/801df0edeb6ed19283744f1e4a41653ed58e7513/src/tbb/scheduler_common.h#L230. This happens because the `waitpkg` doesn't exist on Apple Silicon but the config did not turn it off for Mac OS Universal build (where the code has to be the same but two different platforms are built with).

This fix removes entire Apple platform in __TBB_WAITPKG_INTRINSICS_PRESENT and everything just compiled and run smoothly (on both Apple Silicon and Intel). 

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
