### PR TITLE
Do not intercept allocation symbols in tbbmalloc tests (fix)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,6 @@ include(ProcessorCount)
 
 # General function for test target generation
 function(tbb_add_test)
-    set(options NOMEMCHECK)
     set(oneValueArgs SUBDIR NAME SUFFIX)
     set(multiValueArgs DEPENDENCIES)
     cmake_parse_arguments(_tbb_test "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -77,7 +76,7 @@ function(tbb_add_test)
 
     target_link_libraries(${_tbb_test_TARGET_NAME} PRIVATE ${_tbb_test_DEPENDENCIES} Threads::Threads ${TBB_COMMON_LINK_LIBS})
 
-    if (COMMAND _tbb_run_memcheck AND (NOT _tbb_test_NOMEMCHECK))
+    if (COMMAND _tbb_run_memcheck)
         _tbb_run_memcheck(${_tbb_test_NAME})
     endif()
 endfunction()
@@ -627,7 +626,7 @@ if (TARGET TBB::tbbmalloc)
             tbb_add_test(SUBDIR tbbmalloc NAME test_malloc_atexit DEPENDENCIES TBB::tbbmalloc_proxy TBB::tbbmalloc _test_malloc_atexit)
             tbb_add_test(SUBDIR tbbmalloc NAME test_malloc_overload DEPENDENCIES TBB::tbbmalloc_proxy)
             tbb_add_test(SUBDIR tbbmalloc NAME test_malloc_overload_disable DEPENDENCIES TBB::tbbmalloc_proxy TBB::tbbmalloc) # safer_msize call need to be available
-            tbb_add_test(SUBDIR tbbmalloc NAME test_malloc_new_handler DEPENDENCIES TBB::tbbmalloc_proxy NOMEMCHECK)
+            tbb_add_test(SUBDIR tbbmalloc NAME test_malloc_new_handler DEPENDENCIES TBB::tbbmalloc_proxy)
         endif()
     endif()
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,7 +77,7 @@ function(tbb_add_test)
     target_link_libraries(${_tbb_test_TARGET_NAME} PRIVATE ${_tbb_test_DEPENDENCIES} Threads::Threads ${TBB_COMMON_LINK_LIBS})
 
     if (COMMAND _tbb_run_memcheck)
-        _tbb_run_memcheck(${_tbb_test_NAME})
+        _tbb_run_memcheck(${_tbb_test_NAME} ${_tbb_test_SUBDIR})
     endif()
 endfunction()
 


### PR DESCRIPTION
### Description 

Do not intercept allocation symbols in tbbmalloc tests.

Valgring intercepts all allocation symbols with its own by default,
so it disables using tbbmalloc. In case of tbbmalloc tests
intercept allocation symbols only in the default system libraries,
but not in any other shared library or the executable
defining public malloc or operator new related functions.

With this change the `test_malloc_new_handler` test works correctly,
so let's revert #1077.

This patch fixes three tbbmalloc tests:
- `test_malloc_new_handler`,
- `test_malloc_atexit`,
- `test_malloc_overload`

that have not passed under Valgrind so far.

Fixes: #1075 
Fixes: #1080
Fixes: #1081
Ref: #1077

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [x] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
@KFilipek 
@lplewa
@pavelkumbrasev
@isaevil
