### PR TITLE
Add mutex.h and rw_mutex.h to oneapi/tbb.h

### DIFF
--- a/include/oneapi/tbb.h
+++ b/include/oneapi/tbb.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb.h
+++ b/include/oneapi/tbb.h
@@ -63,6 +63,8 @@
 #include "oneapi/tbb/queuing_rw_mutex.h"
 #include "oneapi/tbb/spin_mutex.h"
 #include "oneapi/tbb/spin_rw_mutex.h"
+#include "oneapi/tbb/mutex.h"
+#include "oneapi/tbb/rw_mutex.h"
 #include "oneapi/tbb/task.h"
 #include "oneapi/tbb/task_arena.h"
 #include "oneapi/tbb/task_group.h"

--- a/test/tbb/test_tbb_header.cpp
+++ b/test/tbb/test_tbb_header.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_tbb_header.cpp
+++ b/test/tbb/test_tbb_header.cpp
@@ -227,6 +227,8 @@ static void DefinitionPresence() {
     TestTypeDefinitionPresence( queuing_rw_mutex );
     TestTypeDefinitionPresence( spin_mutex );
     TestTypeDefinitionPresence( spin_rw_mutex );
+    TestTypeDefinitionPresence( mutex );
+    TestTypeDefinitionPresence( rw_mutex );
     TestTypeDefinitionPresence( speculative_spin_mutex );
     TestTypeDefinitionPresence( speculative_spin_rw_mutex );
     TestTypeDefinitionPresence( task_group_context );


### PR DESCRIPTION
### Description 
Added both `mutex.h` and `rw_mutex.h` to `include/oneapi/tbb`. (This was missed during original PR)

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
