### PR TITLE
Add lost topics from the old documentation 

### DIFF
--- a/doc/main/reference/scalable_memory_pools.rst
+++ b/doc/main/reference/scalable_memory_pools.rst
@@ -41,3 +41,4 @@ Here, ``P`` represents an instance of the memory pool class.
     scalable_memory_pools/memory_pool_cls
     scalable_memory_pools/fixed_pool_cls
     scalable_memory_pools/memory_pool_allocator_cls
+    scalable_memory_pools/malloc_replacement_log

--- a/doc/main/reference/scalable_memory_pools/malloc_replacement_log.rst
+++ b/doc/main/reference/scalable_memory_pools/malloc_replacement_log.rst
@@ -1,0 +1,84 @@
+.. _malloc_replacement_log:
+
+oneTBB_malloc_replacement_log Function
+======================================
+
+.. note:: This function is for Windows* OS only. 
+
+Summary
+*******
+
+Provides information about the status of dynamic memory allocation replacement.
+
+Syntax
+*******
+
+:: 
+
+   extern "C" int TBB_malloc_replacement_log(char *** log_ptr);
+
+
+Header
+******
+
+::
+
+   #include "oneapi/tbb/tbbmalloc_proxy.h"
+
+
+Description
+***********
+
+Dynamic replacement of memory allocation functions on Windows* OS uses in-memory binary instrumentation techniques. 
+To make sure that such instrumentation is safe, oneTBB first searches for a subset of replaced functions in the Visual C++* runtime DLLs
+and checks if each one has a known bytecode pattern. If any required function is not found or its bytecode pattern is unknown, the replacement is skipped, 
+and the program continues to use the standard memory allocation functions.
+
+The ``oneTBB_malloc_replacement_log`` function allows the program to check if the dynamic memory replacement happens and to get a log of the performed checks.
+
+**Returns:**
+
+* 0, if all necessary functions are successfully found and the replacement takes place.
+* 1, otherwise. 
+
+The ``log_ptr`` parameter must be an address of a char** variable or be ``NULL``. If it is not ``NULL``, the function writes there the address of an array of 
+NULL-terminated strings containing detailed information about the searched functions in the following format:
+
+::
+
+   search_status: function_name (dll_name), byte pattern: <bytecodes>
+
+ 
+For more information about the replacement of dynamic memory allocation functions, see :ref:`Windows_C_Dynamic_Memory_Interface_Replacement`. 
+
+
+Example 
+*******
+
+::
+
+   #include "oneapi/tbb/tbbmalloc_proxy.h"
+   #include <stdio.h>
+
+   int main(){
+       char **func_replacement_log;
+       int func_replacement_status = TBB_malloc_replacement_log(&func_replacement_log);
+
+       if (func_replacement_status != 0) {
+           printf("tbbmalloc_proxy cannot replace memory allocation routines\n");
+           for (char** log_string = func_replacement_log; *log_string != 0; log_string++) {
+               printf("%s\n",*log_string);
+            }
+       }
+
+       return 0;
+   }
+
+
+Example output:
+
+:: 
+
+   tbbmalloc_proxy cannot replace memory allocation routines
+   Success: free (ucrtbase.dll), byte pattern: <C7442410000000008B4424>
+   Fail: _msize (ucrtbase.dll), byte pattern: <E90B000000CCCCCCCCCCCC>

--- a/doc/main/tbb_userguide/Floating_Point_Settings.rst
+++ b/doc/main/tbb_userguide/Floating_Point_Settings.rst
@@ -1,0 +1,61 @@
+.. _Floating_Point_Settings:
+
+Floating-point Settings
+=======================
+
+To propagate CPU-specific settings for floating-point computations to tasks executed by the task scheduler, you can use one of the following two methods:
+
+* When a ``task_arena`` or a task scheduler for a given application thread is initialized, they capture the current floating-point settings of the thread. 
+* The ``task_group_context`` class has a method to capture the current floating-point settings. 
+
+By default, worker threads use floating-point settings obtained during the initialization of the implicit arena of the application thread or the explicit ``task_arena``. 
+These settings are applied to all parallel computations within the ``task_arena`` or started by the application thread until that thread terminates its task scheduler instance. 
+If the thread later re-initializes the task scheduler, new settings are captured.
+
+For better control over floating point behavior, a thread may capture the current settings in a task group context. Do it at context creation with a special flag passed to the constructor:
+
+::
+    
+    task_group_context ctx( task_group_context::isolated,
+                        task_group_context::default_traits | task_group_context::fp_settings );
+
+
+Or call the ``capture_fp_settings`` method:
+
+::
+    
+     task_group_context ctx;
+    ctx.capture_fp_settings();
+
+
+You can then pass the task group context to most parallel algorithms, including ``flow::graph``, to ensure that all tasks related to this algorithm use the specified floating-point settings. 
+It is possible to execute the parallel algorithms with different floating-point settings captured to separate contexts, even at the same time.
+
+Floating-point settings captured to a task group context prevail over the settings captured during task scheduler initialization. It means, if a context is passed to a parallel algorithm, the floating-point settings captured to the context are used. 
+Otherwise, if floating-point settings are not captured to the context, or a context is not explicitly specified, the settings captured during task scheduler initialization are used.
+
+In a nested call to a parallel algorithm that does not use the context of a task group with explicitly captured floating-point settings, the outer-level settings are used. 
+If none of the outer-level contexts capture floating-point settings, the settings captured during task scheduler initialization are used.
+
+It guarantees that: 
+
+* Floating-point settings are applied to all tasks executed by the task scheduler, if they are captured: 
+
+  * To a task group context. 
+  * During task scheduler initialization. 
+
+* A call to the oneTBB parallel algorithm does not noticeably change the settings of the calling floating-point stream. Even if the algorithm is executed with different settings.
+
+.. note:: 
+    The guarantees above apply only to the following conditions:
+    
+    * A user code inside a task should: 
+      
+      * Not change the floating-point settings.
+      * Revert any modifications. 
+      * Restore previous settings before the end of the task.
+
+    * oneTBB task scheduler observers are not used to set or modify floating point settings.
+
+    Otherwise, the stated guarantees are not valid and the behavior related to floating-point settings is undefined.
+

--- a/doc/main/tbb_userguide/title.rst
+++ b/doc/main/tbb_userguide/title.rst
@@ -14,6 +14,7 @@
    ../tbb_userguide/Flow_Graph
    ../tbb_userguide/work_isolation
    ../tbb_userguide/Exceptions_and_Cancellation
+   ../tbb_userguide/Floating_Point_Settings
    ../tbb_userguide/Containers
    ../tbb_userguide/Mutual_Exclusion
    ../tbb_userguide/Timing


### PR DESCRIPTION
### Description 

Add two topics that were lost when reworking documentation from TBB to oneTBB. 

Fixes # - _issue number(s) if exists_

- [ ] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@omalyshe @akukanov 

### Other information
Signed-off-by: Alexandra Epanchinzeva alexandra.epanchinzeva@intel.com