### PR TITLE
Update conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -154,10 +154,20 @@ if BUILD_TYPE == 'oneapi'  or BUILD_TYPE == 'dita':
 else:
     html_js_files = ['custom.js']
 
+html_theme_options = { 
+    "logo": {
+        "text": "oneTBB Documentation",
+    }
+}
     
 html_logo = '_static/oneAPI-rgb-rev-100.png'
 html_favicon = '_static/favicons.png'
-html_title = 'oneTBB Documentation'
+
+html_theme_options = { 
+    "logo": {
+        "text": "oneTBB Documentation",
+    }
+}
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -163,11 +163,6 @@ html_theme_options = {
 html_logo = '_static/oneAPI-rgb-rev-100.png'
 html_favicon = '_static/favicons.png'
 
-html_theme_options = { 
-    "logo": {
-        "text": "oneTBB Documentation",
-    }
-}
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
### Description 
Fix to enable the "oneTBB Documentation" title under the logo. Since the new version of the used theme does not support it anymore. 


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
