### PR TITLE
CMake: Include dependency on Threads in published TBBConfig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ else()
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
             COMPONENT devel)
     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+               "find_package(Threads)\n"
                "include(\${CMAKE_CURRENT_LIST_DIR}/${PROJECT_NAME}Targets.cmake)\n")
 
     write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"


### PR DESCRIPTION
Currently neither TBBConfig.cmake nor TBBTargets.cmake specify dependency on Threads package even though TBBTargets.cmake list Threads::Threads among INTERFACE_LINK_LIBRARIES of TBB::tbb library.

This causes configuration failures in projects that specify dependency on TBB via find_package(TBB), but don't themselves depend on the Threads package.

At the moment there's no other way to fix this except to specify the dependency manually.

Maybe some day this will be handled automatically in CMake. This is the bug that tracks such feature: https://gitlab.kitware.com/cmake/cmake/-/issues/20511.

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

