### PR TITLE
Fix build on systems with ucontext.h implemented outside the libc

### DIFF
--- a/cmake/ucontext.cmake
+++ b/cmake/ucontext.cmake
@@ -1,0 +1,20 @@
+# The ucontext API may be implemented outside the default library set
+include(CheckSymbolExists)
+if (NOT DEFINED UCONTEXT_LIBRARIES
+    AND CMAKE_SYSTEM_NAME MATCHES "^Linux")
+    check_symbol_exists("getcontext" "ucontext.h" HAVE_UCONTEXT)
+    if (NOT HAVE_UCONTEXT)
+        message(STATUS "Checking for libucontext")
+        find_library(LIBUCONTEXT "ucontext")
+        if (LIBUCONTEXT STREQUAL "LIBUCONTEXT-NOTFOUND")
+            message(WARNING "No ucontext API available")
+            set(LIBUCONTEXT "")
+        else()
+            message(STATUS "Found libucontext: ${LIBUCONTEXT}")
+            set(HAVE_UCONTEXT 1)
+        endif()
+        set(UCONTEXT_LIBRARIES "${LIBUCONTEXT}" CACHE FILEPATH
+          "Library providing the ucontext API (if not in the default set)")
+    endif()
+endif()
+mark_as_advanced(LIBUCONTEXT HAVE_UCONTEXT)

--- a/src/tbb/CMakeLists.txt
+++ b/src/tbb/CMakeLists.txt
@@ -118,6 +118,7 @@ target_link_libraries(tbb
     Threads::Threads
     ${TBB_LIB_LINK_LIBS}
     ${TBB_COMMON_LINK_LIBS}
+    ${UCONTEXT_LIBRARIES}
 )
 
 tbb_install_target(tbb)


### PR DESCRIPTION
### Description 
Check for the `libucontext` package. The `ucontext.h` API may be implemented outside the libc.

Without this patch the build seems to succeed but results in under-linking.

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users

### Other information
