### PR TITLE
Initialize uninitialized scalar field currTime

### DIFF
--- a/src/tbbmalloc/large_objects.cpp
+++ b/src/tbbmalloc/large_objects.cpp
@@ -134,7 +134,7 @@ class CacheBinFunctor {
 public:
     CacheBinFunctor(typename LargeObjectCacheImpl<Props>::CacheBin *bin, ExtMemoryPool *extMemPool,
                     typename LargeObjectCacheImpl<Props>::BinBitMask *bitMask, int idx) :
-        bin(bin), extMemPool(extMemPool), bitMask(bitMask), idx(idx), toRelease(nullptr), needCleanup(false) {}
+        bin(bin), extMemPool(extMemPool), bitMask(bitMask), idx(idx), toRelease(nullptr), needCleanup(false), currTime(0) {}
     void operator()(CacheBinOperation* opList);
 
     bool isCleanupNeeded() const { return needCleanup; }


### PR DESCRIPTION
### Description 
Initialize uninitialized scalar field currTime.
It fixes the Coverity issue #449478.

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@lplewa @KFilipek 
