### PR TITLE
Fix incorrect value_type for concurrent_[unordered_]set::iterator

### DIFF
--- a/include/oneapi/tbb/concurrent_map.h
+++ b/include/oneapi/tbb/concurrent_map.h
@@ -175,6 +175,17 @@ public:
     void merge(concurrent_multimap<key_type, mapped_type, OtherCompare, Allocator>&& source) {
         this->internal_merge(std::move(source));
     }
+    
+    using base_type::unsafe_erase;
+    using base_type::unsafe_extract;
+    
+    iterator unsafe_erase(iterator pos) {
+        return this->unsafe_erase(const_iterator(pos));
+    }
+    
+    node_type unsafe_extract(iterator pos) {
+        return this->unsafe_extract(const_iterator(pos));
+    }
 }; // class concurrent_map
 
 #if __TBB_CPP17_DEDUCTION_GUIDES_PRESENT
@@ -291,6 +302,17 @@ public:
     template<typename OtherCompare>
     void merge(concurrent_map<key_type, mapped_type, OtherCompare, Allocator>&& source) {
         this->internal_merge(std::move(source));
+    }
+    
+    using base_type::unsafe_erase;
+    using base_type::unsafe_extract;
+    
+    iterator unsafe_erase(iterator pos) {
+        return this->unsafe_erase(const_iterator(pos));
+    }
+    
+    node_type unsafe_extract(iterator pos) {
+        return this->unsafe_extract(const_iterator(pos));
     }
 }; // class concurrent_multimap
 

--- a/include/oneapi/tbb/concurrent_unordered_map.h
+++ b/include/oneapi/tbb/concurrent_unordered_map.h
@@ -156,6 +156,17 @@ public:
     void merge( concurrent_unordered_multimap<key_type, mapped_type, OtherHash, OtherKeyEqual, allocator_type>&& source ) {
         this->internal_merge(std::move(source));
     }
+    
+    using base_type::unsafe_erase;
+    using base_type::unsafe_extract;
+    
+    iterator unsafe_erase(iterator position) {
+        return this->unsafe_erase(const_iterator(position));
+    }
+    
+    node_type unsafe_extract( iterator position ) {
+        return this->unsafe_extract(const_iterator(position));   
+    }
 }; // class concurrent_unordered_map
 
 #if __TBB_CPP17_DEDUCTION_GUIDES_PRESENT
@@ -316,6 +327,17 @@ public:
     template <typename OtherHash, typename OtherKeyEqual>
     void merge( concurrent_unordered_multimap<key_type, mapped_type, OtherHash, OtherKeyEqual, allocator_type>&& source ) {
         this->internal_merge(std::move(source));
+    }
+    
+    using base_type::unsafe_erase;
+    using base_type::unsafe_extract;
+    
+    iterator unsafe_erase(iterator position) {
+        return this->unsafe_erase(const_iterator(position));
+    }
+    
+    node_type unsafe_extract( iterator position ) {
+        return this->unsafe_extract(const_iterator(position));
     }
 }; // class concurrent_unordered_multimap
 

--- a/include/oneapi/tbb/detail/_concurrent_skip_list.h
+++ b/include/oneapi/tbb/detail/_concurrent_skip_list.h
@@ -266,8 +266,11 @@ protected:
     using list_node_type = skip_list_node<value_type, node_allocator_type>;
     using node_type = d1::node_handle<key_type, value_type, list_node_type, allocator_type>;
 
-    using iterator = skip_list_iterator<list_node_type, value_type>;
     using const_iterator = skip_list_iterator<list_node_type, const value_type>;
+    // iterator for ordered sets should be constant to prohibit modification of keys that sorting
+    using iterator = typename std::conditional<std::is_same<value_type, key_type>::value,
+                                               const_iterator,
+                                               skip_list_iterator<list_node_type, value_type>>::type;
 
     using reference = value_type&;
     using const_reference = const value_type&;
@@ -282,6 +285,7 @@ protected:
 private:
     template <typename T>
     using is_transparent = dependent_bool<comp_is_transparent<key_compare>, T>;
+    using non_const_iterator = skip_list_iterator<list_node_type, value_type>;
 public:
     static constexpr bool allow_multimapping = container_traits::allow_multimapping;
 
@@ -441,17 +445,13 @@ public:
         return emplace(std::forward<Args>(args)...).first;
     }
 
