### PR TITLE
Add TBB_BINARY_VERSION only to the RUNTIME library name on MINGW

### DIFF
--- a/src/tbb/CMakeLists.txt
+++ b/src/tbb/CMakeLists.txt
@@ -45,7 +45,11 @@ add_library(tbb
 add_library(TBB::tbb ALIAS tbb)
 
 if (WIN32)
-    set_target_properties(tbb PROPERTIES OUTPUT_NAME "tbb${TBB_BINARY_VERSION}")
+    if(MINGW)
+        set_target_properties(tbb PROPERTIES RUNTIME_OUTPUT_NAME "tbb${TBB_BINARY_VERSION}")
+    else()
+        set_target_properties(tbb PROPERTIES OUTPUT_NAME "tbb${TBB_BINARY_VERSION}")
+    endif()
 endif()
 
 # TODO: Add statistics.cpp
@@ -144,7 +148,7 @@ endif()
 
 set(_tbb_pc_lib_name tbb)
 
-if (WIN32)
+if (MSVC)
     set(_tbb_pc_lib_name ${_tbb_pc_lib_name}${TBB_BINARY_VERSION})
 endif()
 


### PR DESCRIPTION
### Description 
Make it easy for other packages to use `find_library()` to find tbb.

Fixes finding `tbb` with `find_library` on MINGW.

- [ ] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [x] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
