### PR TITLE
[tbb::parallel_for_each] Don't call destructor for uninitialized object

### DIFF
--- a/include/oneapi/tbb/parallel_for_each.h
+++ b/include/oneapi/tbb/parallel_for_each.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/parallel_for_each.h
+++ b/include/oneapi/tbb/parallel_for_each.h
@@ -306,7 +306,9 @@ struct input_block_handling_task : public task {
     ~input_block_handling_task() {
         for(std::size_t counter = 0; counter < max_block_size; ++counter) {
             (task_pool.begin() + counter)->~iteration_task();
-            (block_iteration_space.begin() + counter)->~Item();
+            if (counter < my_size) {
+                (block_iteration_space.begin() + counter)->~Item();
+            }
         }
     }
 

--- a/test/common/parallel_for_each_common.h
+++ b/test/common/parallel_for_each_common.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/common/parallel_for_each_common.h
+++ b/test/common/parallel_for_each_common.h
@@ -36,12 +36,12 @@
 constexpr std::size_t depths_nubmer = 20;
 static std::atomic<int> g_values_counter;
 
-class value_t {
+class value_t : public utils::NoAfterlife {
     size_t x;
     value_t& operator=(const value_t&);
 public:
     value_t(size_t xx) : x(xx) { ++g_values_counter; }
-    value_t(const value_t& v) : x(v.x) { ++g_values_counter; }
+    value_t(const value_t& v) : utils::NoAfterlife(v), x(v.x) { ++g_values_counter; }
     value_t(value_t&& v) : x(v.x) { ++g_values_counter; }
     ~value_t() { --g_values_counter; }
     size_t value() const volatile { return x; }


### PR DESCRIPTION
Signed-off-by: Isaev, Ilya <ilya.isaev@intel.com>

### Description 
Current implementation of `parallel_for_each` may call destructors for uninitialized objects when using Input iterator and count of elements in block is less than `max_block_size`. This can lead to incorrect memory access in some scenarios.


Fixes #691 

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
