### PR TITLE
Fix reserve(0) issue for concurrent unordered containers

### DIFF
--- a/include/oneapi/tbb/detail/_concurrent_unordered_base.h
+++ b/include/oneapi/tbb/detail/_concurrent_unordered_base.h
@@ -677,13 +677,17 @@ public:
         size_type current_bucket_count = my_bucket_count.load(std::memory_order_acquire);
         size_type necessary_bucket_count = current_bucket_count;
 
-        do {
-            // TODO: Log2 seems useful here
-            while (necessary_bucket_count * max_load_factor() < elements_count) {
+        // max_load_factor() is currently unsafe, so we can assume that my_max_load_factor
+        // would not be changed during the calculation
+        // TODO: Log2 seems useful here
+        while (necessary_bucket_count * max_load_factor() < elements_count) {
                 necessary_bucket_count <<= 1;
-            }
-        } while (current_bucket_count >= necessary_bucket_count ||
-                 !my_bucket_count.compare_exchange_strong(current_bucket_count, necessary_bucket_count));
+        }
+
+        while (!my_bucket_count.compare_exchange_strong(current_bucket_count, necessary_bucket_count)) {
+            if (current_bucket_count >= necessary_bucket_count)
+                break;
+        }
     }
 
     // Observers

--- a/test/common/concurrent_unordered_common.h
+++ b/test/common/concurrent_unordered_common.h
@@ -372,4 +372,22 @@ void test_set_comparisons() {
     test_two_way_comparable_container<two_way_comparable_container>();
 }
 
+template <typename Container>
+void test_reserve_regression() {
+    Container container;
+
+    float lf = container.max_load_factor();
+    std::size_t buckets = container.unsafe_bucket_count();
+    std::size_t capacity = buckets * lf;
+
+    for (std::size_t elements = 0; elements < capacity; ++elements) {
+        container.reserve(elements);
+        REQUIRE_MESSAGE(container.unsafe_bucket_count() == buckets,
+                        "reserve() should not increase bucket count if the capacity is not reached");
+    }
+
+    container.reserve(capacity * 2);
+    REQUIRE_MESSAGE(container.unsafe_bucket_count() > buckets, "reserve() should increase bucket count if the capacity is reached");
+}
+
 #endif // __TBB_test_common_concurrent_unordered_common

--- a/test/tbb/test_concurrent_unordered_map.cpp
+++ b/test/tbb/test_concurrent_unordered_map.cpp
@@ -258,3 +258,9 @@ TEST_CASE("container_range concept for concurrent_unordered_multimap ranges") {
     static_assert(test_concepts::container_range<typename tbb::concurrent_unordered_multimap<int, int>::const_range_type>);
 }
 #endif // __TBB_CPP20_CONCEPTS_PRESENT
+
+//! \brief \ref regression
+TEST_CASE("reserve(0) issue regression test") {
+    test_reserve_regression<oneapi::tbb::concurrent_unordered_map<int, int>>();
+    test_reserve_regression<oneapi::tbb::concurrent_unordered_multimap<int, int>>();
+}

--- a/test/tbb/test_concurrent_unordered_set.cpp
+++ b/test/tbb/test_concurrent_unordered_set.cpp
@@ -229,3 +229,9 @@ TEST_CASE("container_range concept for concurrent_unordered_multiset ranges") {
     static_assert(test_concepts::container_range<typename tbb::concurrent_unordered_multiset<int>::const_range_type>);
 }
 #endif // __TBB_CPP20_CONCEPTS_PRESENT
+
+//! \brief \ref regression
+TEST_CASE("reserve(0) issue regression test") {
+    test_reserve_regression<oneapi::tbb::concurrent_unordered_set<int>>();
+    test_reserve_regression<oneapi::tbb::concurrent_unordered_multiset<int>>();
+}


### PR DESCRIPTION
### Description 
Fix `concurrent_unordered_*::reserve` method not to hang if current bucket count is enough to store passed elements count. 


Fixes #1056 

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
