### PR TITLE
Fixes for Android NDK 25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,10 +279,27 @@ endif()
 
 if (ANDROID_PLATFORM)
     if ("${ANDROID_STL}" STREQUAL "c++_shared")
-        configure_file(
-        "${ANDROID_NDK}/sources/cxx-stl/llvm-libc++/libs/${ANDROID_ABI}/libc++_shared.so"
-        "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libc++_shared.so"
-        COPYONLY)
+        if (${ANDROID_NDK_MAJOR} GREATER_EQUAL "25")
+            if(ANDROID_ABI STREQUAL "arm64-v8a")
+                set(ANDROID_TOOLCHAIN_NAME "aarch64-linux-android")
+            elseif(ANDROID_ABI STREQUAL "x86_64")
+                set(ANDROID_TOOLCHAIN_NAME "x86_64-linux-android")
+            elseif(ANDROID_ABI STREQUAL "armeabi-v7a")
+                set(ANDROID_TOOLCHAIN_NAME "arm-linux-androideabi")
+            elseif(ANDROID_ABI STREQUAL "x86")
+                set(ANDROID_TOOLCHAIN_NAME "i686-linux-android")
+            endif()
+
+            configure_file(
+            "${ANDROID_TOOLCHAIN_ROOT}/sysroot/usr/lib/${ANDROID_TOOLCHAIN_NAME}/libc++_shared.so"
+            "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libc++_shared.so"
+            COPYONLY)
+        else()
+            configure_file(
+                "${ANDROID_NDK}/sources/cxx-stl/llvm-libc++/libs/${ANDROID_ABI}/libc++_shared.so"
+                "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libc++_shared.so"
+                COPYONLY)
+        endif()
     endif()
     # This custom target may be implemented without separate CMake script, but it requires
     # ADB(Android Debug Bridge) executable file availability, so to incapsulate this requirement


### PR DESCRIPTION
### Description 

Since Android NDK 25 `libc++_shared.so` is only in one location.


- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
