### PR TITLE
Fix mingw build error

### DIFF
--- a/cmake/compilers/GNU.cmake
+++ b/cmake/compilers/GNU.cmake
@@ -63,6 +63,9 @@ endif()
 set(TBB_IPO_COMPILE_FLAGS $<$<NOT:$<CONFIG:Debug>>:-flto>)
 set(TBB_IPO_LINK_FLAGS $<$<NOT:$<CONFIG:Debug>>:-flto>)
 
+if (MINGW)
+    list(APPEND TBB_COMMON_COMPILE_FLAGS -U__STRICT_ANSI__)
+endif()
 
 if (MINGW AND CMAKE_SYSTEM_PROCESSOR MATCHES "i.86")
     list (APPEND TBB_COMMON_COMPILE_FLAGS -msse2)


### PR DESCRIPTION
### Description 
Revert change made in https://github.com/oneapi-src/oneTBB/commit/4533e4ff0f0a8e4888f1670401df4410174592d2 which breaks mingw builds in certain circumstances.

[Compile error](https://github.com/JuliaPackaging/Yggdrasil/pull/6115#issuecomment-1399074390):

```bash
[22:57:00] In file included from /workspace/srcdir/oneTBB/src/tbb/../../include/oneapi/tbb/detail/_utils.h:26:0,
[22:57:00]                  from /workspace/srcdir/oneTBB/src/tbb/../../include/oneapi/tbb/detail/_template_helpers.h:20,
[22:57:00]                  from /workspace/srcdir/oneTBB/src/tbb/exception.cpp:19:
[22:57:00] /workspace/srcdir/oneTBB/src/tbb/../../include/oneapi/tbb/detail/_machine.h:247:56: error: ‘_MCW_DN’ was not declared in this scope
[22:57:00]      static constexpr unsigned int X87CW_CONTROL_MASK = _MCW_DN | _MCW_EM | _MCW_RC;
[22:57:00]                                                         ^
```

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
