### PR TITLE
Fix compilation against modern MacOS SDKs

### DIFF
--- a/src/tbb/co_context.h
+++ b/src/tbb/co_context.h
@@ -47,6 +47,8 @@
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     #endif
+    // Workaround error "The deprecated ucontext routines require _XOPEN_SOURCE to be defined" found in modern MacOS SDKs
+    #define _XOPEN_SOURCE 700
 #endif // __APPLE__
 
 #include <ucontext.h>


### PR DESCRIPTION
While ucontext routines are marked as deprecated on MacOS, modern SDKs trigger #error during compilation:

```
/usr/include/ucontext.h:51:2: error: The deprecated ucontext routines require _XOPEN_SOURCE to be defined
```

This PR workarounds the problem.
