### PR TITLE
reduces warnings using Xcode/AppleClang

### DIFF
--- a/include/oneapi/tbb/detail/_machine.h
+++ b/include/oneapi/tbb/detail/_machine.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -110,9 +110,9 @@ static inline void machine_pause(int32_t delay) {
 
 #if defined(__GNUC__) || defined(__clang__)
 namespace gnu_builtins {
-    inline uintptr_t clz(unsigned int x) { return __builtin_clz(x); }
-    inline uintptr_t clz(unsigned long int x) { return __builtin_clzl(x); }
-    inline uintptr_t clz(unsigned long long int x) { return __builtin_clzll(x); }
+    inline uintptr_t clz(unsigned int x) { return static_cast<uintptr_t>(__builtin_clz(x)); }
+    inline uintptr_t clz(unsigned long int x) { return static_cast<uintptr_t>(__builtin_clzl(x)); }
+    inline uintptr_t clz(unsigned long long int x) { return static_cast<uintptr_t>(__builtin_clzll(x)); }
 }
 #elif defined(_MSC_VER)
 #pragma intrinsic(__TBB_W(_BitScanReverse))
@@ -221,8 +221,8 @@ T machine_reverse_bits(T src) {
     return builtin_bitreverse(fixed_width_cast(src));
 #else /* Generic */
     T dst;
-    unsigned char *original = (unsigned char *) &src;
-    unsigned char *reversed = (unsigned char *) &dst;
+    unsigned char *original = reinterpret_cast<unsigned char *>(&src);
+    unsigned char *reversed = reinterpret_cast<unsigned char *>(&dst);
 
     for ( int i = sizeof(T) - 1; i >= 0; i-- ) {
         reversed[i] = reverse_byte( original[sizeof(T) - i - 1] );

--- a/include/oneapi/tbb/detail/_task.h
+++ b/include/oneapi/tbb/detail/_task.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2020-2022 Intel Corporation
+    Copyright (c) 2020-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ class wait_context {
 
     void add_reference(std::int64_t delta) {
         call_itt_task_notify(releasing, this);
-        std::uint64_t r = m_ref_count.fetch_add(delta) + delta;
+        std::uint64_t r = m_ref_count.fetch_add(static_cast<std::uint64_t>(delta)) + static_cast<std::uint64_t>(delta);
 
         __TBB_ASSERT_EX((r & overflow_mask) == 0, "Overflow is detected");
 

--- a/include/oneapi/tbb/detail/_template_helpers.h
+++ b/include/oneapi/tbb/detail/_template_helpers.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ template <unsigned u, unsigned long long ull >
 struct select_size_t_constant {
     // Explicit cast is needed to avoid compiler warnings about possible truncation.
     // The value of the right size,   which is selected by ?:, is anyway not truncated or promoted.
-    static const std::size_t value = (std::size_t)((sizeof(std::size_t)==sizeof(u)) ? u : ull);
+    static const std::size_t value = static_cast<std::size_t>((sizeof(std::size_t)==sizeof(u)) ? u : ull);
 };
 
 // TODO: do we really need it?

--- a/include/oneapi/tbb/detail/_utils.h
+++ b/include/oneapi/tbb/detail/_utils.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -177,7 +177,7 @@ inline ArgIntegerType modulo_power_of_two(ArgIntegerType arg, DivisorIntegerType
 //! A function to check if passed in pointer is aligned on a specific border
 template<typename T>
 constexpr bool is_aligned(T* pointer, std::uintptr_t alignment) {
-    return 0 == ((std::uintptr_t)pointer & (alignment - 1));
+    return 0 == (reinterpret_cast<std::uintptr_t>(pointer) & (alignment - 1));
 }
 
 #if TBB_USE_ASSERT

--- a/include/oneapi/tbb/parallel_reduce.h
+++ b/include/oneapi/tbb/parallel_reduce.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -207,7 +207,7 @@ task* start_reduce<Range,Body,Partitioner>::execute(execution_data& ed) {
     __TBB_ASSERT(my_parent, nullptr);
     if( is_right_child && my_parent->m_ref_count.load(std::memory_order_acquire) == 2 ) {
         tree_node_type* parent_ptr = static_cast<tree_node_type*>(my_parent);
-        my_body = (Body*) new( parent_ptr->zombie_space.begin() ) Body(*my_body, split());
+        my_body = static_cast<Body*>(new( parent_ptr->zombie_space.begin() ) Body(*my_body, split()));
         parent_ptr->has_right_zombie = true;
     }
     __TBB_ASSERT(my_body != nullptr, "Incorrect body value");

--- a/include/oneapi/tbb/partitioner.h
+++ b/include/oneapi/tbb/partitioner.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ class affinity_partitioner_base;
 
 inline std::size_t get_initial_auto_partitioner_divisor() {
     const std::size_t factor = 4;
-    return factor * max_concurrency();
+    return factor * static_cast<std::size_t>(max_concurrency());
 }
 
 //! Defines entry point for affinity partitioner into oneTBB run-time library.
@@ -90,7 +90,7 @@ class affinity_partitioner_base: no_copy {
     /** Retains values if resulting size is the same. */
     void resize(unsigned factor) {
         // Check factor to avoid asking for number of workers while there might be no arena.
-        unsigned max_threads_in_arena = max_concurrency();
+        unsigned max_threads_in_arena = static_cast<unsigned>(max_concurrency());
         std::size_t new_size = factor ? factor * max_threads_in_arena : 0;
         if (new_size != my_size) {
             if (my_array) {

--- a/include/oneapi/tbb/profiling.h
+++ b/include/oneapi/tbb/profiling.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -122,14 +122,14 @@ namespace d1 {
 // Distinguish notifications on task for reducing overheads
 #if TBB_USE_PROFILING_TOOLS == 2
     inline void call_itt_task_notify(d1::notify_type t, void *ptr) {
-        r1::call_itt_notify((int)t, ptr);
+        r1::call_itt_notify(static_cast<int>(t), ptr);
     }
 #else
     inline void call_itt_task_notify(d1::notify_type, void *) {}
 #endif // TBB_USE_PROFILING_TOOLS
 
     inline void call_itt_notify(d1::notify_type t, void *ptr) {
-        r1::call_itt_notify((int)t, ptr);
+        r1::call_itt_notify(static_cast<int>(t), ptr);
     }
 
 #if (_WIN32||_WIN64) && !__MINGW32__


### PR DESCRIPTION
### Description 

Introduces explicit `static_cast` or `reinterpret_cast` to suppress warnings from Xcode/AppleClang.  I used `static_cast` when possible and resorted to `reinterpret_cast` when necessary.  I'm currently at  Version 14.2 and not sure which versions these started appearing.  I can confirm that the proposed changes are successful in suppressing these warnings.


Fixes # - _issue number(s) if exists_

I did not see an issue reporting these warnings, and instead paste them here

```
/tbb/include/oneapi/tbb/detail/_machine.h:113:51: Implicit conversion changes signedness: 'int' to 'uintptr_t' (aka 'unsigned long')
/tbb/include/oneapi/tbb/detail/_machine.h:114:56: Implicit conversion changes signedness: 'int' to 'uintptr_t' (aka 'unsigned long')
/tbb/include/oneapi/tbb/detail/_machine.h:115:61: Implicit conversion changes signedness: 'int' to 'uintptr_t' (aka 'unsigned long')
/tbb/include/oneapi/tbb/detail/_machine.h:224:31: Use of old-style cast
/tbb/include/oneapi/tbb/detail/_machine.h:225:31: Use of old-style cast
/tbb/include/oneapi/tbb/detail/_utils.h:180:18: Use of old-style cast
/tbb/include/oneapi/tbb/detail/_template_helpers.h:62:38: Use of old-style cast
/tbb/include/oneapi/tbb/profiling.h:125:29: Use of old-style cast
/tbb/include/oneapi/tbb/profiling.h:132:29: Use of old-style cast
/tbb/include/oneapi/tbb/detail/_task.h:106:58: Implicit conversion changes signedness: 'std::int64_t' (aka 'long long') to 'unsigned long long'
/tbb/include/oneapi/tbb/detail/_task.h:106:49: Implicit conversion changes signedness: 'std::int64_t' (aka 'long long') to 'unsigned long long'
/tbb/include/oneapi/tbb/partitioner.h:73:21: Implicit conversion changes signedness: 'int' to 'unsigned long'
/tbb/include/oneapi/tbb/partitioner.h:93:41: Implicit conversion changes signedness: 'int' to 'unsigned int'
/tbb/include/oneapi/tbb/parallel_reduce.h:210:19: Use of old-style cast
```

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [X] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information

- I wasn't confident about my response to the questions above, but did my best to respond to each of them.