### PR TITLE
Add s390x, hppa and riscv64 architecture detection

### DIFF
--- a/src/tbb/tools_api/ittnotify_config.h
+++ b/src/tbb/tools_api/ittnotify_config.h
@@ -167,6 +167,14 @@
 #  define ITT_ARCH_LOONGARCH64  7
 #endif /* ITT_ARCH_LOONGARCH64 */
 
+#ifndef ITT_ARCH_S390X
+#  define ITT_ARCH_S390X  8
+#endif /* ITT_ARCH_S390X */
+
+#ifndef ITT_ARCH_HPPA
+#  define ITT_ARCH_HPPA  9
+#endif /* ITT_ARCH_HPPA */
+
 #ifndef ITT_ARCH
 #  if defined _M_IX86 || defined __i386__
 #    define ITT_ARCH ITT_ARCH_IA32
@@ -182,6 +190,10 @@
 #    define ITT_ARCH ITT_ARCH_PPC64
 #  elif defined __loongarch__
 #    define ITT_ARCH ITT_ARCH_LOONGARCH64
+#  elif defined __s390__ || defined __s390x__
+#    define ITT_ARCH ITT_ARCH_S390X
+#  elif defined __hppa__
+#    define ITT_ARCH ITT_ARCH_HPPA
 #  endif
 #endif
 

--- a/src/tbb/tools_api/ittnotify_config.h
+++ b/src/tbb/tools_api/ittnotify_config.h
@@ -175,6 +175,10 @@
 #  define ITT_ARCH_HPPA  9
 #endif /* ITT_ARCH_HPPA */
 
+#ifndef ITT_ARCH_RISCV64
+#  define ITT_ARCH_RISCV64  10
+#endif /* ITT_ARCH_RISCV64 */
+
 #ifndef ITT_ARCH
 #  if defined _M_IX86 || defined __i386__
 #    define ITT_ARCH ITT_ARCH_IA32
@@ -194,6 +198,8 @@
 #    define ITT_ARCH ITT_ARCH_S390X
 #  elif defined __hppa__
 #    define ITT_ARCH ITT_ARCH_HPPA
+#  elif defined __riscv && __riscv_xlen == 64
+#    define ITT_ARCH ITT_ARCH_RISCV64
 #  endif
 #endif
 


### PR DESCRIPTION
### Description 

Fixes build failure for riscv64. Also includes previous PR https://github.com/oneapi-src/oneTBB/pull/834 rebased to include s390x and hppa support.

Fix build failure for s390x, riscv64 and hppa.

Fixes #776

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [x] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@cdluminate

### Other information
supersedes https://github.com/oneapi-src/oneTBB/pull/834