### PR TITLE
Workaroud to -Wdeprecated-declarations warnings on macOS 13 SDK

### DIFF
--- a/test/common/doctest.h
+++ b/test/common/doctest.h
@@ -3692,6 +3692,7 @@ String toString(float in) { return fpToString(in, 5) + "f"; }
 String toString(double in) { return fpToString(in, 10); }
 String toString(double long in) { return fpToString(in, 15); }
 
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
 #define DOCTEST_TO_STRING_OVERLOAD(type, fmt)                                                      \
     String toString(type in) {                                                                     \
         char buf[64];                                                                              \
@@ -3710,6 +3711,7 @@ DOCTEST_TO_STRING_OVERLOAD(int long, "%ld")
 DOCTEST_TO_STRING_OVERLOAD(int long unsigned, "%lu")
 DOCTEST_TO_STRING_OVERLOAD(int long long, "%lld")
 DOCTEST_TO_STRING_OVERLOAD(int long long unsigned, "%llu")
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
 String toString(std::nullptr_t) { return "NULL"; }
 

--- a/test/tbb/test_parallel_sort.cpp
+++ b/test/tbb/test_parallel_sort.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@
 #include <string>
 #include <cstring>
 #include <cstddef>
-#include <cstdio>
 #include <iterator>
 #include <type_traits>
 
@@ -99,13 +98,7 @@ void set(Minimal& minimal_ref, ValueType new_value) {
 
 template <typename KeyType>
 void set(std::string& string_ref, KeyType key) {
-    static char buffer[20];
-#if _MSC_VER && __STDC_SECURE_LIB__>=200411
-    sprintf_s(buffer, sizeof(buffer), "%f", static_cast<float>(key));
-#else
-    sprintf(buffer, "%f", static_cast<float>(key));
-#endif
-    string_ref = buffer;
+    string_ref = std::to_string(static_cast<float>(key));
 }
 
 


### PR DESCRIPTION
### Description

XCode 14.1:
    AppleClang 14.0.0.14000029
    macOS 13 SDK

Error 1:
```
/Users/phprus/Devel/oneapi-src/oneTBB/test/common/doctest.h:3702:1: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
DOCTEST_TO_STRING_OVERLOAD(char, "%d")
```

Error 2:
```
/Users/phprus/Devel/oneapi-src/oneTBB/test/tbb/test_parallel_sort.cpp:106:5: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
    sprintf(buffer, "%f", static_cast<float>(key));
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
```



Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
