### PR TITLE
Fix for build error: use of bitwise '|' with boolean operands [-Werror,-Wbitwise-instead-of-logical]

### DIFF
--- a/src/tbbmalloc/backend.cpp
+++ b/src/tbbmalloc/backend.cpp
@@ -815,7 +815,9 @@ FreeBlock *Backend::genericGetBlock(int num, size_t size, bool needAlignedBlock)
         if (block)
             break;
 
-        if (!(scanCoalescQ(/*forceCoalescQDrop=*/true) | extMemPool->softCachesCleanup())) {
+        bool retScanCoalescQ = scanCoalescQ(/*forceCoalescQDrop=*/true);
+        bool retSoftCachesCleanup = extMemPool->softCachesCleanup();
+        if (!(retScanCoalescQ || retSoftCachesCleanup)) {
             // bins are not updated,
             // only remaining possibility is to ask for more memory
             block = askMemFromOS(totalReqSize, startModifiedCnt, &lockedBinsThreshold,

--- a/src/tbbmalloc/frontend.cpp
+++ b/src/tbbmalloc/frontend.cpp
@@ -601,7 +601,9 @@ public:
         // should be called only for the current thread
         bool released = cleanBins ? cleanupBlockBins() : false;
         // both cleanups to be called, and the order is not important
-        return released | lloc.externalCleanup(&memPool->extMemPool) | freeSlabBlocks.externalCleanup();
+        bool lloc_cleaned = lloc.externalCleanup(&memPool->extMemPool);
+        bool free_slab_blocks_cleaned = freeSlabBlocks.externalCleanup();
+        return released || lloc_cleaned || free_slab_blocks_cleaned;
     }
     bool cleanupBlockBins();
     void markUsed() { unused.store(false, std::memory_order_relaxed); } // called by owner when TLS touched

--- a/src/tbbmalloc/large_objects.cpp
+++ b/src/tbbmalloc/large_objects.cpp
@@ -804,8 +804,10 @@ bool LargeObjectCache::doCleanup(uintptr_t currTime, bool doThreshDecr)
 {
     if (!doThreshDecr)
         extMemPool->allLocalCaches.markUnused();
-    return largeCache.regularCleanup(extMemPool, currTime, doThreshDecr)
-        | hugeCache.regularCleanup(extMemPool, currTime, doThreshDecr);
+
+    bool large_cache_cleaned = largeCache.regularCleanup(extMemPool, currTime, doThreshDecr);
+    bool huge_cache_cleaned = hugeCache.regularCleanup(extMemPool, currTime, doThreshDecr);
+    return large_cache_cleaned || huge_cache_cleaned;
 }
 
 bool LargeObjectCache::decreasingCleanup()
@@ -820,7 +822,9 @@ bool LargeObjectCache::regularCleanup()
 
 bool LargeObjectCache::cleanAll()
 {
-    return largeCache.cleanAll(extMemPool) | hugeCache.cleanAll(extMemPool);
+    bool large_cache_cleaned = largeCache.cleanAll(extMemPool);
+    bool huge_cache_cleaned = hugeCache.cleanAll(extMemPool);
+    return large_cache_cleaned || huge_cache_cleaned;
 }
 
 void LargeObjectCache::reset()


### PR DESCRIPTION
### Description 
CMake:
```
cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=20 -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON ../..
```

Compiler:

```
Apple clang version 14.0.3 (clang-1403.0.22.14.1)
Target: arm64-apple-darwin22.4.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

Errors:

```
[  9%] Building CXX object src/tbbmalloc/CMakeFiles/tbbmalloc.dir/backend.cpp.o
cd /Users/phprus/Devel/oneapi-src/oneTBB/build/cxx20-lto/src/tbbmalloc && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -D__TBBMALLOC_BUILD -I/Users/phprus/Devel/oneapi-src/oneTBB/src/tbbmalloc/../../include -O2 -g -DNDEBUG -flto=thin -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fPIC -Wall -Wextra -Werror -Wno-parentheses -Wno-non-virtual-dtor -Wno-dangling-else -fno-rtti -fno-exceptions -D_XOPEN_SOURCE -std=c++20 -MD -MT src/tbbmalloc/CMakeFiles/tbbmalloc.dir/backend.cpp.o -MF CMakeFiles/tbbmalloc.dir/backend.cpp.o.d -o CMakeFiles/tbbmalloc.dir/backend.cpp.o -c /Users/phprus/Devel/oneapi-src/oneTBB/src/tbbmalloc/backend.cpp
/Users/phprus/Devel/oneapi-src/oneTBB/src/tbbmalloc/backend.cpp:818:15: error: use of bitwise '|' with boolean operands [-Werror,-Wbitwise-instead-of-logical]
        if (!(scanCoalescQ(/*forceCoalescQDrop=*/true) | extMemPool->softCachesCleanup())) {
             ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                       ||
/Users/phprus/Devel/oneapi-src/oneTBB/src/tbbmalloc/backend.cpp:818:15: note: cast one or both operands to int to silence this warning
1 error generated.
```

```
[ 10%] Building CXX object src/tbbmalloc/CMakeFiles/tbbmalloc.dir/frontend.cpp.o
cd /Users/phprus/Devel/oneapi-src/oneTBB/build/cxx20-lto/src/tbbmalloc && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -D__TBBMALLOC_BUILD -I/Users/phprus/Devel/oneapi-src/oneTBB/src/tbbmalloc/../../include -O2 -g -DNDEBUG -flto=thin -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fPIC -Wall -Wextra -Werror -Wno-parentheses -Wno-non-virtual-dtor -Wno-dangling-else -fno-rtti -fno-exceptions -D_XOPEN_SOURCE -std=c++20 -MD -MT src/tbbmalloc/CMakeFiles/tbbmalloc.dir/frontend.cpp.o -MF CMakeFiles/tbbmalloc.dir/frontend.cpp.o.d -o CMakeFiles/tbbmalloc.dir/frontend.cpp.o -c /Users/phprus/Devel/oneapi-src/oneTBB/src/tbbmalloc/frontend.cpp
/Users/phprus/Devel/oneapi-src/oneTBB/src/tbbmalloc/frontend.cpp:604:16: error: use of bitwise '|' with boolean operands [-Werror,-Wbitwise-instead-of-logical]
        return released | lloc.externalCleanup(&memPool->extMemPool) | freeSlabBlocks.externalCleanup();
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                     ||
/Users/phprus/Devel/oneapi-src/oneTBB/src/tbbmalloc/frontend.cpp:604:16: note: cast one or both operands to int to silence this warning
1 error generated.
```

```
[ 10%] Building CXX object src/tbbmalloc/CMakeFiles/tbbmalloc.dir/large_objects.cpp.o
cd /Users/phprus/Devel/oneapi-src/oneTBB/build/cxx20-lto/src/tbbmalloc && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -D__TBBMALLOC_BUILD -I/Users/phprus/Devel/oneapi-src/oneTBB/src/tbbmalloc/../../include -O2 -g -DNDEBUG -flto=thin -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fPIC -Wall -Wextra -Werror -Wno-parentheses -Wno-non-virtual-dtor -Wno-dangling-else -fno-rtti -fno-exceptions -D_XOPEN_SOURCE -std=c++20 -MD -MT src/tbbmalloc/CMakeFiles/tbbmalloc.dir/large_objects.cpp.o -MF CMakeFiles/tbbmalloc.dir/large_objects.cpp.o.d -o CMakeFiles/tbbmalloc.dir/large_objects.cpp.o -c /Users/phprus/Devel/oneapi-src/oneTBB/src/tbbmalloc/large_objects.cpp
/Users/phprus/Devel/oneapi-src/oneTBB/src/tbbmalloc/large_objects.cpp:807:12: error: use of bitwise '|' with boolean operands [-Werror,-Wbitwise-instead-of-logical]
    return largeCache.regularCleanup(extMemPool, currTime, doThreshDecr)
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/phprus/Devel/oneapi-src/oneTBB/src/tbbmalloc/large_objects.cpp:807:12: note: cast one or both operands to int to silence this warning
/Users/phprus/Devel/oneapi-src/oneTBB/src/tbbmalloc/large_objects.cpp:823:12: error: use of bitwise '|' with boolean operands [-Werror,-Wbitwise-instead-of-logical]
    return largeCache.cleanAll(extMemPool) | hugeCache.cleanAll(extMemPool);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                           ||
/Users/phprus/Devel/oneapi-src/oneTBB/src/tbbmalloc/large_objects.cpp:823:12: note: cast one or both operands to int to silence this warning
2 errors generated.
```


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
