### PR TITLE
Resolving doctest errors - correcting test classifications.

### DIFF
--- a/test/tbb/test_numa_dist.cpp
+++ b/test/tbb/test_numa_dist.cpp
@@ -104,9 +104,8 @@ int TestNumaDistribution(std::vector<DWORD> &validateProcgrp, int additionalPara
     return master_thread_proc_grp;
 }
 
-//! \brief Testing Numa Thread Distribution
-//! \brief \ref number of processor in Numa node of master thread
-
+//! Testing Numa Thread Distribution Stability
+//! \brief \ref stress
 TEST_CASE("Numa stability for the same node") {
     numa example;
     std::vector<DWORD> validateProcgrp;
@@ -117,6 +116,8 @@ TEST_CASE("Numa stability for the same node") {
     REQUIRE(validateProcgrp == result);
 }
 
+//! Testing Numa Thread Distribution Overflow
+//! \brief \ref stress
 TEST_CASE("Numa overflow") {
     numa example;
     std::vector<DWORD> validateProcgrp;
@@ -132,6 +133,8 @@ TEST_CASE("Numa overflow") {
     REQUIRE(validateProcgrp == result);
 }
 
+//! Testing Numa Thread Distribution Maximum
+//! \brief \ref stress
 TEST_CASE("Numa all threads") {
     numa example;
     std::vector<DWORD> validateProcgrp;
@@ -139,6 +142,8 @@ TEST_CASE("Numa all threads") {
     REQUIRE(validateProcgrp == example.numaProcessors);
 }
 
+//! Testing Numa Thread Distribution Doubled Max
+//! \brief \ref stress
 TEST_CASE("Double threads") {
     numa example;
     std::vector<DWORD> validateProcgrp;


### PR DESCRIPTION
### Description 
The doctest script run to analyze the Doxygen comments in test files indicated the classification of the tests introduced in #846 was incorrect, and some tests were missing required comments.  This PR resolves those issues.

- [ ] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [X] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
@AnuyaWelling2801 

### Other information
