### PR TITLE
Fix test_task_group compilation on GCC 12

### DIFF
--- a/test/tbb/test_task_group.cpp
+++ b/test/tbb/test_task_group.cpp
@@ -99,8 +99,10 @@ class SharedGroupBodyImpl : utils::NoCopy, utils::NoAfterlife {
                 utils::ConcurrencyTracker ct;
                 m_taskGroup->wait();
             }
-            if ( utils::ConcurrencyTracker::PeakParallelism() == 1 )
-                WARN( "Warning: No parallel waiting detected in TestParallelWait" );
+            if ( utils::ConcurrencyTracker::PeakParallelism() == 1 ) {
+                const char* msg = "Warning: No parallel waiting detected in TestParallelWait";
+                WARN( msg );
+            }
             m_barrier.wait();
         }
         else


### PR DESCRIPTION
### Description 
Workaround warning on GCC 12:
```
/doctest.h:1560:42: error: the compiler can assume that the address of ‘doctest::detail::Expression_lhs<const char (&)[58]>::lhs’ will never be NULL [-Werror=address]
 1560 |             bool res = static_cast<bool>(lhs);
      |                                          ^~~
```

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
