### PR TITLE
Disable LTO when configuring in Debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,12 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
+string(TOLOWER ${CMAKE_BUILD_TYPE} _tbb_build_type)
+if (_tbb_build_type STREQUAL "debug")
+    set(TBB_ENABLE_IPO OFF)
+endif()
+unset(_tbb_build_type)
+
 # -------------------------------------------------------------------
 # Files and folders naming
 set(CMAKE_DEBUG_POSTFIX _debug)


### PR DESCRIPTION
### Description 
When using CMake version >= 3.9 LTO will be enabled even when configuring in Debug mode, which is undesired. Current patch disable LTO on all versions of CMake, when CMAKE_BUILD_TYPE=Debug


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [x] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
