### PR TITLE
Exclude includes from version.h during .rc files compilation

### DIFF
--- a/include/oneapi/tbb/version.h
+++ b/include/oneapi/tbb/version.h
@@ -17,8 +17,14 @@
 #ifndef __TBB_version_H
 #define __TBB_version_H
 
-#include "detail/_config.h"
-#include "detail/_namespace_injection.h"
+// Exclude all includes during .rc files compilation
+#ifndef RC_INVOKED
+    #include "detail/_config.h"
+    #include "detail/_namespace_injection.h"
+#else
+    #define __TBB_STRING_AUX(x) #x
+    #define __TBB_STRING(x) __TBB_STRING_AUX(x)
+#endif
 
 // Product version
 #define TBB_VERSION_MAJOR 2021

--- a/src/tbb/tbb.rc
+++ b/src/tbb/tbb.rc
@@ -31,7 +31,6 @@
 //
 #include <winresrc.h>
 #include "../../include/oneapi/tbb/version.h"
-#define ENDL "\r\n"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/src/tbbbind/tbb_bind.rc
+++ b/src/tbbbind/tbb_bind.rc
@@ -31,7 +31,6 @@
 //
 #include <winresrc.h>
 #include "../../include/oneapi/tbb/version.h"
-#define ENDL "\r\n"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/src/tbbmalloc/tbbmalloc.rc
+++ b/src/tbbmalloc/tbbmalloc.rc
@@ -31,7 +31,6 @@
 //
 #include <winresrc.h>
 #include "../../include/oneapi/tbb/version.h"
-#define ENDL "\r\n"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/src/tbbmalloc_proxy/tbbmalloc_proxy.rc
+++ b/src/tbbmalloc_proxy/tbbmalloc_proxy.rc
@@ -31,7 +31,6 @@
 //
 #include <winresrc.h>
 #include "../../include/oneapi/tbb/version.h"
-#define ENDL "\r\n"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS


### PR DESCRIPTION
Signed-off-by: pavelkumbrasev <pavel.kumbrasev@intel.com>

### Description 
This patch is inspired by PR #924. We decided to separate warning fix and future improvements.
Thanks @phprus for provided fix.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
