### PR TITLE
fix build on macOS 10.6

### DIFF
--- a/src/tbbmalloc_proxy/proxy_overload_osx.h
+++ b/src/tbbmalloc_proxy/proxy_overload_osx.h
@@ -135,9 +135,11 @@ struct DoMallocReplacement {
         introspect.force_unlock = &zone_force_unlock;
         introspect.statistics = zone_statistics;
         introspect.zone_locked = &zone_locked;
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
         introspect.enable_discharge_checking = &impl_zone_enable_discharge_checking;
         introspect.disable_discharge_checking = &impl_zone_disable_discharge_checking;
         introspect.discharge = &impl_zone_discharge;
+#endif
 
         zone.size = &impl_malloc_usable_size;
         zone.malloc = &impl_malloc;
@@ -151,7 +153,9 @@ struct DoMallocReplacement {
         zone.version = 8;
         zone.memalign = impl_memalign;
         zone.free_definite_size = &impl_free_definite_size;
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
         zone.pressure_relief = &impl_pressure_relief;
+#endif
 
         // make sure that default purgeable zone is initialized
         malloc_default_purgeable_zone();


### PR DESCRIPTION
### Description 

This is trivial changes that allows to build oneTBB on old macOS with old malloc.

Fixes #830

- [ ] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
