### PR TITLE
Exclude test_numa_dist for UWD testing

### DIFF
--- a/test/tbb/test_numa_dist.cpp
+++ b/test/tbb/test_numa_dist.cpp
@@ -16,6 +16,8 @@
 
 #include "common/test.h"
 
+#if !__TBB_WIN8UI_SUPPORT
+
 #include <stdio.h>
 #include "tbb/parallel_for.h"
 #include "tbb/global_control.h"
@@ -156,3 +158,5 @@ TEST_CASE("Double threads") {
 #if _MSC_VER
 #pragma warning (pop)
 #endif
+
+#endif // !__TBB_WIN8UI_SUPPORT


### PR DESCRIPTION
### Description 
Remove test_numa_dist from UWD testing because `GetMaximumProcessorGroupCount` and`GetActiveProcessorCount`   are not available if `WINAPI_FAMILY == WINAPI_FAMILY_APP`



Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
