### PR TITLE
Fix test_concurrent_queue failure with ICL19.0/VS2017

### DIFF
--- a/test/tbb/test_concurrent_queue.cpp
+++ b/test/tbb/test_concurrent_queue.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -219,6 +219,7 @@ struct TrackableItem {
         auto it = object_addresses.find(this);
         CHECK(it != object_addresses.end());
         object_addresses.erase(it);
+        CHECK(object_addresses.count(this) == 0);
     }
 };
 


### PR DESCRIPTION
### Description 
Prevent an incorrect optimization by ICL 19.0 (fixed in ICL 19.1) with VS 2017 stdlib with inline-level=1 (/Ob1) that resulted in premature object destruction inside `std::unordered_set`.

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change
- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests
- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation
- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information