### PR TITLE
Update release notes for oneTBB 2021.7

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,7 +27,7 @@ This document contains changes of oneTBB compared to the last release.
 - An application using Parallel STL algorithms in libstdc++ versions 9 and 10 may fail to compile due to incompatible interface changes between earlier versions of Threading Building Blocks (TBB) and oneAPI Threading Building Blocks (oneTBB). Disable support for Parallel STL algorithms by defining PSTL_USE_PARALLEL_POLICIES (in libstdc++ 9) or _GLIBCXX_USE_TBB_PAR_BACKEND (in libstdc++ 10) macro to zero before inclusion of the first standard header file in each translation unit.
 - On Linux* OS, if oneAPI Threading Building Blocks (oneTBB) or Threading Building Blocks (TBB) are installed in a system folder like /usr/lib64, the application may fail to link due to the order in which the linker searches for libraries. Use the -L linker option to specify the correct location of oneTBB library. This issue does not affect the program execution.
 - The oneapi::tbb::info namespace interfaces might unexpectedly change the process affinity mask on Windows* OS systems (see https://github.com/open-mpi/hwloc/issues/366 for details) when using hwloc version lower than 2.5.
-- Using a hwloc version other than 1.11, 2.0, or 2.5 may cause an undefined behavior on Windows OS. See https://github.com/open-mpi/hwloc/issues/477 for details.
+- Using a hwloc version other than 1.11, 2.0, or 2.5 may cause an undefined behavior on Windows* OS. See https://github.com/open-mpi/hwloc/issues/477 for details.
 - The NUMA topology may be detected incorrectly on Windows OS machines where the number of NUMA node threads exceeds the size of 1 processor group.
 - On Windows OS on ARM64*, when compiling an application using oneTBB with the Microsoft* Compiler, the compiler issues a warning C4324 that a structure was padded due to the alignment specifier. Consider suppressing the warning by specifying /wd4324 to the compiler command line.
 - oneTBB does not support fork(), to work-around the issue, consider using task_scheduler_handle to join oneTBB worker threads before using fork().
@@ -35,8 +35,8 @@ This document contains changes of oneTBB compared to the last release.
 
 ## :hammer: Fixed Issues
 - Memory allocator crash when allocating ~1TB on 64-bit systems (GitHub* [#838](https://github.com/oneapi-src/oneTBB/issues/838)).
-- Thread Distribution over NUMA Nodes on Windows OS systems.
-- For oneapi::tbb::suspend it is now guaranteed that the user-specified callable object is executed by the calling thread.
+- Thread distribution over NUMA nodes on Windows* OS systems.
+- For oneapi::tbb::suspend, it is guaranteed that the user-specified callable object is executed by the calling thread.
 
 ## :octocat: Open-source Contributions Integrated
-- Fix for full LTO build (library and tests) on UNIX* OS systems. Contributed by Vladislav Shchapov (https://github.com/oneapi-src/oneTBB/pull/798).
+- Fix for full LTO* build, library and tests, on UNIX* OS systems. Contributed by Vladislav Shchapov (https://github.com/oneapi-src/oneTBB/pull/798).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,7 @@ This document contains changes of oneTBB compared to the last release.
 - [Open-source Contributions Integrated](#open-source-contributions-integrated)
 
 ## :rotating_light: Known Limitations
+- A static assert will cause compilation failures in oneTBB headers when compiling with clang 12.0.0 or newer if using the LLVM standard library with -ffreestanding and C++11/14 compiler options.
 - An application using Parallel STL algorithms in libstdc++ versions 9 and 10 may fail to compile due to incompatible interface changes between earlier versions of Threading Building Blocks (TBB) and oneAPI Threading Building Blocks (oneTBB). Disable support for Parallel STL algorithms by defining PSTL_USE_PARALLEL_POLICIES (in libstdc++ 9) or _GLIBCXX_USE_TBB_PAR_BACKEND (in libstdc++ 10) macro to zero before inclusion of the first standard header file in each translation unit.
 - On Linux* OS, if oneAPI Threading Building Blocks (oneTBB) or Threading Building Blocks (TBB) are installed in a system folder like /usr/lib64, the application may fail to link due to the order in which the linker searches for libraries. Use the -L linker option to specify the correct location of oneTBB library. This issue does not affect the program execution.
 - The oneapi::tbb::info namespace interfaces might unexpectedly change the process affinity mask on Windows* OS systems (see https://github.com/open-mpi/hwloc/issues/366 for details) when using hwloc version lower than 2.5.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,4 +38,4 @@ This document contains changes of oneTBB compared to the last release.
 - The function provided to oneapi::tbb::suspend is now guaranteed to be executed on the same thread.
 
 ## :octocat: Open-source Contributions Integrated
-- Fix for full LTO build (library and tests) on UNIX* OS systems. Contributed by Vladislav Shchapov (https://github.com/oneapi-src/oneTBB/pull/671).
+- Fix for full LTO build (library and tests) on UNIX* OS systems. Contributed by Vladislav Shchapov (https://github.com/oneapi-src/oneTBB/pull/798).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,7 +35,7 @@ This document contains changes of oneTBB compared to the last release.
 
 ## :hammer: Fixed Issues
 - Memory allocator crash when allocating ~1TB on 64-bit systems (GitHub* [#838](https://github.com/oneapi-src/oneTBB/issues/838)).
-- Thread distribution over NUMA nodes on Windows* OS systems.
+- Fixed thread distribution over NUMA nodes on Windows* OS systems.
 - For oneapi::tbb::suspend, it is guaranteed that the user-specified callable object is executed by the calling thread.
 
 ## :octocat: Open-source Contributions Integrated

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,7 +23,7 @@ This document contains changes of oneTBB compared to the last release.
 - [Open-source Contributions Integrated](#open-source-contributions-integrated)
 
 ## :rotating_light: Known Limitations
-- A static assert will cause compilation failures in oneTBB headers when compiling with clang 12.0.0 or newer if using the LLVM standard library with -ffreestanding and C++11/14 compiler options.
+- A static assert causes compilation failures in oneTBB headers when compiling with Clang* 12.0.0 or newer if using the LLVM* standard library with -ffreestanding and C++11/14 compiler options.
 - An application using Parallel STL algorithms in libstdc++ versions 9 and 10 may fail to compile due to incompatible interface changes between earlier versions of Threading Building Blocks (TBB) and oneAPI Threading Building Blocks (oneTBB). Disable support for Parallel STL algorithms by defining PSTL_USE_PARALLEL_POLICIES (in libstdc++ 9) or _GLIBCXX_USE_TBB_PAR_BACKEND (in libstdc++ 10) macro to zero before inclusion of the first standard header file in each translation unit.
 - On Linux* OS, if oneAPI Threading Building Blocks (oneTBB) or Threading Building Blocks (TBB) are installed in a system folder like /usr/lib64, the application may fail to link due to the order in which the linker searches for libraries. Use the -L linker option to specify the correct location of oneTBB library. This issue does not affect the program execution.
 - The oneapi::tbb::info namespace interfaces might unexpectedly change the process affinity mask on Windows* OS systems (see https://github.com/open-mpi/hwloc/issues/366 for details) when using hwloc version lower than 2.5.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,7 +35,7 @@ This document contains changes of oneTBB compared to the last release.
 ## :hammer: Fixed Issues
 - Memory allocator crash when allocating ~1TB on 64-bit systems (GitHub* [#838](https://github.com/oneapi-src/oneTBB/issues/838)).
 - Thread Distribution over NUMA Nodes on Windows OS systems.
-- The function provided to oneapi::tbb::suspend is now guaranteed to be executed on the same thread.
+- For oneapi::tbb::suspend it is now guaranteed that the user-specified callable object is executed by the calling thread.
 
 ## :octocat: Open-source Contributions Integrated
 - Fix for full LTO build (library and tests) on UNIX* OS systems. Contributed by Vladislav Shchapov (https://github.com/oneapi-src/oneTBB/pull/798).


### PR DESCRIPTION
### Description 
Update release notes for oneTBB 2021.7 release

Fixes # - _issue number(s) if exists_

- [ ] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
Signed-off-by: Valentina Kats valentina.kats@intel.com