### PR TITLE
fix deadlock in tbbmalloc raportFreeBlocks function

### DIFF
--- a/src/tbbmalloc/backend.cpp
+++ b/src/tbbmalloc/backend.cpp
@@ -1458,6 +1458,7 @@ size_t Backend::Bin::reportFreeBlocks(FILE *f)
     for (FreeBlock *fb = head; fb; fb = fb->next) {
         size_t sz = fb->tryLockBlock();
         fb->setMeFree(sz);
+        fb->rightNeig(sz)->setLeftFree(sz);
         fprintf(f, " [%p;%p]", fb, (void*)((uintptr_t)fb+sz));
         totalSz += sz;
     }


### PR DESCRIPTION
### Description 
trylockblock() locks mutex in the current element and mutex in right
neighbor, so we have to free both locks.


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@ldorau @KFilipek 

### Other information
