### PR TITLE
Add static_assert to prevent implicit conversion of sequencer return type

### DIFF
--- a/include/oneapi/tbb/flow_graph.h
+++ b/include/oneapi/tbb/flow_graph.h
@@ -1600,6 +1600,8 @@ public:
         __TBB_requires(sequencer<Sequencer, T>)
     __TBB_NOINLINE_SYM sequencer_node( graph &g, const Sequencer& s ) : queue_node<T>(g),
         my_sequencer(new function_body_leaf< T, size_t, Sequencer>(s) ) {
+        static_assert(std::is_same_v<decltype(std::declval<Sequencer>()(std::declval<input_type>())), size_t>);
+
         fgt_node( CODEPTR(), FLOW_SEQUENCER_NODE, &(this->my_graph),
                                  static_cast<receiver<input_type> *>(this),
                                  static_cast<sender<output_type> *>(this) );


### PR DESCRIPTION
Currently the sequencer node may implicitly convert a signed sequence key to `size_t` type. To add some safety from the wraparound issue with unsigned integer I propose that the caller should be forced to define a sequencer that explicitly returns a `size_t` type. 
For example, I have seen the following issue happen in practice where the sequencer lambda returns a signed integer and when `ii < 0` the value get's wrapped around.
```
[](int ii) {
   return ii;
}
```

I was willing to put this check in `function_body_leaf`, but their maybe some use cases where we would want to preserve the implicit conversion behavior, not sure.