### PR TITLE
Fix constraint arena construction

### DIFF
--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -543,13 +543,6 @@ void task_arena_impl::initialize(d1::task_arena_base& ta) {
         .set_core_type(ta.core_type())
         .set_max_threads_per_core(ta.max_threads_per_core())
         .set_numa_id(ta.my_numa_id);
-
-    numa_binding_observer* observer = construct_binding_observer(
-        static_cast<d1::task_arena*>(&ta), arena::num_arena_slots(ta.my_max_concurrency, ta.my_num_reserved_slots),
-        ta.my_numa_id, ta.core_type(), ta.max_threads_per_core());
-    if (observer) {
-        observer->on_scheduler_entry(true);
-    }
 #endif /*__TBB_ARENA_BINDING*/
 
     if (ta.my_max_concurrency < 1) {
@@ -559,6 +552,15 @@ void task_arena_impl::initialize(d1::task_arena_base& ta) {
         ta.my_max_concurrency = (int)governor::default_num_threads();
 #endif /*!__TBB_ARENA_BINDING*/
     }
+
+#if __TBB_ARENA_BINDING
+    numa_binding_observer* observer = construct_binding_observer(
+        static_cast<d1::task_arena*>(&ta), arena::num_arena_slots(ta.my_max_concurrency, ta.my_num_reserved_slots),
+        ta.my_numa_id, ta.core_type(), ta.max_threads_per_core());
+    if (observer) {
+        observer->on_scheduler_entry(true);
+    }
+#endif /*__TBB_ARENA_BINDING*/
 
     __TBB_ASSERT(ta.my_arena.load(std::memory_order_relaxed) == nullptr, "Arena already initialized");
     unsigned priority_level = arena_priority_level(ta.my_priority);

--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -553,14 +553,16 @@ void task_arena_impl::initialize(d1::task_arena_base& ta) {
 #endif /*!__TBB_ARENA_BINDING*/
     }
 
-#if __TBB_ARENA_BINDING
+#if __TBB_CPUBIND_PRESENT
     numa_binding_observer* observer = construct_binding_observer(
         static_cast<d1::task_arena*>(&ta), arena::num_arena_slots(ta.my_max_concurrency, ta.my_num_reserved_slots),
         ta.my_numa_id, ta.core_type(), ta.max_threads_per_core());
     if (observer) {
+        // TODO: Consider lazy initialization for internal arena so
+        // the direct calls to observer might be omitted until actual initialization. 
         observer->on_scheduler_entry(true);
     }
-#endif /*__TBB_ARENA_BINDING*/
+#endif /*__TBB_CPUBIND_PRESENT*/
 
     __TBB_ASSERT(ta.my_arena.load(std::memory_order_relaxed) == nullptr, "Arena already initialized");
     unsigned priority_level = arena_priority_level(ta.my_priority);

--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description 
Currently constrained arena might be initialized (first touch to fields) on inappropriate constraints because initializing thread doesn't apply constraints during initialization.
This PR reuses `binding_observer` to apply constraints on thread that performs initialization. 


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
