### PR TITLE
Fix tbb4py test sporadic fails

### DIFF
--- a/python/tbb/test.py
+++ b/python/tbb/test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2016-2021 Intel Corporation
+# Copyright (c) 2016-2022 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/tbb/test.py
+++ b/python/tbb/test.py
@@ -86,8 +86,10 @@ def test(arg=None):
     spin_flag = True
     def timeout_work(param):
         nonlocal spin_flag
+        say("[%d] Spin wait work start..." % get_tid())
         while spin_flag:
             time.sleep(0.0001) # yield equivalent
+        say("[%d] Work done." % get_tid())
         return str(param) if param != None else None
 
     ### Test copy/pasted from multiprocessing

--- a/python/tbb/test.py
+++ b/python/tbb/test.py
@@ -103,7 +103,7 @@ def test(arg=None):
             say("Good. Got expected timeout exception.")
         else:
             assert False, "Expected exception !"
-        spin_flag = False # unlock threads
+        spin_flag = False # unlock threads in timeout_work
 
     ### Test copy/pasted from multiprocessing
     pool = Pool(4)  # start worker threads

--- a/python/tbb/test.py
+++ b/python/tbb/test.py
@@ -87,7 +87,6 @@ def test(arg=None):
     def timeout_work(param):
         nonlocal spin_flag
         while spin_flag:
-            # print(spin_flag)
             time.sleep(0.0001) # yield equivalent
         return str(param) if param != None else None
 

--- a/python/tbb/test.py
+++ b/python/tbb/test.py
@@ -103,7 +103,7 @@ def test(arg=None):
             say("Good. Got expected timeout exception.")
         else:
             assert False, "Expected exception !"
-        spin_flag = False
+        spin_flag = False # unlock threads
 
     ### Test copy/pasted from multiprocessing
     pool = Pool(4)  # start worker threads


### PR DESCRIPTION
Signed-off-by: Isaev, Ilya <ilya.isaev@intel.com>

### Description 
There are sporadic fails with tbb4py test (test.py). The problem is that some test cases rely on the fact, that submitted async work will not finish until calling `get` with timeout. To do there is a call for `time.sleep` in functor submitted. Sporadically, expected result is not happening (like OSX example in issue) so to prevent that, the blocking is used.


Fixes #377 

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
