### PR TITLE
FIX: Remove broken style.css reference from layout.html

### DIFF
--- a/doc/main/_templates/layout.html
+++ b/doc/main/_templates/layout.html
@@ -12,5 +12,4 @@
               var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
         })();
       </script>
-      <link href="{{ pathto("_static/style.css", True) }}" rel="stylesheet" type="text/css">
 {% endblock %}

--- a/doc/main/_templates/layout.html
+++ b/doc/main/_templates/layout.html
@@ -6,10 +6,10 @@
         var wapLocalCode = 'us-en'; // Dynamically set per localized site, see mapping table for values
         var wapSection = "oneapi-tbb"; // WAP team will give you a unique section for your site
         // Load TMS
-            (function () {
-              var url = 'https://www.intel.com/content/dam/www/global/wap/tms-loader.js'; // WAP file URL
-              var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true; po.src = url;
-              var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
+        (function () {
+            var url = 'https://www.intel.com/content/dam/www/global/wap/tms-loader.js'; // WAP file URL
+            var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true; po.src = url;
+            var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
         })();
       </script>
 {% endblock %}


### PR DESCRIPTION
### Description 

In this PR, I have addressed the issue of missing `style.css` file in the `_static` directory, which was causing an error. I have removed the reference to the non-existent file to resolve the issue. The error can be observed in the screenshot provided below:

![image](https://github.com/oneapi-src/oneTBB/assets/35470921/2aace64f-4463-4bfe-a8ba-ca5183f42cff)

For example, please visit this [link](https://oneapi-src.github.io/oneTBB/) to verify the occurrence of the described error.
Additionally, I have made some indentation refinements in the affected file.


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
