### PR TITLE
Fix task_task_arena for one thread environment 

### DIFF
--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -1987,14 +1987,13 @@ TEST_CASE("worker threads occupy slots in correct range") {
         arena.initialize(1, 0);
     }
 
-    tbb::task_group tg;
+    std::atomic<int> counter{0};
     for (auto& arena : arenas) {
-        arena.execute([&] {
-            tg.run([] {
-                CHECK(tbb::this_task_arena::current_thread_index() == 0);
-            });
+        arena.enqueue([&] {
+            CHECK(tbb::this_task_arena::current_thread_index() == 0);
+            ++counter;
         });
     }
 
-    tg.wait();
+    while (counter < 42) { utils::yield(); }
 }


### PR DESCRIPTION
### Description 
The task should be enqueued in order to pass on one thread environment. 


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
