### PR TITLE
allow building for iOS 32-bit

### DIFF
--- a/cmake/compilers/AppleClang.cmake
+++ b/cmake/compilers/AppleClang.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2022 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 set(TBB_LINK_DEF_FILE_FLAG -Wl,-exported_symbols_list,)
-set(TBB_DEF_FILE_PREFIX mac${TBB_ARCH})
+if (NOT "${CMAKE_OSX_ARCHITECTURES}" MATCHES "armv7")
+    set(TBB_DEF_FILE_PREFIX mac${TBB_ARCH})
+endif()
 set(TBB_WARNING_LEVEL -Wall -Wextra $<$<BOOL:${TBB_STRICT}>:-Werror>)
 set(TBB_TEST_WARNING_FLAGS -Wshadow -Wcast-qual -Woverloaded-virtual -Wnon-virtual-dtor)
 set(TBB_WARNING_SUPPRESS -Wno-parentheses -Wno-non-virtual-dtor -Wno-dangling-else)


### PR DESCRIPTION
### Description 

Building for iOS armv7/armv7s fails with the following error:

```
ninja: error: '../src/tbb/def/mac32-tbb.def', needed by 'appleclang_13.1_cxx11_32_release/libtbb.12.7.dylib', missing and no known rule to make it
```

This change fixes it.

Tested by building with Ninja and Makefiles generators using [ios-cmake toolchain](https://github.com/leetal/ios-cmake), also built the Getting Started example.

```
cmake -S . -B build -G Ninja \
  -DTBB_TEST=OFF \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_TOOLCHAIN_FILE=~/dev/vcmi/vcmi-ios-depends/ios-cmake/ios.toolchain.cmake \
  -DPLATFORM=OS \
  -DENABLE_BITCODE=OFF \
  -DDEPLOYMENT_TARGET=10.0 \
  -DENABLE_ARC=ON \
  -DENABLE_VISIBILITY=ON
```

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Other information
