### PR TITLE
Verify size in alignToBin()

### DIFF
--- a/src/tbbmalloc/large_objects.h
+++ b/src/tbbmalloc/large_objects.h
@@ -80,6 +80,7 @@ public:
     static const unsigned NumBins = (MaxSizeExp - MinSizeExp) * StepFactor;
 
     static size_t alignToBin(size_t size) {
+        MALLOC_ASSERT(size >= StepFactor, "Size must not be less than the StepFactor");
         size_t minorStepExp = BitScanRev(size) - StepFactorExp;
         return alignUp(size, 1ULL << minorStepExp);
     }


### PR DESCRIPTION
### Description 
Size in alignToBin() must not be less than the StepFactor (8).
It fixes the Coverity issues: 449474 and 913880.

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@lplewa @KFilipek 
