### PR TITLE
Assert if a shift amount is negative

### DIFF
--- a/src/tbbmalloc/large_objects.h
+++ b/src/tbbmalloc/large_objects.h
@@ -88,8 +88,10 @@ public:
     static int sizeToIdx(size_t size) {
         MALLOC_ASSERT(MinSize <= size && size <= MaxSize, ASSERT_TEXT);
         int sizeExp = (int)BitScanRev(size); // same as __TBB_Log2
+        MALLOC_ASSERT(sizeExp >= 0, "A shift amount (sizeExp) must not be negative");
         size_t majorStepSize = 1ULL << sizeExp;
         int minorStepExp = sizeExp - StepFactorExp;
+        MALLOC_ASSERT(minorStepExp >= 0, "A shift amount (minorStepExp) must not be negative");
         int minorIdx = (size - majorStepSize) >> minorStepExp;
         MALLOC_ASSERT(size == majorStepSize + ((size_t)minorIdx << minorStepExp),
             "Size is not aligned on the bin");


### PR DESCRIPTION
### Description 
Shifting by a negative amount has an undefined behavior.
A shift amount must not be negative.
Assert if a shift amount is negative.
It fixes the Coverity issues: 449477 and 913889.

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@lplewa @KFilipek 
