### PR TITLE
Add issue and PR labeler based on description

### DIFF
--- a/.github/issue_labeler.yml
+++ b/.github/issue_labeler.yml
@@ -1,0 +1,27 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# PR template regexp's for issue labeler
+bug fix:
+    - '\[(x|X)\]\sbug\sfix'
+enhancement:
+    - '\[(x|X)\]\snew\sfeature'
+tests:
+    - '\[(x|X)\]\stests'
+infrastructure:
+    - '\[(x|X)\]\sinfrastructure'
+documentation:
+    - '\[(x|X)\]\sdocumentation'
+allocator:
+    - '\[(x|X)\]\sallocator'

--- a/.github/workflows/issue_labeler.yml
+++ b/.github/workflows/issue_labeler.yml
@@ -1,0 +1,30 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v2.5 #May not be the latest version
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/issue_labeler.yml
+        enable-versioned-regex: 0


### PR DESCRIPTION
### Description 
This PR introduces the issue and PR labeler based on the description.
The following labels were used to mark PR and set proper labels:

| label          | regexp                  |
|----------------|-------------------------|
| bug fix        | `\[(x\|X)\]\sbug\sfix`       |
| enhancement    | `\[(x\|X)\]\snew\sfeature`   |
| tests          | `\[(x\|X)\]\stests`          |
| infrastructure | `\[(x\|X)\]\sinfrastructure` |
| documentation  | `\[(x\|X)\]\sdocumentation`  |

Execution example on my fork:
https://github.com/KFilipek/oneTBB/pull/4

Fixes # - N/A

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [ ] bug fix - _change that fixes an issue_
- [x] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@ldorau

### Other information
Missing labels from the table above should be added. Otherwise, the plugin returns an error during execution.
To cover issues should be prepared issue template which I can also prepare with changes to that script.