### PR TITLE
Set TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH to ON on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,11 @@ if (NOT BUILD_SHARED_LIBS)
     message(WARNING "You are building oneTBB as a static library. This is highly discouraged and such configuration is not supported. Consider building a dynamic library to avoid unforeseen issues.")
 endif()
 
+# Prevent searching HWLOC by pkg-config on macOS
+if (APPLE)
+    set(TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH ON)
+endif()
+
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type" FORCE)
     message(STATUS "CMAKE_BUILD_TYPE is not specified. Using default: ${CMAKE_BUILD_TYPE}")


### PR DESCRIPTION
### Description 
HWLOC can be installed on MacOS and can be found by pkg-config and thus making `test_arena_constraints` and `conformance_arena_constraints` pass regular expression wrong: it will expect, that TBBBind is available, but it is not. To resolve that we need to set `TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH` CMake option to `ON`.

Fixes #1050 

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
