### PR TITLE
Add riscv64 toolchain.cmake

### DIFF
--- a/cmake/toolchains/riscv64.cmake
+++ b/cmake/toolchains/riscv64.cmake
@@ -1,0 +1,21 @@
+
+# Prevent double invocation.
+if (RISCV_TOOLCHAIN_INCLUDED)
+    return()
+endif()
+set(RISCV_TOOLCHAIN_INCLUDED TRUE)
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR riscv)
+
+# User can use -DCMAKE_FIND_ROOT_PATH to specific toolchain path
+set(CMAKE_C_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/riscv64-unknown-linux-gnu-clang)
+set(CMAKE_CXX_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/riscv64-unknown-linux-gnu-clang++)
+set(CMAKE_LINKER ${CMAKE_FIND_ROOT_PATH}/bin/riscv64-unknown-linux-gnu-ld)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# Most linux on riscv64 support rv64imafd_zba_zbb extensions
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=rv64imafd_zba_zbb -mabi=lp64d " CACHE INTERNAL "")

--- a/cmake/toolchains/riscv64.cmake
+++ b/cmake/toolchains/riscv64.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/toolchains/riscv64.cmake
+++ b/cmake/toolchains/riscv64.cmake
@@ -1,3 +1,16 @@
+# Copyright (c) 2020-2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Prevent double invocation.
 if (RISCV_TOOLCHAIN_INCLUDED)


### PR DESCRIPTION
### Description 
Add riscv64 toolchain.cmake in `cmake/toolchains`.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [x] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
The modification is verified by running tests on qemu. The toolchain/qemu can get from this [document](https://github.com/sifive/prepare-riscv-toolchain-qemu/blob/main/README.md), here is the [example script](https://github.com/sifive/prepare-riscv-toolchain-qemu/blob/main/prepare_riscv_toolchain_qemu.sh) to prepare toolchain/qemu.
