### PR TITLE
Fix the implicit deduction guides on Apple LLVM 10.0.0

### DIFF
--- a/include/oneapi/tbb/concurrent_unordered_map.h
+++ b/include/oneapi/tbb/concurrent_unordered_map.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -223,6 +223,16 @@ concurrent_unordered_map( std::initializer_list<std::pair<Key, T>>, std::size_t,
 -> concurrent_unordered_map<std::remove_const_t<Key>, T, Hash,
                             std::equal_to<std::remove_const_t<Key>>, Alloc>;
 
+#if __APPLE__ && __TBB_CLANG_VERSION == 100000
+// An explicit deduction guide is required for copy/move constructor with allocator for APPLE LLVM 10.0.0
+// due to an issue with generating an implicit deduction guide for these constructors under several strange surcumstances.
+// Currently the issue takes place because the last template parameter for Traits is boolean, it should not affect the deduction guides
+// The issue reproduces only on this version of the compiler
+template <typename Key, typename T, typename Hash, typename KeyEq, typename Alloc>
+concurrent_unordered_map( concurrent_unordered_map<Key, T, Hash, KeyEq, Alloc>, Alloc )
+-> concurrent_unordered_map<Key, T, Hash, KeyEq, Alloc>;
+#endif
+
 #endif // __TBB_CPP17_DEDUCTION_GUIDES_PRESENT
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>
@@ -372,6 +382,15 @@ concurrent_unordered_multimap( std::initializer_list<std::pair<Key, T>>, std::si
 -> concurrent_unordered_multimap<std::remove_const_t<Key>, T, Hash,
                                  std::equal_to<std::remove_const_t<Key>>, Alloc>;
 
+#if __APPLE__ && __TBB_CLANG_VERSION == 100000
+// An explicit deduction guide is required for copy/move constructor with allocator for APPLE LLVM 10.0.0
+// due to an issue with generating an implicit deduction guide for these constructors under several strange surcumstances.
+// Currently the issue takes place because the last template parameter for Traits is boolean, it should not affect the deduction guides
+// The issue reproduces only on this version of the compiler
+template <typename Key, typename T, typename Hash, typename KeyEq, typename Alloc>
+concurrent_unordered_multimap( concurrent_unordered_multimap<Key, T, Hash, KeyEq, Alloc>, Alloc )
+-> concurrent_unordered_multimap<Key, T, Hash, KeyEq, Alloc>;
+#endif
 #endif // __TBB_CPP17_DEDUCTION_GUIDES_PRESENT
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator>

--- a/include/oneapi/tbb/concurrent_unordered_set.h
+++ b/include/oneapi/tbb/concurrent_unordered_set.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -163,6 +163,15 @@ template <typename T, typename Hash, typename Alloc,
 concurrent_unordered_set( std::initializer_list<T>, std::size_t, Hash, Alloc )
 -> concurrent_unordered_set<T, Hash, std::equal_to<T>, Alloc>;
 
+#if __APPLE__ && __TBB_CLANG_VERSION == 100000
+// An explicit deduction guide is required for copy/move constructor with allocator for APPLE LLVM 10.0.0
+// due to an issue with generating an implicit deduction guide for these constructors under several strange surcumstances.
+// Currently the issue takes place because the last template parameter for Traits is boolean, it should not affect the deduction guides
+// The issue reproduces only on this version of the compiler
+template <typename T, typename Hash, typename KeyEq, typename Alloc>
+concurrent_unordered_set( concurrent_unordered_set<T, Hash, KeyEq, Alloc>, Alloc )
+-> concurrent_unordered_set<T, Hash, KeyEq, Alloc>;
+#endif
 #endif // __TBB_CPP17_DEDUCTION_GUIDES_PRESENT
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>
@@ -292,6 +301,15 @@ template <typename T, typename Hash, typename Alloc,
 concurrent_unordered_multiset( std::initializer_list<T>, std::size_t, Hash, Alloc )
 -> concurrent_unordered_multiset<T, Hash, std::equal_to<T>, Alloc>;
 
+#if __APPLE__ && __TBB_CLANG_VERSION == 100000
+// An explicit deduction guide is required for copy/move constructor with allocator for APPLE LLVM 10.0.0
+// due to an issue with generating an implicit deduction guide for these constructors under several strange surcumstances.
+// Currently the issue takes place because the last template parameter for Traits is boolean, it should not affect the deduction guides
+// The issue reproduces only on this version of the compiler
+template <typename T, typename Hash, typename KeyEq, typename Alloc>
+concurrent_unordered_multiset( concurrent_unordered_multiset<T, Hash, KeyEq, Alloc>, Alloc )
+-> concurrent_unordered_multiset<T, Hash, KeyEq, Alloc>;
+#endif
 #endif // __TBB_CPP17_DEDUCTION_GUIDES_PRESENT
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator>


### PR DESCRIPTION
### Description 
Fixing the issue with `concurrent_unordered_map` Class Template Argument deduction on MacOS with Apple LLVM 10.0.0
The issue is that the implicit deduction guide for copy/move constructor with extra `allocator_type` argument is not working correctly and results in a substitution failure with the unclear logs.

The short reproducer for the issue:

    #define WITH_BOOL 0
    
    #if WITH_BOOL
    template <typename T, typename Allocator, bool Allow>
    #else
    template <typename T, typename Allocator>
    #endif
    struct Traits {
        using allocator_type = Allocator;
    };
    
    template <typename TraitsType>
    struct base {
        using allocator_type = typename TraitsType::allocator_type;
        base() = default;
        base(const base&, const allocator_type&) {}
    };
    
    template <typename T, typename Allocator = std::allocator<T>>
    #if WITH_BOOL
    struct derived : base<Traits<T, Allocator, false>> {
    #else
    struct derived : base<Traits<T, Allocator>> {
    #endif
    private:
    #if WITH_BOOL
        using base_type = base<Traits<T, Allocator , false>>;
    #else
        using base_type = base<Traits<T, Allocator>>;
    #endif
    public:
        using allocator_type = typename base_type::allocator_type;
        using base_type::base_type;
    
        derived() = default;
        derived(const derived& other, const allocator_type& alloc) : base_type(other, alloc) {}
    };
    
    int main() {
        std::allocator<int> alloc;
        derived<int> d1;
    
        derived d2(d1, alloc);
    }

The problem is actually caused by the last boolean template parameter for `Traits`. If there is no such parameter, the code above works fine.
The issue is not reproduced on the Linux LLVM configurations as well as on the elder versions of Apple LLVM.

The fix is to provide explicit deduction guide for copy/move constructor with allocator only for the affected Apple LLVM compiler version.


Fixes # - _issue number(s) if exists_

- [ ] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
