### PR TITLE
Use CMAKE_DL_LIBS to properly choose to use libdl or not.

### DIFF
--- a/cmake/compilers/GNU.cmake
+++ b/cmake/compilers/GNU.cmake
@@ -40,9 +40,7 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "(AMD64|amd64|i.86|x86)")
     set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -mrtm $<$<AND:$<NOT:$<CXX_COMPILER_ID:Intel>>,$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},11.0>>>:-mwaitpkg>)
 endif()
 
-if (NOT MINGW)
-    set(TBB_COMMON_LINK_LIBS dl)
-endif()
+set(TBB_COMMON_LINK_LIBS ${CMAKE_DL_LIBS})
 
 # Ignore -Werror set through add_compile_options() or added to CMAKE_CXX_FLAGS if TBB_STRICT is disabled.
 if (NOT TBB_STRICT AND COMMAND tbb_remove_compile_flag)


### PR DESCRIPTION
Fixes build on *BSD with GCC.

Same also done here for Clang..
https://github.com/oneapi-src/oneTBB/commit/dbccbee9f5527e802925852e225b1d1584f43a7a