### PR TITLE
Fix current_thread_index for masterless arena(1,0)

### DIFF
--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -110,7 +110,7 @@ std::uintptr_t arena::calculate_stealing_threshold() {
 void arena::process(thread_data& tls) {
     governor::set_thread_data(tls); // TODO: consider moving to create_one_job.
     __TBB_ASSERT( is_alive(my_guard), nullptr);
-    __TBB_ASSERT( my_num_slots > 1, nullptr);
+    __TBB_ASSERT( my_num_slots >= 1, nullptr);
 
     std::size_t index = occupy_free_slot</*as_worker*/true>(tls);
     if (index == out_of_arena) {
@@ -171,7 +171,7 @@ arena::arena ( market& m, unsigned num_slots, unsigned num_reserved_slots, unsig
     my_market = &m;
     my_limit = 1;
     // Two slots are mandatory: for the external thread, and for 1 worker (required to support starvation resistant tasks).
-    my_num_slots = num_arena_slots(num_slots);
+    my_num_slots = num_arena_slots(num_slots, num_reserved_slots);
     my_num_reserved_slots = num_reserved_slots;
     my_max_num_workers = num_slots-num_reserved_slots;
     my_priority_level = priority_level;
@@ -212,11 +212,11 @@ arena& arena::allocate_arena( market& m, unsigned num_slots, unsigned num_reserv
     __TBB_ASSERT( sizeof(base_type) + sizeof(arena_slot) == sizeof(arena), "All arena data fields must go to arena_base" );
     __TBB_ASSERT( sizeof(base_type) % cache_line_size() == 0, "arena slots area misaligned: wrong padding" );
     __TBB_ASSERT( sizeof(mail_outbox) == max_nfs_size, "Mailbox padding is wrong" );
-    std::size_t n = allocation_size(num_arena_slots(num_slots));
+    std::size_t n = allocation_size(num_arena_slots(num_slots, num_reserved_slots));
     unsigned char* storage = (unsigned char*)cache_aligned_allocate(n);
     // Zero all slots to indicate that they are empty
     std::memset( storage, 0, n );
-    return *new( storage + num_arena_slots(num_slots) * sizeof(mail_outbox) )
+    return *new( storage + num_arena_slots(num_slots, num_reserved_slots) * sizeof(mail_outbox) )
         arena(m, num_slots, num_reserved_slots, priority_level);
 }
 
@@ -478,7 +478,7 @@ bool task_arena_impl::attach(d1::task_arena_base& ta) {
         ta.my_num_reserved_slots = a->my_num_reserved_slots;
         ta.my_priority = arena_priority(a->my_priority_level);
         ta.my_max_concurrency = ta.my_num_reserved_slots + a->my_max_num_workers;
-        __TBB_ASSERT(arena::num_arena_slots(ta.my_max_concurrency) == a->my_num_slots, nullptr);
+        __TBB_ASSERT(arena::num_arena_slots(ta.my_max_concurrency, ta.my_num_reserved_slots) == a->my_num_slots, nullptr);
         ta.my_arena.store(a, std::memory_order_release);
         // increases market's ref count for task_arena
         market::global_market( /*is_public=*/true );

--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -312,8 +312,8 @@ public:
     static arena& allocate_arena( market& m, unsigned num_slots, unsigned num_reserved_slots,
                                   unsigned priority_level );
 
-    static int unsigned num_arena_slots ( unsigned num_slots ) {
-        return max(2u, num_slots);
+    static int unsigned num_arena_slots ( unsigned num_slots, unsigned num_reserved_slots ) {
+        return num_reserved_slots == 0 ? num_slots : max(2u, num_slots);
     }
 
     static int allocation_size ( unsigned num_slots ) {

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -1979,3 +1979,22 @@ TEST_CASE("is_inside_task in arena::execute") {
     });
 }
 #endif //__TBB_PREVIEW_TASK_GROUP_EXTENSIONS
+
+//! \brief \ref interface \ref requirement \ref regression
+TEST_CASE("worker threads occupy slots in correct range") {
+    std::vector<tbb::task_arena> arenas(42);
+    for (auto& arena : arenas) {
+        arena.initialize(1, 0);
+    }
+
+    tbb::task_group tg;
+    for (auto& arena : arenas) {
+        arena.execute([&] {
+            tg.run([] {
+                CHECK(tbb::this_task_arena::current_thread_index() == 0);
+            });
+        });
+    }
+
+    tg.wait();
+}


### PR DESCRIPTION
### Description 
A masterless `arena(max concurrency = 1, master threads = 0)` values might return unexpected  tbb::this_task_arena::current_thread_index(), not 0 but 1.  That happens because arena preserve additional slot for arenas with max_concurrency == 1 for correct support of enqueue tasks (to ensure that there is a slot for a worker in case of enqueue task submit).  However, it is not the case for  `arena(max concurrency = 1, master threads = 0)`  because there is a slot for worker thread. 


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
