### PR TITLE
Compile resumable tasks with ucontext even if  it is deprecated

### DIFF
--- a/cmake/resumable_tasks.cmake
+++ b/cmake/resumable_tasks.cmake
@@ -15,9 +15,17 @@
 include(CheckSymbolExists)
 
 if (UNIX)
+    set(CMAKE_REQUIRED_FLAGS -Wno-deprecated-declarations)
+    if (APPLE)
+        set(CMAKE_REQUIRED_DEFINITIONS -D_XOPEN_SOURCE)
+    endif()
+
     check_symbol_exists("getcontext" "ucontext.h" _tbb_have_ucontext)
     if (NOT _tbb_have_ucontext)
         set(TBB_RESUMABLE_TASKS_USE_THREADS "__TBB_RESUMABLE_TASKS_USE_THREADS=1")
     endif()
+
     unset(_tbb_have_ucontext)
+    unset(CMAKE_REQUIRED_DEFINITIONS)
+    unset(CMAKE_REQUIRED_FLAGS)
 endif()


### PR DESCRIPTION
### Description 
Library should be compiled with ucontext implementation while it is available on a system. (even if it is deprecated) 


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
