### PR TITLE
Fix uninitialized variable in tbbmalloc for KW

### DIFF
--- a/src/tbbmalloc/large_objects.cpp
+++ b/src/tbbmalloc/large_objects.cpp
@@ -124,7 +124,7 @@ class CacheBinFunctor {
     public:
         OperationPreprocessor(typename LargeObjectCacheImpl<Props>::CacheBin *bin) :
             bin(bin), lclTime(0), opGet(nullptr), opClean(nullptr), cleanTime(0),
-            lastGetOpTime(0), updateUsedSize(0), head(nullptr), isCleanAll(false)  {}
+            lastGetOpTime(0), updateUsedSize(0), head(nullptr), tail(nullptr), isCleanAll(false)  {}
         void operator()(CacheBinOperation* opList);
         uintptr_t getTimeRange() const { return -lclTime; }
 
@@ -543,6 +543,7 @@ template<typename Props> LargeMemoryBlock *LargeObjectCacheImpl<Props>::
     MALLOC_ASSERT( !last.load(std::memory_order_relaxed) ||
         (last.load(std::memory_order_relaxed)->age != 0 && last.load(std::memory_order_relaxed)->age != -1U), ASSERT_TEXT );
     MALLOC_ASSERT( (tail==head && num==1) || (tail!=head && num>1), ASSERT_TEXT );
+    MALLOC_ASSERT( tail, ASSERT_TEXT );
     LargeMemoryBlock *toRelease = nullptr;
     if (size < hugeSizeThreshold && !lastCleanedAge) {
         // 1st object of such size was released.
@@ -559,7 +560,6 @@ template<typename Props> LargeMemoryBlock *LargeObjectCacheImpl<Props>::
     }
     if (num) {
         // add [head;tail] list to cache
-        MALLOC_ASSERT( tail, ASSERT_TEXT );
         tail->next = first;
         if (first)
             first->prev = tail;
@@ -1055,4 +1055,3 @@ void *ExtMemoryPool::remap(void *ptr, size_t oldSize, size_t newSize, size_t ali
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
     #pragma warning(pop)
 #endif
-


### PR DESCRIPTION
### Description 
Fix uninitialized variable `rml::internal::CacheBinFunctor::OperationPreprocessor::tail` reported by static code analysis tool.


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
