### PR TITLE
Fix signed/unsigned compare.

### DIFF
--- a/test/tbb/test_numa_dist.cpp
+++ b/test/tbb/test_numa_dist.cpp
@@ -143,7 +143,7 @@ TEST_CASE("Double threads") {
     numa example;
     std::vector<DWORD> validateProcgrp;
     std::vector<DWORD> result(example.numaProcessors.size(), 0);
-    for (int i = 0; i < example.numaProcessors.size(); i++) result[i] = 2 * example.numaProcessors[i];
+    for (size_t i = 0; i < example.numaProcessors.size(); i++) result[i] = 2 * example.numaProcessors[i];
     TestNumaDistribution(validateProcgrp, example.maxProcessors * 2, 1);
     REQUIRE(validateProcgrp == result);
 }


### PR DESCRIPTION


### Description 
Warning:
```
test_numa_dist.cpp
F:\...\3rdparty\onetbb\src\test\tbb\test_numa_dist.cpp(146): warning C4018: '<': signed/unsigned mismatch
```
Used ``int`` type  to iterate over std::vector instead of ``size_t``.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [x] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
