### PR TITLE
Improve performance by doing test-and-test-and-set for spin_mutex

### DIFF
--- a/include/tbb/tbb_machine.h
+++ b/include/tbb/tbb_machine.h
@@ -909,6 +909,12 @@ typedef unsigned char __TBB_Flag;
 #endif
 typedef __TBB_atomic __TBB_Flag __TBB_atomic_flag;
 
+#ifndef __TBB_IsLocked
+inline bool __TBB_IsLocked( const __TBB_atomic_flag& flag ) {
+    return (flag == 1);
+}
+#endif
+
 #ifndef __TBB_TryLockByte
 inline bool __TBB_TryLockByte( __TBB_atomic_flag &flag ) {
     return __TBB_machine_cmpswp1(&flag,1,0)==0;
@@ -918,7 +924,11 @@ inline bool __TBB_TryLockByte( __TBB_atomic_flag &flag ) {
 #ifndef __TBB_LockByte
 inline __TBB_Flag __TBB_LockByte( __TBB_atomic_flag& flag ) {
     tbb::internal::atomic_backoff backoff;
-    while( !__TBB_TryLockByte(flag) ) backoff.pause();
+    do {
+        while( __TBB_IsLocked(flag) )
+            backoff.pause();
+    }
+    while( !__TBB_TryLockByte(flag) ) ;
     return 0;
 }
 #endif

--- a/include/tbb/tbb_machine.h
+++ b/include/tbb/tbb_machine.h
@@ -911,7 +911,7 @@ typedef __TBB_atomic __TBB_Flag __TBB_atomic_flag;
 
 #ifndef __TBB_IsLocked
 inline bool __TBB_IsLocked( const __TBB_atomic_flag& flag ) {
-    return (flag == 1);
+    return flag == 1;
 }
 #endif
 
@@ -924,11 +924,9 @@ inline bool __TBB_TryLockByte( __TBB_atomic_flag &flag ) {
 #ifndef __TBB_LockByte
 inline __TBB_Flag __TBB_LockByte( __TBB_atomic_flag& flag ) {
     tbb::internal::atomic_backoff backoff;
-    do {
-        while( __TBB_IsLocked(flag) )
-            backoff.pause();
+    while (__TBB_IsLocked(flag) ||  !__TBB_TryLockByte(flag)) {
+        backoff.pause();
     }
-    while( !__TBB_TryLockByte(flag) ) ;
     return 0;
 }
 #endif

--- a/include/tbb/tbb_machine.h
+++ b/include/tbb/tbb_machine.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2020 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/spin_mutex.cpp
+++ b/src/tbb/spin_mutex.cpp
@@ -39,6 +39,8 @@ void spin_mutex::scoped_lock::internal_release() {
 
 bool spin_mutex::scoped_lock::internal_try_acquire( spin_mutex& m ) {
     __TBB_ASSERT( !my_mutex, "already holding a lock on a spin_mutex" );
+    if( __TBB_IsLocked(m.flag) )
+        return false;
     bool result = bool( __TBB_TryLockByte(m.flag) );
     if( result ) {
         my_mutex = &m;

--- a/src/tbb/spin_mutex.cpp
+++ b/src/tbb/spin_mutex.cpp
@@ -39,9 +39,7 @@ void spin_mutex::scoped_lock::internal_release() {
 
 bool spin_mutex::scoped_lock::internal_try_acquire( spin_mutex& m ) {
     __TBB_ASSERT( !my_mutex, "already holding a lock on a spin_mutex" );
-    if( __TBB_IsLocked(m.flag) )
-        return false;
-    bool result = bool( __TBB_TryLockByte(m.flag) );
+    bool result = !bool( __TBB_IsLocked(m.flag) ) && bool( __TBB_TryLockByte(m.flag) );
     if( result ) {
         my_mutex = &m;
         ITT_NOTIFY(sync_acquired, &m);

--- a/src/tbb/spin_mutex.cpp
+++ b/src/tbb/spin_mutex.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2020 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description 
In spin mutex lock, add a lock check followed by a backoff before doing a compare-and-swap (which can be highly contended).

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change
- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@vossmjp @akukanov @pavelkumbrasev @AlexMWells

### Other information
