### PR TITLE
Workaround test_eh_thread sporadic failures

### DIFF
--- a/test/tbb/test_eh_thread.cpp
+++ b/test/tbb/test_eh_thread.cpp
@@ -54,15 +54,16 @@ void limitThreads(size_t limit)
     CHECK_MESSAGE(0 == ret, "setrlimit has returned an error");
 }
 
-static bool g_exception_caught = false;
-static std::mutex m;
-static std::condition_variable cv;
-static std::atomic<bool> stop{ false };
+size_t getThreadLimit() {
+    rlimit rlim;
+
+    int ret = getrlimit(RLIMIT_NPROC, &rlim);
+    CHECK_MESSAGE(0 == ret, "getrlimit has returned an error");
+    return rlim.rlim_cur;
+}
 
 static void* thread_routine(void*)
 {
-    std::unique_lock<std::mutex> lock(m);
-    cv.wait(lock, [] { return stop == true; });
     return nullptr;
 }
 
@@ -94,33 +95,17 @@ TEST_CASE("Too many threads") {
     }
 
     // Some systems set really big limit (e.g. >45К) for the number of processes/threads
-    limitThreads(1024);
-
-    std::thread /* isolate test */ ([] {
-        std::vector<Thread> threads;
-        stop = false;
-        auto finalize = [&] {
-            stop = true;
-            cv.notify_all();
-            for (auto& t : threads) {
-                t.join();
-            }
-        };
-
-        for (int i = 0;; ++i) {
+    limitThreads(1);
+    if (getThreadLimit() == 1) {
+        for (int attempt = 0; attempt < 5; ++attempt) {
             Thread thread;
-            if (!thread.isValid()) {
-                break;
-            }
-            threads.push_back(thread);
-            if (i == 1024) {
-                WARN_MESSAGE(false, "setrlimit seems having no effect");
-                finalize();
+            if (thread.isValid()) {
+                WARN_MESSAGE(false, "We were able to create a thread. setrlimit seems having no effect");
+                thread.join();
                 return;
             }
         }
-        tbb::global_control g(tbb::global_control::max_allowed_parallelism, 2);
-        g_exception_caught = false;
+        bool g_exception_caught = false;
         try {
             // Initialize the library to create worker threads
             tbb::parallel_for(0, 2, [](int) {});
@@ -133,11 +118,11 @@ TEST_CASE("Too many threads") {
         }
         // Do not CHECK to avoid memory allocation (we can be out of memory)
         if (!g_exception_caught) {
-            // There is no guarantee that new thread creation will fail even if we directly set the limit
-            // because another process might free resources during library initialization.
-            WARN_MESSAGE(false, "No exception was thrown on library initialization");
+            FAIL("No exception was thrown on library initialization");
         }
         finalize();
-    }).join();
+    } else {
+        WARN_MESSAGE(false, "setrlimit seems having no effect");
+    }
 }
 #endif

--- a/test/tbb/test_eh_thread.cpp
+++ b/test/tbb/test_eh_thread.cpp
@@ -119,6 +119,7 @@ TEST_CASE("Too many threads") {
                 return;
             }
         }
+        tbb::global_control g(tbb::global_control::max_allowed_parallelism, 2);
         g_exception_caught = false;
         try {
             // Initialize the library to create worker threads
@@ -132,7 +133,9 @@ TEST_CASE("Too many threads") {
         }
         // Do not CHECK to avoid memory allocation (we can be out of memory)
         if (!g_exception_caught) {
-            FAIL("No exception was caught");
+            // There is no guarantee that new thread creation will fail even if we directly set the limit
+            // because another process might free resources during library initialization.
+            WARN_MESSAGE(false, "No exception was thrown on library initialization");
         }
         finalize();
     }).join();

--- a/test/tbb/test_eh_thread.cpp
+++ b/test/tbb/test_eh_thread.cpp
@@ -120,7 +120,6 @@ TEST_CASE("Too many threads") {
         if (!g_exception_caught) {
             FAIL("No exception was thrown on library initialization");
         }
-        finalize();
     } else {
         WARN_MESSAGE(false, "setrlimit seems having no effect");
     }


### PR DESCRIPTION
Signed-off-by: Isaev, Ilya <ilya.isaev@intel.com>

### Description 
Test might sporadically fail on test case "Too many threads" because there is no guarantee that new thread creation will fail even if we directly set the limit because another process might free resources during library initialization. Since this behavior is not under TBB or test control, we only can decrease probability of that scenario. Current patch reworks test by setting thread limit to 1 to prevent TBB threads initialization and to allow it to throw an exception.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
