### PR TITLE
Fix part of Coverity hits

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,36 +18,25 @@
 This document contains changes of oneTBB compared to the last release.
 
 ## Table of Contents <!-- omit in toc -->
-- [New Features](#new_features)
 - [Known Limitations](#known-limitations)
 - [Fixed Issues](#fixed-issues)
 - [Open-source Contributions Integrated](#open-source-contributions-integrated)
 
-## :white_check_mark: New Features
-- Improved support and use of the latest C++ standards for parallel_sort that allows using this algorithm with user-defined and standard library-defined objects with modern semantics.
-- The following features are now fully functional: task_arena extensions, collaborative_call_once, adaptive mutexes, heterogeneous overloads for concurrent_hash_map, and task_scheduler_handle.
-- Added support for Windows* Server 2022 and Python 3.10.
-
 ## :rotating_light: Known Limitations
+- A static assert causes compilation failures in oneTBB headers when compiling with Clang* 12.0.0 or newer if using the LLVM* standard library with -ffreestanding and C++11/14 compiler options.
 - An application using Parallel STL algorithms in libstdc++ versions 9 and 10 may fail to compile due to incompatible interface changes between earlier versions of Threading Building Blocks (TBB) and oneAPI Threading Building Blocks (oneTBB). Disable support for Parallel STL algorithms by defining PSTL_USE_PARALLEL_POLICIES (in libstdc++ 9) or _GLIBCXX_USE_TBB_PAR_BACKEND (in libstdc++ 10) macro to zero before inclusion of the first standard header file in each translation unit.
 - On Linux* OS, if oneAPI Threading Building Blocks (oneTBB) or Threading Building Blocks (TBB) are installed in a system folder like /usr/lib64, the application may fail to link due to the order in which the linker searches for libraries. Use the -L linker option to specify the correct location of oneTBB library. This issue does not affect the program execution.
 - The oneapi::tbb::info namespace interfaces might unexpectedly change the process affinity mask on Windows* OS systems (see https://github.com/open-mpi/hwloc/issues/366 for details) when using hwloc version lower than 2.5.
-- Using a hwloc version other than 1.11, 2.0, or 2.5 may cause an undefined behavior on Windows OS. See https://github.com/open-mpi/hwloc/issues/477 for details.
+- Using a hwloc version other than 1.11, 2.0, or 2.5 may cause an undefined behavior on Windows* OS. See https://github.com/open-mpi/hwloc/issues/477 for details.
 - The NUMA topology may be detected incorrectly on Windows OS machines where the number of NUMA node threads exceeds the size of 1 processor group.
 - On Windows OS on ARM64*, when compiling an application using oneTBB with the Microsoft* Compiler, the compiler issues a warning C4324 that a structure was padded due to the alignment specifier. Consider suppressing the warning by specifying /wd4324 to the compiler command line.
 - oneTBB does not support fork(), to work-around the issue, consider using task_scheduler_handle to join oneTBB worker threads before using fork().
 - C++ exception handling mechanism on Windows* OS on ARM64* might corrupt memory if an exception is thrown from any oneTBB parallel algorithm (see Windows* OS on ARM64* compiler issue: https://developercommunity.visualstudio.com/t/ARM64-incorrect-stack-unwinding-for-alig/1544293).
 
 ## :hammer: Fixed Issues
-- Memory allocator crash on a system with an incomplete /proc/meminfo (GitHub* [#584](https://github.com/oneapi-src/oneTBB/issues/584)).
-- Incorrect blocking of task stealing (GitHub* #[478](https://github.com/oneapi-src/oneTBB/issues/478)).
-- Hang due to incorrect decrement of a limiter_node (GitHub* [#634](https://github.com/oneapi-src/oneTBB/issues/634)).
-- Memory corruption in some rare cases when passing big messages in a flow graph (GitHub* [#639](https://github.com/oneapi-src/oneTBB/issues/639)).
-- Possible deadlock in a throwable flow graph node with a lightweight policy. The lightweight policy is now ignored for functors that can throw exceptions (GitHub* [#420](https://github.com/oneapi-src/oneTBB/issues/420)).
-- Crash when obtaining a range from empty ordered and unordered containers (GitHub* [#641](https://github.com/oneapi-src/oneTBB/issues/641)).
-- Deadlock in a concurrent_vector resize() that could happen when the new size is less than the previous size (GitHub* [#733](https://github.com/oneapi-src/oneTBB/issues/733)).
+- Memory allocator crash when allocating ~1TB on 64-bit systems (GitHub* [#838](https://github.com/oneapi-src/oneTBB/issues/838)).
+- Fixed thread distribution over NUMA nodes on Windows* OS systems.
+- For oneapi::tbb::suspend, it is guaranteed that the user-specified callable object is executed by the calling thread.
 
 ## :octocat: Open-source Contributions Integrated
-- Improved aligned memory allocation. Contributed by Andrey Semashev (https://github.com/oneapi-src/oneTBB/pull/671).
-- Optimized usage of atomic_fence on IA-32 and Intel(R) 64 architectures. Contributed by Andrey Semashev (https://github.com/oneapi-src/oneTBB/pull/328).
-- Fixed incorrect definition of the assignment operator in containers. Contributed by Andrey Semashev (https://github.com/oneapi-src/oneTBB/issues/372).
+- Fix for full LTO* build, library and tests, on UNIX* OS systems. Contributed by Vladislav Shchapov (https://github.com/oneapi-src/oneTBB/pull/798).

--- a/include/oneapi/tbb/concurrent_hash_map.h
+++ b/include/oneapi/tbb/concurrent_hash_map.h
@@ -158,8 +158,7 @@ public:
         if (is_initial) {
             init_buckets_impl(ptr, sz);
         } else {
-            node_base* bucket_initializer = reinterpret_cast<node_base*>(rehash_req_flag);
-            init_buckets_impl(ptr, sz, bucket_initializer);
+            init_buckets_impl(ptr, sz, reinterpret_cast<node_base*>(rehash_req_flag));
         }
     }
 

--- a/include/oneapi/tbb/concurrent_hash_map.h
+++ b/include/oneapi/tbb/concurrent_hash_map.h
@@ -147,9 +147,9 @@ public:
     }
 
     template <typename... Args>
-    void init_buckets_impl( segment_ptr_type ptr, size_type sz, Args&&... args ) {
+    void init_buckets_impl( segment_ptr_type ptr, size_type sz, const Args&... args ) {
         for (size_type i = 0; i < sz; ++i) {
-            bucket_allocator_traits::construct(my_allocator, ptr + i, std::forward<Args>(args)...);
+            bucket_allocator_traits::construct(my_allocator, ptr + i, args...);
         }
     }
 
@@ -158,7 +158,8 @@ public:
         if (is_initial) {
             init_buckets_impl(ptr, sz);
         } else {
-            init_buckets_impl(ptr, sz, reinterpret_cast<node_base*>(rehash_req_flag));
+            node_base* bucket_initializer = reinterpret_cast<node_base*>(rehash_req_flag);
+            init_buckets_impl(ptr, sz, bucket_initializer);
         }
     }
 

--- a/include/oneapi/tbb/concurrent_lru_cache.h
+++ b/include/oneapi/tbb/concurrent_lru_cache.h
@@ -325,13 +325,16 @@ public:
 public:
     retrieve_aggregator_operation(key_type key)
         : aggregator_operation(aggregator_operation::op_type::retrieve),
-          my_key(key), my_is_new_value_needed(false) {}
+          my_key(key), my_map_record_ptr(nullptr), my_is_new_value_needed(false) {}
 
     void handle(lru_cache_type& lru_cache_ref) {
         my_map_record_ptr = &lru_cache_ref.retrieve_serial(my_key, my_is_new_value_needed);
     }
 
-    storage_map_reference_type result() { return *my_map_record_ptr; }
+    storage_map_reference_type result() {
+        __TBB_ASSERT(my_map_record_ptr, "Attempt to call result() before calling handle()");
+        return *my_map_record_ptr;
+    }
 
     bool is_new_value_needed() { return my_is_new_value_needed; }
 };

--- a/include/oneapi/tbb/detail/_aggregator.h
+++ b/include/oneapi/tbb/detail/_aggregator.h
@@ -155,14 +155,17 @@ public:
 // template<class U, class V> friend class aggregating_functor;
 template <typename AggregatingClass, typename OperationList>
 class aggregating_functor {
-    AggregatingClass* my_object;
+    AggregatingClass* my_object = nullptr;
 public:
     aggregating_functor() = default;
     aggregating_functor( AggregatingClass* object ) : my_object(object) {
         __TBB_ASSERT(my_object, nullptr);
     }
 
-    void operator()( OperationList* op_list ) { my_object->handle_operations(op_list); }
+    void operator()( OperationList* op_list ) {
+        __TBB_ASSERT(my_object, nullptr);
+        my_object->handle_operations(op_list);
+    }
 }; // class aggregating_functor
 
 

--- a/include/oneapi/tbb/detail/_concurrent_skip_list.h
+++ b/include/oneapi/tbb/detail/_concurrent_skip_list.h
@@ -1068,6 +1068,7 @@ protected:
                 __TBB_ASSERT(!handle.empty(), "Extracted handle in merge is empty");
 
                 if (!insert(std::move(handle)).second) {
+                    __TBB_ASSERT(!handle.empty(), "Handle should not be empty if insert fails");
                     //If the insertion fails - return the node into source
                     source.insert(std::move(handle));
                 }

--- a/include/oneapi/tbb/detail/_flow_graph_join_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_join_impl.h
@@ -384,7 +384,7 @@
             graph_task* bypass_t;
             // constructor for value parameter
             queueing_port_operation(const T& e, op_type t) :
-                type(char(t)), my_val(e)
+                type(char(t)), my_val(e), my_arg(nullptr)
                 , bypass_t(nullptr)
             {}
             // constructor for pointer parameter
@@ -393,7 +393,7 @@
                 , bypass_t(nullptr)
             {}
             // constructor with no parameter
-            queueing_port_operation(op_type t) : type(char(t))
+            queueing_port_operation(op_type t) : type(char(t)), my_arg(nullptr)
                 , bypass_t(nullptr)
             {}
         };
@@ -422,6 +422,7 @@
                     break;
                 case get__item:
                     if(!this->buffer_empty()) {
+                        __TBB_ASSERT(current->my_arg, nullptr);
                         *(current->my_arg) = this->front();
                         current->status.store( SUCCEEDED, std::memory_order_release);
                     }
@@ -547,12 +548,12 @@
             input_type *my_arg;
             // constructor for value parameter
             key_matching_port_operation(const input_type& e, op_type t) :
-                type(char(t)), my_val(e) {}
+                type(char(t)), my_val(e), my_arg(nullptr) {}
             // constructor for pointer parameter
             key_matching_port_operation(const input_type* p, op_type t) :
                 type(char(t)), my_arg(const_cast<input_type*>(p)) {}
             // constructor with no parameter
-            key_matching_port_operation(op_type t) : type(char(t)) {}
+            key_matching_port_operation(op_type t) : type(char(t)), my_arg(nullptr) {}
         };
 
         typedef aggregating_functor<class_type, key_matching_port_operation> handler_type;
@@ -573,6 +574,7 @@
                     break;
                 case get__item:
                     // use current_key from FE for item
+                    __TBB_ASSERT(current->my_arg, nullptr);
                     if(!this->find_with_key(my_join->current_key, *(current->my_arg))) {
                         __TBB_ASSERT(false, "Failed to find item corresponding to current_key.");
                     }

--- a/include/oneapi/tbb/detail/_flow_graph_node_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_node_impl.h
@@ -159,8 +159,8 @@ private:
         };
         graph_task* bypass_t;
         operation_type(const input_type& e, op_type t) :
-            type(char(t)), elem(const_cast<input_type*>(&e)) {}
-        operation_type(op_type t) : type(char(t)), r(nullptr) {}
+            type(char(t)), elem(const_cast<input_type*>(&e)), bypass_t(nullptr) {}
+        operation_type(op_type t) : type(char(t)), r(nullptr), bypass_t(nullptr) {}
     };
 
     bool forwarder_busy;

--- a/include/oneapi/tbb/flow_graph.h
+++ b/include/oneapi/tbb/flow_graph.h
@@ -1183,8 +1183,9 @@ protected:
 
         buffer_operation(const T& e, op_type t) : type(char(t))
                                                   , elem(const_cast<T*>(&e)) , ltask(nullptr)
+                                                  , r(nullptr)
         {}
-        buffer_operation(op_type t) : type(char(t)),  ltask(nullptr) {}
+        buffer_operation(op_type t) : type(char(t)), elem(nullptr), ltask(nullptr), r(nullptr) {}
     };
 
     bool forwarder_busy;
@@ -1271,12 +1272,14 @@ protected:
 
     //! Register successor
     virtual void internal_reg_succ(buffer_operation *op) {
+        __TBB_ASSERT(op->r, nullptr);
         my_successors.register_successor(*(op->r));
         op->status.store(SUCCEEDED, std::memory_order_release);
     }
 
     //! Remove successor
     virtual void internal_rem_succ(buffer_operation *op) {
+        __TBB_ASSERT(op->r, nullptr);
         my_successors.remove_successor(*(op->r));
         op->status.store(SUCCEEDED, std::memory_order_release);
     }
@@ -1330,12 +1333,14 @@ protected:
     }
 
     virtual bool internal_push(buffer_operation *op) {
+        __TBB_ASSERT(op->elem, nullptr);
         this->push_back(*(op->elem));
         op->status.store(SUCCEEDED, std::memory_order_release);
         return true;
     }
 
     virtual void internal_pop(buffer_operation *op) {
+        __TBB_ASSERT(op->elem, nullptr);
         if(this->pop_back(*(op->elem))) {
             op->status.store(SUCCEEDED, std::memory_order_release);
         }
@@ -1345,6 +1350,7 @@ protected:
     }
 
     virtual void internal_reserve(buffer_operation *op) {
+        __TBB_ASSERT(op->elem, nullptr);
         if(this->reserve_front(*(op->elem))) {
             op->status.store(SUCCEEDED, std::memory_order_release);
         }

--- a/include/oneapi/tbb/parallel_for.h
+++ b/include/oneapi/tbb/parallel_for.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/parallel_for.h
+++ b/include/oneapi/tbb/parallel_for.h
@@ -79,6 +79,7 @@ struct start_for : public task {
     start_for( const Range& range, const Body& body, Partitioner& partitioner, small_object_allocator& alloc ) :
         my_range(range),
         my_body(body),
+        my_parent(nullptr),
         my_partition(partitioner),
         my_allocator(alloc) {}
     //! Splitting constructor used to generate children.
@@ -86,6 +87,7 @@ struct start_for : public task {
     start_for( start_for& parent_, typename Partitioner::split_type& split_obj, small_object_allocator& alloc ) :
         my_range(parent_.my_range, get_range_split_object<Range>(split_obj)),
         my_body(parent_.my_body),
+        my_parent(nullptr),
         my_partition(parent_.my_partition, split_obj),
         my_allocator(alloc) {}
     //! Construct right child from the given range as response to the demand.
@@ -93,6 +95,7 @@ struct start_for : public task {
     start_for( start_for& parent_, const Range& r, depth_t d, small_object_allocator& alloc ) :
         my_range(r),
         my_body(parent_.my_body),
+        my_parent(nullptr),
         my_partition(parent_.my_partition, split()),
         my_allocator(alloc)
     {

--- a/include/oneapi/tbb/parallel_reduce.h
+++ b/include/oneapi/tbb/parallel_reduce.h
@@ -104,6 +104,7 @@ struct start_reduce : public task {
     start_reduce( const Range& range, Body& body, Partitioner& partitioner, small_object_allocator& alloc ) :
         my_range(range),
         my_body(&body),
+        my_parent(nullptr),
         my_partition(partitioner),
         my_allocator(alloc),
         is_right_child(false) {}
@@ -112,6 +113,7 @@ struct start_reduce : public task {
     start_reduce( start_reduce& parent_, typename Partitioner::split_type& split_obj, small_object_allocator& alloc ) :
         my_range(parent_.my_range, get_range_split_object<Range>(split_obj)),
         my_body(parent_.my_body),
+        my_parent(nullptr),
         my_partition(parent_.my_partition, split_obj),
         my_allocator(alloc),
         is_right_child(true)
@@ -123,6 +125,7 @@ struct start_reduce : public task {
     start_reduce( start_reduce& parent_, const Range& r, depth_t d, small_object_allocator& alloc ) :
         my_range(r),
         my_body(parent_.my_body),
+        my_parent(nullptr),
         my_partition(parent_.my_partition, split()),
         my_allocator(alloc),
         is_right_child(true)
@@ -201,6 +204,7 @@ task* start_reduce<Range,Body,Partitioner>::execute(execution_data& ed) {
 
     // The acquire barrier synchronizes the data pointed with my_body if the left
     // task has already finished.
+    __TBB_ASSERT(my_parent, nullptr);
     if( is_right_child && my_parent->m_ref_count.load(std::memory_order_acquire) == 2 ) {
         tree_node_type* parent_ptr = static_cast<tree_node_type*>(my_parent);
         my_body = (Body*) new( parent_ptr->zombie_space.begin() ) Body(*my_body, split());
@@ -261,6 +265,7 @@ struct start_deterministic_reduce : public task {
     start_deterministic_reduce( const Range& range, Partitioner& partitioner, Body& body, small_object_allocator& alloc ) :
         my_range(range),
         my_body(body),
+        my_parent(nullptr),
         my_partition(partitioner),
         my_allocator(alloc) {}
     //! Splitting constructor used to generate children.
@@ -269,6 +274,7 @@ struct start_deterministic_reduce : public task {
                                 small_object_allocator& alloc ) :
         my_range(parent_.my_range, get_range_split_object<Range>(split_obj)),
         my_body(body),
+        my_parent(nullptr),
         my_partition(parent_.my_partition, split_obj),
         my_allocator(alloc) {}
     static void run(const Range& range, Body& body, Partitioner& partitioner, task_group_context& context) {

--- a/include/oneapi/tbb/partitioner.h
+++ b/include/oneapi/tbb/partitioner.h
@@ -160,6 +160,7 @@ struct tree_node : public node {
 template<typename TreeNodeType>
 void fold_tree(node* n, const execution_data& ed) {
     for (;;) {
+        __TBB_ASSERT(n, nullptr);
         __TBB_ASSERT(n->m_ref_count.load(std::memory_order_relaxed) > 0, "The refcount must be positive.");
         call_itt_task_notify(releasing, n);
         if (--n->m_ref_count > 0) {


### PR DESCRIPTION
### Description 
Fixed "Using a moved object" bug in `concurrent_hash_map`.
Improved source code around "Uninitialized pointer fields" hits.


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