-    iterator unsafe_erase( iterator pos ) {
+    iterator unsafe_erase( const_iterator pos ) {
         std::pair<node_ptr, node_ptr> extract_result = internal_extract(pos);
         if (extract_result.first) { // node was extracted
             delete_value_node(extract_result.first);
             return extract_result.second;
         }
         return end();
-    }
-
-    iterator unsafe_erase( const_iterator pos ) {
-        return unsafe_erase(get_iterator(pos));
     }
 
     iterator unsafe_erase( const_iterator first, const_iterator last ) {
@@ -478,10 +478,6 @@ public:
     node_type unsafe_extract( const_iterator pos ) {
         std::pair<node_ptr, node_ptr> extract_result = internal_extract(pos);
         return extract_result.first ? d1::node_handle_accessor::construct<node_type>(extract_result.first) : node_type();
-    }
-
-    node_type unsafe_extract( iterator pos ) {
-        return unsafe_extract(const_iterator(pos));
     }
 
     node_type unsafe_extract( const key_type& key ) {
@@ -762,7 +758,8 @@ private:
         } else {
             my_size.store(0, std::memory_order_relaxed);
             my_max_height.store(other.my_max_height.load(std::memory_order_relaxed), std::memory_order_relaxed);
-            internal_copy(std::make_move_iterator(other.begin()), std::make_move_iterator(other.end()));
+            internal_copy(std::make_move_iterator(non_const_iterator(other.internal_begin())),
+                          std::make_move_iterator(non_const_iterator(nullptr)));
         }
     }
 
@@ -1170,7 +1167,8 @@ private:
         if (my_node_allocator == other.my_node_allocator) {
             internal_move(std::move(other));
         } else {
-            internal_copy(std::make_move_iterator(other.begin()), std::make_move_iterator(other.end()));
+            internal_copy(std::make_move_iterator(non_const_iterator(other.internal_begin())),
+                          std::make_move_iterator(non_const_iterator(nullptr)));
         }
     }
 

--- a/include/oneapi/tbb/detail/_concurrent_unordered_base.h
+++ b/include/oneapi/tbb/detail/_concurrent_unordered_base.h
@@ -205,8 +205,11 @@ public:
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
 
-    using iterator = solist_iterator<self_type, value_type>;
     using const_iterator = solist_iterator<self_type, const value_type>;
+    // iterator for unordered sets should be constant to prohibit modification of keys inside buckets
+    using iterator = typename std::conditional<std::is_same<value_type, key_type>::value,
+                                               const_iterator,
+                                               solist_iterator<self_type, value_type>>::type;
     using local_iterator = iterator;
     using const_local_iterator = const_iterator;
 
@@ -495,10 +498,6 @@ public:
         return iterator(first_value_node(internal_erase(pos.get_node_ptr())));
     }
 
-    iterator unsafe_erase( iterator pos ) {
-        return iterator(first_value_node(internal_erase(pos.get_node_ptr())));
-    }
-
     iterator unsafe_erase( const_iterator first, const_iterator last ) {
         while(first != last) {
             first = unsafe_erase(first);
@@ -524,10 +523,6 @@ public:
         return node_handle_accessor::construct<node_type>(pos.get_node_ptr());
     }
 
-    node_type unsafe_extract( iterator pos ) {
-        internal_extract(pos.get_node_ptr());
-        return node_handle_accessor::construct<node_type>(pos.get_node_ptr());
-    }
 
     node_type unsafe_extract( const key_type& key ) {
         iterator item = find(key);

--- a/test/conformance/conformance_concurrent_set.cpp
+++ b/test/conformance/conformance_concurrent_set.cpp
@@ -77,7 +77,7 @@ void test_member_types() {
 
     static_assert(utils::is_forward_iterator<typename container_type::iterator>::value,
                   "Incorrect container iterator member type");
-    static_assert(!std::is_const<typename container_type::iterator::value_type>::value,
+    static_assert(std::is_const<typename container_type::iterator::value_type>::value,
                   "Incorrect container iterator member type");
     static_assert(utils::is_forward_iterator<typename container_type::const_iterator>::value,
                   "Incorrect container const_iterator member type");

--- a/test/conformance/conformance_concurrent_unordered_set.cpp
+++ b/test/conformance/conformance_concurrent_unordered_set.cpp
@@ -90,7 +90,7 @@ void test_member_types() {
 
     static_assert(utils::is_forward_iterator<typename container_type::iterator>::value,
                   "Incorrect container iterator member type");
-    static_assert(!std::is_const<typename container_type::iterator::value_type>::value,
+    static_assert(std::is_const<typename container_type::iterator::value_type>::value,
                   "Incorrect container iterator member type");
     static_assert(utils::is_forward_iterator<typename container_type::const_iterator>::value,
                   "Incorrect container const_iterator member type");
@@ -98,7 +98,7 @@ void test_member_types() {
                   "Incorrect container iterator member type");
     static_assert(utils::is_forward_iterator<typename container_type::local_iterator>::value,
                   "Incorrect container local_iterator member type");
-    static_assert(!std::is_const<typename container_type::local_iterator::value_type>::value,
+    static_assert(std::is_const<typename container_type::local_iterator::value_type>::value,
                   "Incorrect container local_iterator member type");
     static_assert(utils::is_forward_iterator<typename container_type::const_local_iterator>::value,
                   "Incorrect container const_local_iterator member type");


### PR DESCRIPTION
### Description 
Fix an issue in `concurrent_set` and `concurrent_unordered_set` - `iterator` types should be constant for these classes.
Current implementation allows to write the following:

```
oneapi::tbb::concurrent_set<int> s = {1, 2, 3};
*s.begin() = 42;
// Now s is {42, 2, 3} - elements ordering is broken
```

The code above can brake elements ordering for ordered containers and place wrong elements into buckets for unordered.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
