### PR TITLE
Correct behavior for proportional_mode

### DIFF
--- a/test/tbb/test_partitioner.cpp
+++ b/test/tbb/test_partitioner.cpp
@@ -19,6 +19,7 @@
 #include "tbb/parallel_for.h"
 #include "tbb/task_arena.h"
 #include "tbb/global_control.h"
+#include "oneapi/tbb/mutex.h"
 
 #include "common/utils.h"
 #include "common/utils_concurrency_limit.h"
@@ -28,6 +29,7 @@
 #include <cstddef>
 #include <utility>
 #include <vector>
+#include <algorithm>
 
 //! \file test_partitioner.cpp
 //! \brief Test for [internal] functionality
@@ -137,4 +139,54 @@ void strict_test() {
 TEST_CASE("Threads respect task affinity") {
     task_affinity_retention::relaxed_test();
     task_affinity_retention::strict_test();
+}
+
+template <typename Range>
+void test_custom_range() {
+    int num_trials = 100;
+
+    std::vector<std::vector<std::size_t>> results(num_trials);
+    oneapi::tbb::mutex results_mutex;
+
+    for (int i = 0; i < num_trials; ++i) {
+        oneapi::tbb::parallel_for(Range(0, 42 * utils::get_platform_max_threads(), 1), [&] (const Range& r) {
+            oneapi::tbb::mutex::scoped_lock lock(results_mutex);
+            results[i].push_back(r.size());
+        }, oneapi::tbb::static_partitioner{});
+    }
+
+    for (auto& res : results) {
+        REQUIRE(res.size() == utils::get_platform_max_threads());
+
+        std::size_t min_size = *std::min_element(res.begin(), res.end());
+        for (std::size_t idx = 0; idx < res.size(); ++idx) {
+            REQUIRE(min_size * 2 >= res[idx]);
+        }
+    }
+}
+
+//! \brief \ref regression
+TEST_CASE("Test ranges without proportional split") {
+    class custom_range : public oneapi::tbb::blocked_range<int> {
+        using base_type = oneapi::tbb::blocked_range<int>;
+    public:
+        custom_range(int l, int r, int g) : base_type(l, r, g) {}
+        custom_range(const custom_range& r) : base_type(r) {}
+
+        custom_range(custom_range& r, tbb::split) : base_type(r, tbb::split()) {}
+    };
+
+    test_custom_range<custom_range>();
+
+    class custom_range_with_psplit : public oneapi::tbb::blocked_range<int> {
+        using base_type = oneapi::tbb::blocked_range<int>;
+    public:
+        custom_range_with_psplit(int l, int r, int g) : base_type(l, r, g) {}
+        custom_range_with_psplit(const custom_range_with_psplit& r) : base_type(r) {}
+
+        custom_range_with_psplit(custom_range_with_psplit& r, tbb::split) : base_type(r, tbb::split()) {}
+        custom_range_with_psplit(custom_range_with_psplit& r, tbb::proportional_split& p) : base_type(r, p) {}
+    };
+
+    test_custom_range<custom_range_with_psplit>();
 }


### PR DESCRIPTION
### Description 
This patch correct the behavior of static_partitioner when it used with custom range that does not support proportional splitting. 
For example such combination (static_partitioner + custom range) on machine with 6 threads leads to tasks with: [0,32], [32,64], [64,128], [128,256], [256,512], [512,1024] range distribution. Hence, leads to huge disbalance and performance degradation. 

It happens because during partition at [function](https://github.com/oneapi-src/oneTBB/blob/8155aaeb6baead9bd571bbb76a9b5dc56a1a9403/include/oneapi/tbb/partitioner.h#L283) we lost partitioner dividing proportions.

This patch propose always use proportional_split with calculated proportions with respect to available partitioner resources. The correct constructor for range will be called via [line](https://github.com/oneapi-src/oneTBB/blob/8155aaeb6baead9bd571bbb76a9b5dc56a1a9403/include/oneapi/tbb/parallel_for.h#L87).

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@kboyarinov @aleksei-fedotov 

### Other information
Signed-off-by: pavelkumbrasev <pavel.kumbrasev@intel.com>