### PR TITLE
Handle case when LRU history capacity is zero

### DIFF
--- a/include/oneapi/tbb/concurrent_lru_cache.h
+++ b/include/oneapi/tbb/concurrent_lru_cache.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/concurrent_lru_cache.h
+++ b/include/oneapi/tbb/concurrent_lru_cache.h
@@ -140,6 +140,11 @@ private:
         if (! --(map_it->second.my_ref_counter)) {
             // if the LRU history is full, evict the oldest items to get space
             if (my_history_list.size() >= my_history_list_capacity) {
+                if (my_history_list_capacity == 0) {
+                    // Since LRU history capacity is zero, there is no need to keep the element in history
+                    my_storage_map.erase(map_it);
+                    return;
+                }
                 std::size_t number_of_elements_to_evict = 1 + my_history_list.size() - my_history_list_capacity;
 
                 for (std::size_t i = 0; i < number_of_elements_to_evict; ++i) {

--- a/test/common/utils.h
+++ b/test/common/utils.h
@@ -462,13 +462,11 @@ public:
     }
 
     static bool is_alive(const LifeTrackableObject& object) {
-        auto it = alive_objects.find(&object);
-        return it != alive_objects.end();
+        return is_alive(&object);
     }
 
     static bool is_alive(const LifeTrackableObject* object) {
-        auto it = alive_objects.find(object);
-        return it != alive_objects.end();
+        return alive_objects.find(object) != alive_objects.end();
     }
 
     static const set_type& set() {

--- a/test/common/utils.h
+++ b/test/common/utils.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <cstring>
 #include <chrono>
+#include <unordered_set>
 
 #if HARNESS_TBBMALLOC_THREAD_SHUTDOWN && __TBB_SOURCE_DIRECTLY_INCLUDED && (_WIN32 || _WIN64)
 #include "../../src/tbbmalloc/tbbmalloc_internal_api.h"
@@ -436,6 +437,45 @@ concept well_formed_instantiation = requires {
     typename Template<Types...>;
 };
 #endif // __TBB_CPP20_CONCEPTS_PRESENT
+
+class LifeTrackableObject {
+    using set_type = std::unordered_set<const LifeTrackableObject*>;
+    static set_type alive_objects;
+public:
+    LifeTrackableObject() {
+        alive_objects.insert(this);
+    }
+
+    LifeTrackableObject(const LifeTrackableObject&) {
+        alive_objects.insert(this);
+    }
+
+    LifeTrackableObject(LifeTrackableObject&&) {
+        alive_objects.insert(this);
+    }
+
+    LifeTrackableObject& operator=(const LifeTrackableObject&) = default;
+    LifeTrackableObject& operator=(LifeTrackableObject&&) = default;
+
+    ~LifeTrackableObject() {
+        alive_objects.erase(this);
+    }
+
+    static bool is_alive(const LifeTrackableObject& object) {
+        auto it = alive_objects.find(&object);
+        return it != alive_objects.end();
+    }
+
+    static bool is_alive(const LifeTrackableObject* object) {
+        auto it = alive_objects.find(object);
+        return it != alive_objects.end();
+    }
+
+    static const set_type& set() {
+        return alive_objects;
+    }
+};
+std::unordered_set<const LifeTrackableObject*> LifeTrackableObject::alive_objects{};
 
 } // namespace utils
 

--- a/test/tbb/test_concurrent_lru_cache.cpp
+++ b/test/tbb/test_concurrent_lru_cache.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_concurrent_lru_cache.cpp
+++ b/test/tbb/test_concurrent_lru_cache.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #include "common/test.h"
+#include "common/utils.h"
 #include <tbb/concurrent_lru_cache.h>
 #include <common/concurrent_lru_cache_common.h>
 
@@ -125,27 +126,27 @@ TEST_CASE("basic test for eviction of only unused items 2") {
     REQUIRE_MESSAGE(is_correct, "cache should not evict items in use");
 }
 
+
+#include <iostream>
 //! \brief \ref error_guessing
 TEST_CASE("basic test for handling case when number_of_lru_history_items is zero") {
-    int call_count = 0;
-    auto counter_func = [&call_count] (int key) {
-        call_count++;
-        return key*2;
+    auto counter_func = [] (int) {
+        return utils::LifeTrackableObject{};
     };
-    
-    using cache_type =  tbb::concurrent_lru_cache<int, int, decltype(counter_func)>;
+    using cache_type =  tbb::concurrent_lru_cache<int, utils::LifeTrackableObject, decltype(counter_func)>;
     cache_type cache{counter_func, 0};
-
-    for(int i = 1; i <= 10; ++i) {
-        cache[1];
-        REQUIRE_MESSAGE(call_count == i, "when number_of_lru_history_items is zero, element must be erased after use");
+    
+    for(int i = 0; i < 10; ++i) {
+        const utils::LifeTrackableObject* obj_addr = &cache[1].value();
+        REQUIRE_MESSAGE(utils::LifeTrackableObject::is_alive(obj_addr) == false, "when number_of_lru_history_items is zero, element must be erased after use");
     }
 
-    call_count = 0;
     cache_type::handle h = cache[1];
+    const utils::LifeTrackableObject* obj_addr = &h.value();
+    auto& object_set = utils::LifeTrackableObject::set();
     for(int i = 0; i < 10; ++i) {
         cache[1];
-        REQUIRE_MESSAGE(call_count == 1, "there is still a reference for key=1");
+        REQUIRE_MESSAGE(utils::LifeTrackableObject::is_alive(obj_addr), "there is still a reference for key=1");
+        REQUIRE_MESSAGE(object_set.size() == 1, "no other values should be added");
     }
-    REQUIRE(h.value() == 2);
 }

--- a/test/tbb/test_concurrent_lru_cache.cpp
+++ b/test/tbb/test_concurrent_lru_cache.cpp
@@ -126,8 +126,6 @@ TEST_CASE("basic test for eviction of only unused items 2") {
     REQUIRE_MESSAGE(is_correct, "cache should not evict items in use");
 }
 
-
-#include <iostream>
 //! \brief \ref error_guessing
 TEST_CASE("basic test for handling case when number_of_lru_history_items is zero") {
     auto counter_func = [] (int) {


### PR DESCRIPTION
Signed-off-by: Isaev, Ilya <ilya.isaev@intel.com>

### Description 
Current implementation of `concurrent_lru_cache` doesn't handle case when `number_of_lru_history_items` equals zero. This patch is inspired by #263


Fixes #265 

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@kboyarinov @pavelkumbrasev @HenryHeffanFormlabs

### Other information
