### PR TITLE
Remove unused variable

### DIFF
--- a/test/conformance/conformance_flowgraph.h
+++ b/test/conformance/conformance_flowgraph.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2020-2021 Intel Corporation
+    Copyright (c) 2020-2022 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/conformance/conformance_flowgraph.h
+++ b/test/conformance/conformance_flowgraph.h
@@ -79,8 +79,9 @@ struct message {
 template<typename V>
 typename std::enable_if<!std::is_default_constructible<V>::value, std::vector<V>>::type get_values( test_push_receiver<V>& rr ) {
     std::vector<V> messages;
-    int val = 0;
-    for(V tmp(0); rr.try_get(tmp); ++val) {
+    V tmp(0);
+
+    while (rr.try_get(tmp)) {
         messages.push_back(tmp);
     }
     return messages;
@@ -89,8 +90,9 @@ typename std::enable_if<!std::is_default_constructible<V>::value, std::vector<V>
 template<typename V>
 typename std::enable_if<std::is_default_constructible<V>::value, std::vector<V>>::type get_values( test_push_receiver<V>& rr ) {
     std::vector<V> messages;
-    int val = 0;
-    for(V tmp; rr.try_get(tmp); ++val) {
+    V tmp;
+
+    while (rr.try_get(tmp)) {
         messages.push_back(tmp);
     }
     return messages;


### PR DESCRIPTION
Signed-off-by: pavelkumbrasev <pavel.kumbrasev@intel.com>

### Description 
Removed unused variable from tests. Clang 15.0.4 reports: 
```
conformance_flowgraph.h:82:9: error: variable 'val' set but not used [-Werror,-Wunused-but-set-variable]
    int val = 0;
        ^
conformance_flowgraph.h:92:9: error: variable 'val' set but not used [-Werror,-Wunused-but-set-variable]
    int val = 0;
```


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_
@isaevil @aleksei-fedotov 

### Other information
