### PR TITLE
Make alias input_type protected for join_node

### DIFF
--- a/include/oneapi/tbb/detail/_flow_graph_join_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_join_impl.h
@@ -669,12 +669,12 @@
 
     template<typename InputTuple, typename OutputTuple>
     class join_node_FE<reserving, InputTuple, OutputTuple> : public reserving_forwarding_base {
-    public:
+    private:
         static const int N = std::tuple_size<OutputTuple>::value;
         typedef OutputTuple output_type;
         typedef InputTuple input_type;
         typedef join_node_base<reserving, InputTuple, OutputTuple> base_node_type; // for forwarding
-
+    public:
         join_node_FE(graph &g) : reserving_forwarding_base(g), my_node(nullptr) {
             ports_with_no_inputs = N;
             join_helper<N>::set_join_node_pointer(my_inputs, this);
@@ -1028,7 +1028,6 @@
                            public sender<OutputTuple> {
     protected:
         using graph_node::my_graph;
-        using input_type = typename join_node_FE<JP, InputTuple, OutputTuple>::input_type;
     public:
         typedef OutputTuple output_type;
 

--- a/include/oneapi/tbb/detail/_flow_graph_join_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_join_impl.h
@@ -1028,6 +1028,7 @@
                            public sender<OutputTuple> {
     protected:
         using graph_node::my_graph;
+        using input_type = typename join_node_FE<JP, InputTuple, OutputTuple>::input_type;
     public:
         typedef OutputTuple output_type;
 

--- a/include/oneapi/tbb/detail/_flow_graph_join_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_join_impl.h
@@ -1214,10 +1214,10 @@
     //  using tuple_element.  The class PT is the port type (reserving_port, queueing_port, key_matching_port)
     //  and should match the typename.
 
-    template<int N, template<class> class PT, typename OutputTuple, typename JP>
+    template<int M, template<class> class PT, typename OutputTuple, typename JP>
     class unfolded_join_node : public join_base<N,PT,OutputTuple,JP>::type {
     public:
-        typedef typename wrap_tuple_elements<N, PT, OutputTuple>::type input_ports_type;
+        typedef typename wrap_tuple_elements<M, PT, OutputTuple>::type input_ports_type;
         typedef OutputTuple output_type;
     private:
         typedef join_node_base<JP, input_ports_type, output_type > base_type;

--- a/include/oneapi/tbb/detail/_flow_graph_join_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_join_impl.h
@@ -1215,7 +1215,7 @@
     //  and should match the typename.
 
     template<int M, template<class> class PT, typename OutputTuple, typename JP>
-    class unfolded_join_node : public join_base<N,PT,OutputTuple,JP>::type {
+    class unfolded_join_node : public join_base<M,PT,OutputTuple,JP>::type {
     public:
         typedef typename wrap_tuple_elements<M, PT, OutputTuple>::type input_ports_type;
         typedef OutputTuple output_type;


### PR DESCRIPTION
Currently the public aliases exposed by `flow_graph::join_node` includes `input_type`. This is a bit confusing since `join_node` has multiple input ports and I believe other nodes(with multiple inputs) don't have the same issue. I have been leveraging substitution failure with `input_ports_type` and `input_type` and similarly for `output_ports_type` and `output_type` for implementing a higher level interface for flow_graph. AFAIT only `join_node` breaks this distinction. Also, having `join_node` expose `input_type` as a public alias could be confusing to users.
 