### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -120,3 +120,17 @@ REM Install "release with debug information" configuration
 cmake --install . --config relwithdebinfo
 REM Well done! Your installed oneTBB is in %TMP%\my_installed_onetbb
 ```
+
+# Installation from vcpkg
+
+You can download and install oneTBB using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+```sh
+  git clone https://github.com/Microsoft/vcpkg.git
+  cd vcpkg
+  ./bootstrap-vcpkg.sh #.\bootstrap-vcpkg.bat(for windows)
+  ./vcpkg integrate install
+  ./vcpkg install tbb
+```
+
+The oneTBB port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -77,6 +77,19 @@ cmake <options> ..
 cpack
 ```
 
+## Installation from vcpkg
+
+You can download and install oneTBB using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+```sh
+  git clone https://github.com/Microsoft/vcpkg.git
+  cd vcpkg
+  ./bootstrap-vcpkg.sh #.\bootstrap-vcpkg.bat(for Windows)
+  ./vcpkg integrate install
+  ./vcpkg install tbb
+```
+
+The oneTBB port in vcpkg is kept up to date by Microsoft* team members and community contributors. If the version is out of date, create an issue or pull request on the [vcpkg repository](https://github.com/Microsoft/vcpkg).
+
 ## Example of Installation
 
 ### Single-configuration generators
@@ -120,17 +133,4 @@ REM Install "release with debug information" configuration
 cmake --install . --config relwithdebinfo
 REM Well done! Your installed oneTBB is in %TMP%\my_installed_onetbb
 ```
-
-# Installation from vcpkg
-
-You can download and install oneTBB using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
-```sh
-  git clone https://github.com/Microsoft/vcpkg.git
-  cd vcpkg
-  ./bootstrap-vcpkg.sh #.\bootstrap-vcpkg.bat(for windows)
-  ./vcpkg integrate install
-  ./vcpkg install tbb
-```
-
-The oneTBB port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -133,4 +133,3 @@ REM Install "release with debug information" configuration
 cmake --install . --config relwithdebinfo
 REM Well done! Your installed oneTBB is in %TMP%\my_installed_onetbb
 ```
-


### PR DESCRIPTION
`oneTBB` available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `oneTBB` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `oneTBB`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/tbb/portfile.cmake). We try to keep the library maintained as close as possible to the original library.