### PR TITLE
Do not run the test_malloc_new_handler test under Valgrind

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ include(ProcessorCount)
 
 # General function for test target generation
 function(tbb_add_test)
+    set(options NOMEMCHECK)
     set(oneValueArgs SUBDIR NAME SUFFIX)
     set(multiValueArgs DEPENDENCIES)
     cmake_parse_arguments(_tbb_test "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -76,7 +77,7 @@ function(tbb_add_test)
 
     target_link_libraries(${_tbb_test_TARGET_NAME} PRIVATE ${_tbb_test_DEPENDENCIES} Threads::Threads ${TBB_COMMON_LINK_LIBS})
 
-    if (COMMAND _tbb_run_memcheck)
+    if (COMMAND _tbb_run_memcheck AND (NOT _tbb_test_NOMEMCHECK))
         _tbb_run_memcheck(${_tbb_test_NAME})
     endif()
 endfunction()
@@ -626,7 +627,7 @@ if (TARGET TBB::tbbmalloc)
             tbb_add_test(SUBDIR tbbmalloc NAME test_malloc_atexit DEPENDENCIES TBB::tbbmalloc_proxy TBB::tbbmalloc _test_malloc_atexit)
             tbb_add_test(SUBDIR tbbmalloc NAME test_malloc_overload DEPENDENCIES TBB::tbbmalloc_proxy)
             tbb_add_test(SUBDIR tbbmalloc NAME test_malloc_overload_disable DEPENDENCIES TBB::tbbmalloc_proxy TBB::tbbmalloc) # safer_msize call need to be available
-            tbb_add_test(SUBDIR tbbmalloc NAME test_malloc_new_handler DEPENDENCIES TBB::tbbmalloc_proxy)
+            tbb_add_test(SUBDIR tbbmalloc NAME test_malloc_new_handler DEPENDENCIES TBB::tbbmalloc_proxy NOMEMCHECK)
         endif()
     endif()
 endif()


### PR DESCRIPTION
### Description 
Add the `NOMEMCHECK` option to the `tbb_add_test()` function.

Do not run the `test_malloc_new_handler` test under Valgrind, because this test throws an exception in new/new[], but Valgrind cannot throw exceptions and so is aborting instead:
```
**25896** new/new[] failed and should throw an exception, but Valgrind
**25896**    cannot throw exceptions and so is aborting instead.  Sorry.
```

Fixes: #1075

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@KFilipek 
@lplewa
