### PR TITLE
Minor fixes for KW in tbbmalloc

### DIFF
--- a/src/tbbmalloc/backend.cpp
+++ b/src/tbbmalloc/backend.cpp
@@ -379,7 +379,7 @@ FreeBlock *Backend::IndexedBins::getFromBin(int binIdx, BackendSync *sync, size_
 try_next:
     FreeBlock *fBlock = nullptr;
     if (!b->empty()) {
-        bool locked;
+        bool locked = false;
         MallocMutex::scoped_lock scopedLock(b->tLock, wait, &locked);
 
         if (!locked) {
@@ -505,7 +505,7 @@ void Backend::IndexedBins::addBlock(int binIdx, FreeBlock *fBlock, size_t /* blo
 
 bool Backend::IndexedBins::tryAddBlock(int binIdx, FreeBlock *fBlock, bool addToTail)
 {
-    bool locked;
+    bool locked = false;
     Bin *b = &freeBins[binIdx];
     fBlock->myBin = binIdx;
     if (addToTail) {

--- a/src/tbbmalloc/frontend.cpp
+++ b/src/tbbmalloc/frontend.cpp
@@ -196,7 +196,7 @@ public:
         return *this;
     }
     static bool init() { return true; }
-#if __TBB_SOURCE_DIRECTLY_INCLUDED   
+#if __TBB_SOURCE_DIRECTLY_INCLUDED
     static void destroy() {}
 #endif
 };
@@ -694,7 +694,7 @@ bool AllLocalCaches::cleanup(bool cleanOnlyUnused)
 
 void AllLocalCaches::markUnused()
 {
-    bool locked;
+    bool locked = false;
     MallocMutex::scoped_lock lock(listLock, /*block=*/false, &locked);
     if (!locked) // not wait for marking if someone doing something with it
         return;
@@ -1808,7 +1808,7 @@ void TLSData::release()
 
         if (syncOnMailbox) {
             // Although, we synchronized on nextPrivatizable inside a block, we still need to
-            // synchronize on the bin lifetime because the thread releasing an object into the public 
+            // synchronize on the bin lifetime because the thread releasing an object into the public
             // free list is touching the bin (mailbox and mailLock)
             MallocMutex::scoped_lock scoped_cs(bin[index].mailLock);
         }
@@ -2868,7 +2868,7 @@ void doThreadShutdownNotification(TLSData* tls, bool main_thread)
         defaultMemPool->onThreadShutdown(defaultMemPool->getTLS(/*create=*/false));
         // Take lock to walk through other pools; but waiting might be dangerous at this point
         // (e.g. on Windows the main thread might deadlock)
-        bool locked;
+        bool locked = false;
         MallocMutex::scoped_lock lock(MemoryPool::memPoolListLock, /*wait=*/!main_thread, &locked);
         if (locked) { // the list is safe to process
             for (MemoryPool *memPool = defaultMemPool->next; memPool; memPool = memPool->next)


### PR DESCRIPTION
### Description 
Fix uninitialized boolean variables in TBBMalloc found by KW.


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
