### PR TITLE
Fix invalid WORKING_DIRECTORY for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -170,6 +170,13 @@ foreach(output_type LIBRARY ARCHIVE PDB RUNTIME)
         unset(_tbb_suffix_upper)
     endif()
 endforeach()
+
+if (CMAKE_CONFIGURATION_TYPES)
+    # We can't use generator expressions in a cmake variable name.
+    set(TBB_TEST_WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${TBB_OUTPUT_DIR_BASE}_$<LOWER_CASE:$<CONFIG>>)
+else()
+    set(TBB_TEST_WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+endif()
 
 # -------------------------------------------------------------------
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,10 +50,10 @@ function(tbb_add_test)
                          -DTEST_NAME=${_tbb_test_TARGET_NAME}
                          -P ${PROJECT_SOURCE_DIR}/cmake/android/test_launcher.cmake)
     else()
-        add_test(NAME ${_tbb_test_TARGET_NAME} COMMAND ${_tbb_test_TARGET_NAME} --force-colors=1 WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+        add_test(NAME ${_tbb_test_TARGET_NAME} COMMAND ${_tbb_test_TARGET_NAME} --force-colors=1 WORKING_DIRECTORY ${TBB_TEST_WORKING_DIRECTORY})
         # Additional testing scenarios if Intel(R) Software Development Emulator is found
         if (UNIX AND ";test_mutex;conformance_mutex;" MATCHES ";${_tbb_test_TARGET_NAME};" AND SDE_EXE)
-            add_test(NAME ${_tbb_test_TARGET_NAME}_SDE COMMAND ${SDE_EXE} -nhm -rtm_mode disabled -- ./${_tbb_test_TARGET_NAME} --force-colors=1 WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+            add_test(NAME ${_tbb_test_TARGET_NAME}_SDE COMMAND ${SDE_EXE} -nhm -rtm_mode disabled -- ./${_tbb_test_TARGET_NAME} --force-colors=1 WORKING_DIRECTORY ${TBB_TEST_WORKING_DIRECTORY})
             set_property(TEST ${_tbb_test_TARGET_NAME}_SDE PROPERTY ENVIRONMENT ${TBB_TESTS_ENVIRONMENT} APPEND)
         endif()
     endif()
@@ -99,7 +99,7 @@ function(tbb_add_c_test)
                         -DTEST_NAME=${_tbb_test_NAME}
                         -P ${PROJECT_SOURCE_DIR}/cmake/android/test_launcher.cmake)
     else()
-        add_test(NAME ${_tbb_test_NAME} COMMAND ${_tbb_test_NAME} --force-colors=1 WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+        add_test(NAME ${_tbb_test_NAME} COMMAND ${_tbb_test_NAME} --force-colors=1 WORKING_DIRECTORY ${TBB_TEST_WORKING_DIRECTORY})
     endif()
 
     set_property(TEST ${_tbb_test_NAME} PROPERTY ENVIRONMENT ${TBB_TESTS_ENVIRONMENT} APPEND)


### PR DESCRIPTION
### Description 
Fix invalid ``WORKING_DIRECTORY`` for tests and multi-config CMake Generator (like Microsoft Visual Studio).

In a multi-configuration environment, the ``${CMAKE_RUNTIME_OUTPUT_DIRECTORY}`` variable may not correspond to the actual directory where the executables will be.

Error:
```
      Test #137: test_malloc_overload_disable .............***Failed    0.03 sec
'test_malloc_overload_disable.exe' is not recognized as an internal or external command,
operable program or batch file.
[doctest] doctest version is "2.4.7"
[doctest] run with "--help" for options
Test error: unable to run the command: test_malloc_overload_disable.exe

...

The following tests FAILED:
	137 - test_malloc_overload_disable (Failed)
```

See:

https://github.com/oneapi-src/oneTBB/blob/323260671b40db33c9fc0d66d1f1eed6ecc82ce2/CMakeLists.txt#L156-L172

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
