### PR TITLE
CI: Update issue-labeler to latest version

### DIFF
--- a/.github/workflows/issue_labeler.yml
+++ b/.github/workflows/issue_labeler.yml
@@ -22,9 +22,14 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
     steps:
-    - uses: github/issue-labeler@v2.5 #May not be the latest version
+    - uses: github/issue-labeler@v3.2 #May not be the latest version
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/issue_labeler.yml
         enable-versioned-regex: 0
+        sync-labels: 1


### PR DESCRIPTION
Issue Labeler will work only after merge. Working is here on my repository: https://github.com/KFilipek/oneTBB/pull/10
Issue labeler stops working due to GHA upgrade to newer Node: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

### Description 
After migrating to Node16 from Node12, some old workflows are failing.
I've updated the plugin to the latest version: https://github.com/github/issue-labeler

Fixes # - N/A

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
N/A
<!-- _List users with `@` to send notifications -->

### Other information
N/A