### PR TITLE
Support multiple layout variations in Linux/Windows vars scripts, refactor modulefiles

### DIFF
--- a/integration/linux/modulefiles/tbb
+++ b/integration/linux/modulefiles/tbb
@@ -1,6 +1,6 @@
 #%Module1.0###################################################################
 #
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,16 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Why all the directory and filename boilerplate code? It is needed in order
-# to properly remove symbolic links used in assembly of the modulefiles
-# folder as well as those found within the oneAPI installation folders.
-# Without it many modulefiles will fail to work as expected.
-
-# IMPORTANT: quotes around "$variables" and "[expressions]" are there
-# to insure that paths/filenames which include spaces are handled properly.
-
 # This modulefile requires Environment Modules 4.1 or later.
 # Type `module --version` to determine the current installed version.
+
+##############################################################################
 
 set min_tcl_ver 8.4
 if { $tcl_version < $min_tcl_ver } {
@@ -33,72 +27,44 @@ if { $tcl_version < $min_tcl_ver } {
     exit 1
 }
 
-# get full pathname for this script file
+# if modulefile script name is a symlink, resolve it and then
+# get the fully qualified pathname to this modulefile script
 set scriptpath "${ModulesCurrentModulefile}"
-
-# if modulefile script name is a symlink, resolve it
 if { "[file type "$scriptpath"]" eq "link" } {
     set scriptpath "[file readlink "$scriptpath"]"
 }
-
-# if fullpath contains links, resolve them
 set scriptpath "[file normalize "$scriptpath"]"
 
-# get directory holding this modulefile script and others
-set modulefileroot "[file dirname "$scriptpath"]"
+# define componentroot, modulefileroot, modulefilename and modulefilever
+set modulefilename "[file tail [file dirname "${scriptpath}"]]"
+set modulefilever "[file tail "$scriptpath"]"
+set modulefilepath "${scriptpath}"
+set componentroot "[file dirname [file dirname [file dirname [file dirname "${scriptpath}"]]]]"
 
-# get name of modulefile script we are loading
-set modulefilename "[file tail "$scriptpath"]"
+##############################################################################
 
-# determine modulefile script version
-set modulefilever "[file dirname "$modulefileroot"]"
-set modulefilever "[file tail "$modulefilever"]"
+module-whatis "Name: Intel(R) oneAPI Threading Building Blocks"
+module-whatis "Version: $modulefilename/$modulefilever"
+module-whatis "Description: Flexible threading library for adding parallelism to complex applications across accelerated architectures."
+module-whatis "URL: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onetbb.html"
+module-whatis "Dependencies: none"
 
-# point to component top-level root folder
-set componentroot "[file dirname "$modulefileroot"]"
-set componentroot "[file dirname "$componentroot"]"
-
-# get component folder name
-set componentname "[file tail "$componentroot"]"
-
-# get oneAPI top-level root folder
-set oneapiroot "[file dirname "$componentroot"]"
-
-# disallow loading multiple versions of this modulefile
-# disallow loading multiple architectures of this modulefile
-# if only 64-bit architecture exists the test still works
-set mname32 $modulefilename
-set mname64 [string trimright $mname32 "32"]
-if { [string equal "$mname32" "$mname64"] } {
-    append mname32 "32"
-}
-conflict $mname32
-conflict $mname64
-
-
-# On load print component name and version being loaded
-if { [ module-info mode load ] } {
-    puts stderr "Loading $modulefilename version $modulefilever"
+proc ModulesHelp { } {
+    global modulefilename
+    global modulefilever
+    module whatis "${modulefilename}/${modulefilever}"
 }
 
-# On `module unload` print component module name and version being removed
-# Include `module list` message only if this modulefile loads dependent modules
-if { [ module-info mode ] == "unload" || [ module-info mode ] == "remove" } {
-    puts stderr "Removing $modulefilename version $modulefilever"
-    puts stderr "Use `module list` to view any remaining dependent modules."
-}
+##############################################################################
 
+# Define environment variables needed for an isolated component install.
 
-# ###### Component Specific env vars setup ###################################
-
-set tbbroot "$componentroot/$modulefilever"
+set tbbroot "$componentroot"
 set tbb_target_arch "intel64"
-
-module-whatis "Intel(R) oneAPI Threading Building Blocks for $tbb_target_arch."
 
 setenv TBBROOT "$tbbroot"
 
 prepend-path CPATH "$tbbroot/include"
-prepend-path LIBRARY_PATH "$tbbroot/lib/$tbb_target_arch/gcc4.8"
-prepend-path LD_LIBRARY_PATH "$tbbroot/lib/$tbb_target_arch/gcc4.8"
+prepend-path LIBRARY_PATH "$tbbroot/lib"
+prepend-path LD_LIBRARY_PATH "$tbbroot/lib"
 prepend-path CMAKE_PREFIX_PATH "$tbbroot"

--- a/integration/linux/modulefiles/tbb
+++ b/integration/linux/modulefiles/tbb
@@ -30,14 +30,14 @@ if { $tcl_version < $min_tcl_ver } {
 # if modulefile script name is a symlink, resolve it and then
 # get the fully qualified pathname to this modulefile script
 set scriptpath "${ModulesCurrentModulefile}"
-if { "[file type "$scriptpath"]" eq "link" } {
-    set scriptpath "[file readlink "$scriptpath"]"
+if { "[file type "${scriptpath}"]" eq "link" } {
+    set scriptpath "[file readlink "${scriptpath}"]"
 }
-set scriptpath "[file normalize "$scriptpath"]"
+set scriptpath "[file normalize "${scriptpath}"]"
 
-# define componentroot, modulefileroot, modulefilename and modulefilever
+# define componentroot, modulefilepath, modulefilename and modulefilever
 set modulefilename "[file tail [file dirname "${scriptpath}"]]"
-set modulefilever "[file tail "$scriptpath"]"
+set modulefilever "[file tail "${scriptpath}"]"
 set modulefilepath "${scriptpath}"
 set componentroot "[file dirname [file dirname [file dirname [file dirname "${scriptpath}"]]]]"
 

--- a/integration/linux/modulefiles/tbb32
+++ b/integration/linux/modulefiles/tbb32
@@ -1,6 +1,6 @@
 #%Module1.0###################################################################
 #
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,16 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Why all the directory and filename boilerplate code? It is needed in order
-# to properly remove symbolic links used in assembly of the modulefiles
-# folder as well as those found within the oneAPI installation folders.
-# Without it many modulefiles will fail to work as expected.
-
-# IMPORTANT: quotes around "$variables" and "[expressions]" are there
-# to insure that paths/filenames which include spaces are handled properly.
-
 # This modulefile requires Environment Modules 4.1 or later.
 # Type `module --version` to determine the current installed version.
+
+##############################################################################
 
 set min_tcl_ver 8.4
 if { $tcl_version < $min_tcl_ver } {
@@ -33,72 +27,44 @@ if { $tcl_version < $min_tcl_ver } {
     exit 1
 }
 
-# get full pathname for this script file
+# if modulefile script name is a symlink, resolve it and then
+# get the fully qualified pathname to this modulefile script
 set scriptpath "${ModulesCurrentModulefile}"
-
-# if modulefile script name is a symlink, resolve it
 if { "[file type "$scriptpath"]" eq "link" } {
     set scriptpath "[file readlink "$scriptpath"]"
 }
-
-# if fullpath contains links, resolve them
 set scriptpath "[file normalize "$scriptpath"]"
 
-# get directory holding this modulefile script and others
-set modulefileroot "[file dirname "$scriptpath"]"
+# define componentroot, modulefileroot, modulefilename and modulefilever
+set modulefilename "[file tail [file dirname "${scriptpath}"]]"
+set modulefilever "[file tail "$scriptpath"]"
+set modulefilepath "${scriptpath}"
+set componentroot "[file dirname [file dirname [file dirname [file dirname "${scriptpath}"]]]]"
 
-# get name of modulefile script we are loading
-set modulefilename "[file tail "$scriptpath"]"
+##############################################################################
 
-# determine modulefile script version
-set modulefilever "[file dirname "$modulefileroot"]"
-set modulefilever "[file tail "$modulefilever"]"
+module-whatis "Name: Intel(R) oneAPI Threading Building Blocks"
+module-whatis "Version: $modulefilename/$modulefilever"
+module-whatis "Description: Flexible threading library for adding parallelism to complex applications across accelerated architectures."
+module-whatis "URL: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onetbb.html"
+module-whatis "Dependencies: none"
 
-# point to component top-level root folder
-set componentroot "[file dirname "$modulefileroot"]"
-set componentroot "[file dirname "$componentroot"]"
-
-# get component folder name
-set componentname "[file tail "$componentroot"]"
-
-# get oneAPI top-level root folder
-set oneapiroot "[file dirname "$componentroot"]"
-
-# disallow loading multiple versions of this modulefile
-# disallow loading multiple architectures of this modulefile
-# if only 64-bit architecture exists the test still works
-set mname32 $modulefilename
-set mname64 [string trimright $mname32 "32"]
-if { [string equal "$mname32" "$mname64"] } {
-    append mname32 "32"
-}
-conflict $mname32
-conflict $mname64
-
-
-# On load print component name and version being loaded
-if { [ module-info mode load ] } {
-    puts stderr "Loading $modulefilename version $modulefilever"
+proc ModulesHelp { } {
+    global modulefilename
+    global modulefilever
+    module whatis "${modulefilename}/${modulefilever}"
 }
 
-# On `module unload` print component module name and version being removed
-# Include `module list` message only if this modulefile loads dependent modules
-if { [ module-info mode ] == "unload" || [ module-info mode ] == "remove" } {
-    puts stderr "Removing $modulefilename version $modulefilever"
-    puts stderr "Use `module list` to view any remaining dependent modules."
-}
+##############################################################################
 
+# Define environment variables needed for an isolated component install.
 
-# ###### Component Specific env vars setup ###################################
-
-set tbbroot "$componentroot/$modulefilever"
+set tbbroot "$componentroot"
 set tbb_target_arch "ia32"
-
-module-whatis "Intel(R) oneAPI Threading Building Blocks for $tbb_target_arch."
 
 setenv TBBROOT "$tbbroot"
 
-prepend-path CPATH "$tbbroot/include"
-prepend-path LIBRARY_PATH "$tbbroot/lib/$tbb_target_arch/gcc4.8"
-prepend-path LD_LIBRARY_PATH "$tbbroot/lib/$tbb_target_arch/gcc4.8"
+prepend-path CPATH "$tbbroot/include32:$tbbroot/include"
+prepend-path LIBRARY_PATH "$tbbroot/lib32"
+prepend-path LD_LIBRARY_PATH "$tbbroot/lib32"
 prepend-path CMAKE_PREFIX_PATH "$tbbroot"

--- a/integration/linux/modulefiles/tbb32
+++ b/integration/linux/modulefiles/tbb32
@@ -30,14 +30,14 @@ if { $tcl_version < $min_tcl_ver } {
 # if modulefile script name is a symlink, resolve it and then
 # get the fully qualified pathname to this modulefile script
 set scriptpath "${ModulesCurrentModulefile}"
-if { "[file type "$scriptpath"]" eq "link" } {
-    set scriptpath "[file readlink "$scriptpath"]"
+if { "[file type "${scriptpath}"]" eq "link" } {
+    set scriptpath "[file readlink "${scriptpath}"]"
 }
-set scriptpath "[file normalize "$scriptpath"]"
+set scriptpath "[file normalize "${scriptpath}"]"
 
-# define componentroot, modulefileroot, modulefilename and modulefilever
+# define componentroot, modulefilepath, modulefilename and modulefilever
 set modulefilename "[file tail [file dirname "${scriptpath}"]]"
-set modulefilever "[file tail "$scriptpath"]"
+set modulefilever "[file tail "${scriptpath}"]"
 set modulefilepath "${scriptpath}"
 set componentroot "[file dirname [file dirname [file dirname [file dirname "${scriptpath}"]]]]"
 

--- a/integration/linux/oneapi/vars.sh
+++ b/integration/linux/oneapi/vars.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Copyright (c) 2005-2023 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/integration/mac/env/vars.sh
+++ b/integration/mac/env/vars.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # shellcheck shell=sh
 #
-# Copyright (c) 2005-2023 Intel Corporation
+# Copyright (c) 2005-2021 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,20 +15,135 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -z "${SETVARS_CALL:-}" ] ; then
-  >&2 echo " "
-  >&2 echo ":: ERROR: This script must be sourced by setvars.sh."
-  >&2 echo "   Try 'source <install-dir>/setvars.sh --help' for help."
-  >&2 echo " "
-  return 255
+# Get absolute path to script. Gets a relative path as argument and outputs an absolute path.
+get_script_path() (
+  script_path="$1"
+  while [ -L "$script_path" ] ; do
+    script_dir=$(command dirname -- "$script_path")
+    script_dir=$(cd "$script_dir" && command pwd -P)
+    script_path="$(readlink "$script_path")"
+    case $script_path in
+      (/*) ;;
+       (*) script_path="$script_dir/$script_path" ;;
+    esac
+  done
+  script_dir=$(command dirname -- "$script_path")
+  script_dir=$(cd "$script_dir" && command pwd -P)
+  printf "%s" "$script_dir"
+)
+
+_vars_get_proc_name() {
+  if [ -n "${ZSH_VERSION:-}" ] ; then
+    script="$(ps -p "$$" -o comm=)"
+  else
+    script="$1"
+    while [ -L "$script" ] ; do
+      script="$(readlink "$script")"
+    done
+  fi
+  basename -- "$script"
+}
+
+_vars_this_script_name="vars.sh"
+if [ "$_vars_this_script_name" = "$(_vars_get_proc_name "$0")" ] ; then
+  echo ":: ERROR: Incorrect usage: this script must be sourced."
+  echo "   Usage: . path/to/${_vars_this_script_name}"
+  return 255 2>/dev/null || exit 255
 fi
 
-if [ -z "${ONEAPI_ROOT:-}" ] ; then
-  >&2 echo " "
-  >&2 echo ":: ERROR: This script requires that the ONEAPI_ROOT env variable is set."
-  >&2 echo "   Try 'source <install-dir>\setvars.sh --help' for help."
-  >&2 echo " "
-  return 254
+# Prepend path segment(s) to path-like env vars (PATH, CPATH, etc.).
+
+# prepend_path() avoids dangling ":" that affects some env vars (PATH and CPATH)
+# PATH > https://www.gnu.org/software/libc/manual/html_node/Standard-Environment.html
+
+# Usage:
+#   env_var=$(prepend_path "$prepend_to_var" "$existing_env_var")
+#   export env_var
+#
+# Inputs:
+#   $1 == path segment to be prepended to $2
+#   $2 == value of existing path-like environment variable
+
+prepend_path() (
+  path_to_add="$1"
+  path_is_now="$2"
+
+  if [ "" = "${path_is_now}" ] ; then   # avoid dangling ":"
+    printf "%s" "${path_to_add}"
+  else
+    printf "%s" "${path_to_add}:${path_is_now}"
+  fi
+)
+
+# Extract the name and location of this sourced script.
+
+# Generally, "ps -o comm=" is limited to a 15 character result, but it works
+# fine for this usage, because we are primarily interested in finding the name
+# of the execution shell, not the name of any calling script.
+
+vars_script_name=""
+vars_script_shell="$(ps -p "$$" -o comm=)"
+# ${var:-} needed to pass "set -eu" checks
+if [ -n "${ZSH_VERSION:-}" ] && [ -n "${ZSH_EVAL_CONTEXT:-}" ] ; then     # zsh 5.x and later
+  # shellcheck disable=2249
+  case $ZSH_EVAL_CONTEXT in (*:file*) vars_script_name="${(%):-%x}" ;; esac ;
+elif [ -n "${KSH_VERSION:-}" ] ; then                                     # ksh, mksh or lksh
+  if [ "$(set | grep -Fq "KSH_VERSION=.sh.version" ; echo $?)" -eq 0 ] ; then # ksh
+    vars_script_name="${.sh.file}" ;
+  else # mksh or lksh or [lm]ksh masquerading as ksh or sh
+    # force [lm]ksh to issue error msg; which contains this script's path/filename, e.g.:
+    # mksh: /home/ubuntu/intel/oneapi/vars.sh[137]: ${.sh.file}: bad substitution
+    vars_script_name="$( (echo "${.sh.file}") 2>&1 )" || : ;
+    vars_script_name="$(expr "${vars_script_name:-}" : '^.*sh: \(.*\)\[[0-9]*\]:')" ;
+  fi
+elif [ -n "${BASH_VERSION:-}" ] ; then        # bash
+  # shellcheck disable=2128
+  (return 0 2>/dev/null) && vars_script_name="${BASH_SOURCE}" ;
+elif [ "dash" = "$vars_script_shell" ] ; then # dash
+  # force dash to issue error msg; which contains this script's rel/path/filename, e.g.:
+  # dash: 146: /home/ubuntu/intel/oneapi/vars.sh: Bad substitution
+  vars_script_name="$( (echo "${.sh.file}") 2>&1 )" || : ;
+  vars_script_name="$(expr "${vars_script_name:-}" : '^.*dash: [0-9]*: \(.*\):')" ;
+elif [ "sh" = "$vars_script_shell" ] ; then   # could be dash masquerading as /bin/sh
+  # force a shell error msg; which should contain this script's path/filename
+  # sample error msg shown; assume this file is named "vars.sh"; as required by setvars.sh
+  vars_script_name="$( (echo "${.sh.file}") 2>&1 )" || : ;
+  if [ "$(printf "%s" "$vars_script_name" | grep -Eq "sh: [0-9]+: .*vars\.sh: " ; echo $?)" -eq 0 ] ; then # dash as sh
+    # sh: 155: /home/ubuntu/intel/oneapi/vars.sh: Bad substitution
+    vars_script_name="$(expr "${vars_script_name:-}" : '^.*sh: [0-9]*: \(.*\):')" ;
+  fi
+else  # unrecognized shell or dash being sourced from within a user's script
+  # force a shell error msg; which should contain this script's path/filename
+  # sample error msg shown; assume this file is named "vars.sh"; as required by setvars.sh
+  vars_script_name="$( (echo "${.sh.file}") 2>&1 )" || : ;
+  if [ "$(printf "%s" "$vars_script_name" | grep -Eq "^.+: [0-9]+: .*vars\.sh: " ; echo $?)" -eq 0 ] ; then # dash
+    # .*: 164: intel/oneapi/vars.sh: Bad substitution
+    vars_script_name="$(expr "${vars_script_name:-}" : '^.*: [0-9]*: \(.*\):')" ;
+  else
+    vars_script_name="" ;
+  fi
 fi
 
-TBBROOT="${ONEAPI_ROOT}"; export TBBROOT
+if [ "" = "$vars_script_name" ] ; then
+  >&2 echo ":: ERROR: Unable to proceed: possible causes listed below."
+  >&2 echo "   This script must be sourced. Did you execute or source this script?" ;
+  >&2 echo "   Unrecognized/unsupported shell (supported: bash, zsh, ksh, m/lksh, dash)." ;
+  >&2 echo "   Can be caused by sourcing from ZSH version 4.x or older." ;
+  return 255 2>/dev/null || exit 255
+fi
+
+TBBROOT=$(get_script_path "${vars_script_name:-}")/..
+LIBTBB_NAME="libtbb.dylib"
+
+if [ -e "$TBBROOT/lib/$LIBTBB_NAME" ]; then
+    export TBBROOT
+
+    LIBRARY_PATH=$(prepend_path "${TBBROOT}/lib" "${LIBRARY_PATH:-}") ; export LIBRARY_PATH
+    DYLD_LIBRARY_PATH=$(prepend_path "${TBBROOT}/lib" "${DYLD_LIBRARY_PATH:-}") ; export DYLD_LIBRARY_PATH
+    CPATH=$(prepend_path "${TBBROOT}/include" "${CPATH:-}") ; export CPATH
+    CMAKE_PREFIX_PATH=$(prepend_path "${TBBROOT}" "${CMAKE_PREFIX_PATH:-}") ; export CMAKE_PREFIX_PATH
+    PKG_CONFIG_PATH=$(prepend_path "${TBBROOT}/lib/pkgconfig" "${PKG_CONFIG_PATH:-}") ; export PKG_CONFIG_PATH
+else
+    >&2 echo "ERROR: $LIBTBB_NAME library does not exist in $TBBROOT/lib."
+    return 255 2>/dev/null || exit 255
+fi

--- a/integration/windows/env/vars.bat
+++ b/integration/windows/env/vars.bat
@@ -24,41 +24,70 @@ REM    if ^<arch^> is not set Intel(R) 64 architecture will be used
 REM    ^<vs^> should be one of the following
 REM        vs2019      : Set to use with Microsoft Visual Studio 2019 runtime DLLs
 REM        vs2022      : Set to use with Microsoft Visual Studio 2022 runtime DLLs
-REM        all         : Set to use TBB statically linked with Microsoft Visual C++ runtime
-REM    if ^<vs^> is not set TBB statically linked with Microsoft Visual C++ runtime will be used.
+REM        all         : Set to use oneTBB statically linked with Microsoft Visual C++ runtime
+REM    if ^<vs^> is not set oneTBB dynamically linked with Microsoft Visual C++ runtime will be used.
 
 set "SCRIPT_NAME=%~nx0"
-set "TBB_BIN_DIR=%~d0%~p0"
-set "TBBROOT=%TBB_BIN_DIR%.."
+set "TBB_SCRIPT_DIR=%~d0%~p0"
+set "TBBROOT=%TBB_SCRIPT_DIR%.."
 
 :: Set the default arguments
 set TBB_TARGET_ARCH=intel64
-set TBB_TARGET_VS=vc_mt
+set TBB_ARCH_SUFFIX=
+set TBB_TARGET_VS=vc14
 
 :ParseArgs
 :: Parse the incoming arguments
-if /i "%1"==""        goto SetEnv
+if /i "%1"==""             goto ParseLayout
 if /i "%1"=="ia32"         (set TBB_TARGET_ARCH=ia32)     & shift & goto ParseArgs
 if /i "%1"=="intel64"      (set TBB_TARGET_ARCH=intel64)  & shift & goto ParseArgs
 if /i "%1"=="vs2019"       (set TBB_TARGET_VS=vc14)       & shift & goto ParseArgs
 if /i "%1"=="vs2022"       (set TBB_TARGET_VS=vc14)       & shift & goto ParseArgs
 if /i "%1"=="all"          (set TBB_TARGET_VS=vc_mt)      & shift & goto ParseArgs
 
-:SetEnv
-if exist "%TBBROOT%\redist\%TBB_TARGET_ARCH%\%TBB_TARGET_VS%\tbb12.dll" (
-    set "TBB_DLL_PATH=%TBBROOT%\redist\%TBB_TARGET_ARCH%\%TBB_TARGET_VS%"
+:ParseLayout
+if exist "%TBBROOT%\redist\" (
+    set "TBB_BIN_DIR=%TBBROOT%\redist"
+    set "TBB_SUBDIR=%TBB_TARGET_ARCH%"
+    goto SetEnv
 )
-if exist "%TBBROOT%\..\redist\%TBB_TARGET_ARCH%\tbb\%TBB_TARGET_VS%\tbb12.dll" (
-    set "TBB_DLL_PATH=%TBBROOT%\..\redist\%TBB_TARGET_ARCH%\tbb\%TBB_TARGET_VS%"
+
+if "%TBB_TARGET_ARCH%" == "ia32" (
+    set TBB_ARCH_SUFFIX=32
+)
+if exist "%TBBROOT%\bin%TBB_ARCH_SUFFIX%" (
+    set "TBB_BIN_DIR=%TBBROOT%\bin%TBB_ARCH_SUFFIX%"
+    if "%TBB_TARGET_VS%" == "vc14" (
+        set TBB_TARGET_VS=
+    )
+    goto SetEnv
+)
+:: Couldn't parse TBBROOT/bin, unset variable
+set TBB_ARCH_SUFFIX=
+
+if exist "%TBBROOT%\..\redist\" (
+    set "TBB_BIN_DIR=%TBBROOT%\..\redist"
+    set "TBB_SUBDIR=%TBB_TARGET_ARCH%\tbb"
+    goto SetEnv
+)
+
+:SetEnv
+if exist "%TBB_BIN_DIR%\%TBB_SUBDIR%\%TBB_TARGET_VS%\tbb12.dll" (
+    set "TBB_DLL_PATH=%TBB_BIN_DIR%\%TBB_SUBDIR%\%TBB_TARGET_VS%"
+) else (
+    echo:
+    echo :: ERROR: tbb12.dll library does not exist in "%TBB_BIN_DIR%\%TBB_SUBDIR%\%TBB_TARGET_VS%\"
+    echo:
+    exit /b 255
 )
 
 set "PATH=%TBB_DLL_PATH%;%PATH%"
 
-set "LIB=%TBBROOT%\lib\%TBB_TARGET_ARCH%\%TBB_TARGET_VS%;%LIB%"
+set "LIB=%TBBROOT%\lib%TBB_ARCH_SUFFIX%\%TBB_SUBDIR%\%TBB_TARGET_VS%;%LIB%"
 set "INCLUDE=%TBBROOT%\include;%INCLUDE%"
 set "CPATH=%TBBROOT%\include;%CPATH%"
 set "CMAKE_PREFIX_PATH=%TBBROOT%;%CMAKE_PREFIX_PATH%"
-set "PKG_CONFIG_PATH=%TBBROOT%\lib\pkgconfig;%PKG_CONFIG_PATH%"
+set "PKG_CONFIG_PATH=%TBBROOT%\lib%TBB_ARCH_SUFFIX%\pkgconfig;%PKG_CONFIG_PATH%"
 
 :End
 exit /B 0

--- a/integration/windows/oneapi/vars.bat
+++ b/integration/windows/oneapi/vars.bat
@@ -1,0 +1,56 @@
+@echo off
+REM
+REM Copyright (c) 2023 Intel Corporation
+REM
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
+
+if not defined SETVARS_CALL (
+    echo:
+    echo :: ERROR: This script must be executed by setvars.bat.
+    echo:   Try '[install-dir]\setvars.bat --help' for help.
+    echo:
+    exit /b 255
+)
+
+if not defined ONEAPI_ROOT (
+    echo:
+    echo :: ERROR: This script requires that the ONEAPI_ROOT env variable is set."
+    echo:   Try '[install-dir]\setvars.bat --help' for help.
+    echo:
+    exit /b 254
+)
+
+set "TBBROOT=%ONEAPI_ROOT%"
+
+:: Set the default arguments
+set "TBB_TARGET_ARCH=%INTEL_TARGET_ARCH%"
+set TBB_TARGET_VS=
+set ARCH_SUFFIX=
+
+:ParseArgs
+:: Parse the incoming arguments
+if /i "%1"==""        goto SetEnv
+if /i "%1"=="vs2019"       (set TBB_TARGET_VS= )       & shift & goto ParseArgs
+if /i "%1"=="vs2022"       (set TBB_TARGET_VS= )       & shift & goto ParseArgs
+if /i "%1"=="all"          (set TBB_TARGET_VS=vc_mt)   & shift & goto ParseArgs
+
+if "%TBB_TARGET_ARCH%"=="ia32" set ARCH_SUFFIX=32  
+
+:SetEnv
+if exist "%TBBROOT%\bin%ARCH_SUFFIX%\%TBB_TARGET_VS%\tbb12.dll" (
+    set "TBB_DLL_PATH=%TBBROOT%\bin%ARCH_SUFFIX%\%TBB_TARGET_VS%"
+)
+
+:End
+exit /B 0


### PR DESCRIPTION
### Description 
env/vars scripts now support different layouts (for example, `bin/` or `redist/` on Windows, `lib/<arch>` or `lib<arch_suffix>/` on Linux). Also modulefiles now rely on `lib/` and `lib32/` for library path, not on `lib/intel64/gcc4.8` or  `lib/ia32/gcc4.8`


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [x] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [x] Yes (for modulefiles)
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
