### PR TITLE
Extend migration example

### DIFF
--- a/examples/migration/recursive_fibonacci/fibonacci.cpp
+++ b/examples/migration/recursive_fibonacci/fibonacci.cpp
@@ -53,7 +53,7 @@ int main(int argc, char* argv[]) {
     std::cout << "Fibonacci two tasks impl N = " << res.first << " Avg time = " << res.second << " ms"
               << std::endl;
 
-    auto res = measure(fibonacci_single_task, numbers, ntrial);
+    res = measure(fibonacci_single_task, numbers, ntrial);
     std::cout << "Fibonacci single task impl N = " << res.first << " Avg time = " << res.second << " ms"
               << std::endl;
 }

--- a/examples/migration/recursive_fibonacci/fibonacci.cpp
+++ b/examples/migration/recursive_fibonacci/fibonacci.cpp
@@ -14,67 +14,14 @@
     limitations under the License.
 */
 
-#include "task_emulation_layer.h"
+#include "fibonacci_single_task.h"
+#include "fibonacci_two_tasks.h"
 
 #include <iostream>
 #include <numeric>
 #include <utility>
 
 int cutoff;
-
-long serial_fib(int n) {
-    return n < 2 ? n : serial_fib(n - 1) + serial_fib(n - 2);
-}
-
-struct fib_continuation : task_emulation::base_task {
-    fib_continuation(int& s) : sum(s) {}
-
-    void execute() override {
-        sum = x + y;
-    }
-
-    int x{ 0 }, y{ 0 };
-    int& sum;
-};
-
-struct fib_computation : task_emulation::base_task {
-    fib_computation(int n, int* x) : n(n), x(x) {}
-
-    void execute() override {
-        if (n < cutoff) {
-            *x = serial_fib(n);
-        }
-        else {
-            // Continuation passing
-            auto& c = *this->create_continuation<fib_continuation>(/* children_counter = */ 2, *x);
-            task_emulation::run_task(c.create_child_of_continuation<fib_computation>(n - 1, &c.x));
-
-            // Recycling
-            this->recycle_as_child_of_continuation(c);
-            n = n - 2;
-            x = &c.y;
-
-            // Bypass is not supported by task_emulation and next_task executed directly.
-            // However, the old-TBB bypass behavior can be achieved with
-            // `return task_group::defer()` (check Migration Guide).
-            // Consider submit another task if recursion call is not acceptable
-            // i.e. instead of Recycling + Direct Body call
-            // submit task_emulation::run_task(c.create_child_of_continuation<fib_computation>(n - 2, &c.y));
-            this->operator()();
-        }
-    }
-
-    int n;
-    int* x;
-};
-
-int fibonacci(int n) {
-    int sum{};
-    tbb::task_group tg;
-    tg.run_and_wait(
-        task_emulation::create_root_task<fib_computation>(/* for root task = */ tg, n, &sum));
-    return sum;
-}
 
 template <typename F>
 std::pair</* result */ unsigned long, /* time */ unsigned long> measure(F&& f,
@@ -102,7 +49,11 @@ int main(int argc, char* argv[]) {
     cutoff = argc > 2 ? strtol(argv[2], nullptr, 0) : 16;
     unsigned long ntrial = argc > 3 ? (unsigned long)strtoul(argv[3], nullptr, 0) : 20;
 
-    auto res = measure(fibonacci, numbers, ntrial);
-    std::cout << "Fibonacci N = " << res.first << " Avg time = " << res.second << " ms"
+    auto res = measure(fibonacci_two_tasks, numbers, ntrial);
+    std::cout << "Fibonacci two tasks impl N = " << res.first << " Avg time = " << res.second << " ms"
+              << std::endl;
+
+    auto res = measure(fibonacci_single_task, numbers, ntrial);
+    std::cout << "Fibonacci single task impl N = " << res.first << " Avg time = " << res.second << " ms"
               << std::endl;
 }

--- a/examples/migration/recursive_fibonacci/fibonacci.cpp
+++ b/examples/migration/recursive_fibonacci/fibonacci.cpp
@@ -50,10 +50,10 @@ int main(int argc, char* argv[]) {
     unsigned long ntrial = argc > 3 ? (unsigned long)strtoul(argv[3], nullptr, 0) : 20;
 
     auto res = measure(fibonacci_two_tasks, numbers, ntrial);
-    std::cout << "Fibonacci two tasks impl N = " << res.first << " Avg time = " << res.second << " ms"
-              << std::endl;
+    std::cout << "Fibonacci two tasks impl N = " << res.first << " Avg time = " << res.second
+              << " ms" << std::endl;
 
     res = measure(fibonacci_single_task, numbers, ntrial);
-    std::cout << "Fibonacci single task impl N = " << res.first << " Avg time = " << res.second << " ms"
-              << std::endl;
+    std::cout << "Fibonacci single task impl N = " << res.first << " Avg time = " << res.second
+              << " ms" << std::endl;
 }

--- a/examples/migration/recursive_fibonacci/fibonacci_single_task.h
+++ b/examples/migration/recursive_fibonacci/fibonacci_single_task.h
@@ -56,19 +56,19 @@ struct single_fib_task : task_emulation::base_task {
             *x = serial_fib_1(n);
         }
         else {
-            auto bypass = this->allocate_child_of_continuation_safe<single_fib_task>(n - 2, &x_r);
-            task_emulation::run_task(this->allocate_child_of_continuation_safe<single_fib_task>(n - 1, &x_l));
+            auto bypass = this->allocate_child_and_increment<single_fib_task>(n - 2, &x_r);
+            task_emulation::run_task(this->allocate_child_and_increment<single_fib_task>(n - 1, &x_l));
 
             // Recycling
             this->s = state::sum;
-            this->recycle_as_continuation();
+            this->recycle_as_predecessor();
 
             // Bypass is not supported by task_emulation and next_task executed directly.
             // However, the old-TBB bypass behavior can be achieved with
             // `return task_group::defer()` (check Migration Guide).
             // Consider submit another task if recursion call is not acceptable
-            // i.e. instead of Recycling + Direct Body call
-            // submit task_emulation::run_task(c.create_child_of_continuation<fib_computation>(n - 2, &c.y));
+            // i.e. instead of Direct Body call
+            // submit task_emulation::run_task(this->allocate_child_and_increment<single_fib_task>(n - 2, &x_r));
             bypass->operator()();
         }
     }

--- a/examples/migration/recursive_fibonacci/fibonacci_single_task.h
+++ b/examples/migration/recursive_fibonacci/fibonacci_single_task.h
@@ -56,8 +56,8 @@ struct single_fib_task : task_emulation::base_task {
             *x = serial_fib_1(n);
         }
         else {
-            task_emulation::run_task(this->create_child_of_continuation_safe<single_fib_task>(n - 1, &x_l));
-            auto bypass = this->create_child_of_continuation_safe<single_fib_task>(n - 2, &x_r);
+            auto bypass = this->allocate_child_of_continuation_safe<single_fib_task>(n - 2, &x_r);
+            task_emulation::run_task(this->allocate_child_of_continuation_safe<single_fib_task>(n - 1, &x_l));
 
             // Recycling
             this->s = state::sum;
@@ -69,7 +69,7 @@ struct single_fib_task : task_emulation::base_task {
             // Consider submit another task if recursion call is not acceptable
             // i.e. instead of Recycling + Direct Body call
             // submit task_emulation::run_task(c.create_child_of_continuation<fib_computation>(n - 2, &c.y));
-            bypass.operator()();
+            bypass->operator()();
         }
     }
 
@@ -84,8 +84,7 @@ struct single_fib_task : task_emulation::base_task {
 int fibonacci_single_task(int n) {
     int sum{};
     tbb::task_group tg;
-    tg.run_and_wait(
-        task_emulation::create_root_task<single_fib_task>(/* for root task = */ tg, n, &sum));
+    task_emulation::run_and_wait(tg, task_emulation::allocate_root_task<single_fib_task>(/* for root task = */ tg, n, &sum));
     return sum;
 }
 

--- a/examples/migration/recursive_fibonacci/fibonacci_single_task.h
+++ b/examples/migration/recursive_fibonacci/fibonacci_single_task.h
@@ -61,7 +61,7 @@ struct single_fib_task : task_emulation::base_task {
 
             // Recycling
             this->s = state::sum;
-            this->recycle_as_predecessor();
+            this->recycle_as_continuation();
 
             // Bypass is not supported by task_emulation and next_task executed directly.
             // However, the old-TBB bypass behavior can be achieved with

--- a/examples/migration/recursive_fibonacci/fibonacci_single_task.h
+++ b/examples/migration/recursive_fibonacci/fibonacci_single_task.h
@@ -1,0 +1,92 @@
+/*
+    Copyright (c) 2023 Intel Corporation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef SINGLE_TASK_HEADER
+#define SINGLE_TASK_HEADER
+
+#include "task_emulation_layer.h"
+
+#include <iostream>
+#include <numeric>
+#include <utility>
+
+extern int cutoff;
+
+long serial_fib_1(int n) {
+    return n < 2 ? n : serial_fib_1(n - 1) + serial_fib_1(n - 2);
+}
+
+struct single_fib_task : task_emulation::base_task {
+    enum class state {
+        compute,
+        sum
+    };
+
+    single_fib_task(int n, int* x) : n(n), x(x), s(state::compute)
+    {}
+
+    void execute() override {
+        switch (s) {
+            case state::compute : {
+                compute_impl();
+                break;
+            }
+            case state::sum : {
+                *x = x_l + x_r;
+                break;
+            }
+        }
+    }
+
+    void compute_impl() {
+        if (n < cutoff) {
+            *x = serial_fib_1(n);
+        }
+        else {
+            task_emulation::run_task(this->create_child_of_continuation_safe<single_fib_task>(n - 1, &x_l));
+            auto bypass = this->create_child_of_continuation_safe<single_fib_task>(n - 2, &x_r);
+
+            // Recycling
+            this->s = state::sum;
+            this->recycle_as_continuation();
+
+            // Bypass is not supported by task_emulation and next_task executed directly.
+            // However, the old-TBB bypass behavior can be achieved with
+            // `return task_group::defer()` (check Migration Guide).
+            // Consider submit another task if recursion call is not acceptable
+            // i.e. instead of Recycling + Direct Body call
+            // submit task_emulation::run_task(c.create_child_of_continuation<fib_computation>(n - 2, &c.y));
+            bypass.operator()();
+        }
+    }
+
+
+    int n;
+    int* x;
+    state s;
+
+    int x_l{ 0 }, x_r{ 0 };
+};
+
+int fibonacci_single_task(int n) {
+    int sum{};
+    tbb::task_group tg;
+    tg.run_and_wait(
+        task_emulation::create_root_task<single_fib_task>(/* for root task = */ tg, n, &sum));
+    return sum;
+}
+
+#endif // SINGLE_TASK_HEADER

--- a/examples/migration/recursive_fibonacci/fibonacci_two_tasks.h
+++ b/examples/migration/recursive_fibonacci/fibonacci_two_tasks.h
@@ -50,11 +50,11 @@ struct fib_computation : task_emulation::base_task {
         }
         else {
             // Continuation passing
-            auto& c = *this->allocate_predecessor<fib_continuation>(/* children_counter = */ 2, *x);
+            auto& c = *this->allocate_continuation<fib_continuation>(/* children_counter = */ 2, *x);
             task_emulation::run_task(c.create_child<fib_computation>(n - 1, &c.x));
 
             // Recycling
-            this->recycle_as_child_of_predecessor(c);
+            this->recycle_as_child_of(c);
             n = n - 2;
             x = &c.y;
 

--- a/examples/migration/recursive_fibonacci/fibonacci_two_tasks.h
+++ b/examples/migration/recursive_fibonacci/fibonacci_two_tasks.h
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <numeric>
 #include <utility>
+#include <functional>
 
 extern int cutoff;
 
@@ -49,7 +50,7 @@ struct fib_computation : task_emulation::base_task {
         }
         else {
             // Continuation passing
-            auto& c = *this->create_continuation<fib_continuation>(/* children_counter = */ 2, *x);
+            auto& c = *this->allocate_continuation<fib_continuation>(/* children_counter = */ 2, *x);
             task_emulation::run_task(c.create_child_of_continuation<fib_computation>(n - 1, &c.x));
 
             // Recycling

--- a/examples/migration/recursive_fibonacci/fibonacci_two_tasks.h
+++ b/examples/migration/recursive_fibonacci/fibonacci_two_tasks.h
@@ -50,11 +50,11 @@ struct fib_computation : task_emulation::base_task {
         }
         else {
             // Continuation passing
-            auto& c = *this->allocate_continuation<fib_continuation>(/* children_counter = */ 2, *x);
-            task_emulation::run_task(c.create_child_of_continuation<fib_computation>(n - 1, &c.x));
+            auto& c = *this->allocate_predecessor<fib_continuation>(/* children_counter = */ 2, *x);
+            task_emulation::run_task(c.create_child<fib_computation>(n - 1, &c.x));
 
             // Recycling
-            this->recycle_as_child_of_continuation(c);
+            this->recycle_as_child_of_predecessor(c);
             n = n - 2;
             x = &c.y;
 
@@ -63,7 +63,7 @@ struct fib_computation : task_emulation::base_task {
             // `return task_group::defer()` (check Migration Guide).
             // Consider submit another task if recursion call is not acceptable
             // i.e. instead of Recycling + Direct Body call
-            // submit task_emulation::run_task(c.create_child_of_continuation<fib_computation>(n - 2, &c.y));
+            // submit task_emulation::run_task(c.create_child<fib_computation>(n - 2, &c.y));
             this->operator()();
         }
     }

--- a/examples/migration/recursive_fibonacci/fibonacci_two_tasks.h
+++ b/examples/migration/recursive_fibonacci/fibonacci_two_tasks.h
@@ -1,0 +1,82 @@
+/*
+    Copyright (c) 2023 Intel Corporation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef TWO_TASKS_HEADER
+#define TWO_TASKS_HEADER
+
+#include "task_emulation_layer.h"
+
+#include <iostream>
+#include <numeric>
+#include <utility>
+
+extern int cutoff;
+
+long serial_fib(int n) {
+    return n < 2 ? n : serial_fib(n - 1) + serial_fib(n - 2);
+}
+
+struct fib_continuation : task_emulation::base_task {
+    fib_continuation(int& s) : sum(s) {}
+
+    void execute() override {
+        sum = x + y;
+    }
+
+    int x{ 0 }, y{ 0 };
+    int& sum;
+};
+
+struct fib_computation : task_emulation::base_task {
+    fib_computation(int n, int* x) : n(n), x(x) {}
+
+    void execute() override {
+        if (n < cutoff) {
+            *x = serial_fib(n);
+        }
+        else {
+            // Continuation passing
+            auto& c = *this->create_continuation<fib_continuation>(/* children_counter = */ 2, *x);
+            task_emulation::run_task(c.create_child_of_continuation<fib_computation>(n - 1, &c.x));
+
+            // Recycling
+            this->recycle_as_child_of_continuation(c);
+            n = n - 2;
+            x = &c.y;
+
+            // Bypass is not supported by task_emulation and next_task executed directly.
+            // However, the old-TBB bypass behavior can be achieved with
+            // `return task_group::defer()` (check Migration Guide).
+            // Consider submit another task if recursion call is not acceptable
+            // i.e. instead of Recycling + Direct Body call
+            // submit task_emulation::run_task(c.create_child_of_continuation<fib_computation>(n - 2, &c.y));
+            this->operator()();
+        }
+    }
+
+    int n;
+    int* x;
+};
+
+int fibonacci_two_tasks(int n) {
+    int sum{};
+    tbb::task_group tg;
+    tg.run_and_wait(
+        task_emulation::create_root_task<fib_computation>(/* for root task = */ tg, n, &sum));
+    return sum;
+}
+
+#endif // TWO_TASKS_HEADER

--- a/examples/migration/recursive_fibonacci/task_emulation_layer.h
+++ b/examples/migration/recursive_fibonacci/task_emulation_layer.h
@@ -70,7 +70,7 @@ public:
     virtual void execute() = 0;
 
     template <typename C, typename... Args>
-    C* allocate_predecessor(std::uint64_t ref, Args&&... args) {
+    C* allocate_continuation(std::uint64_t ref, Args&&... args) {
         C* continuation = new C{std::forward<Args>(args)...};
         continuation->m_type = task_type::continuation;
         continuation->reset_parent(reset_parent());
@@ -101,11 +101,11 @@ public:
     }
 
     template <typename C>
-    void recycle_as_child_of_predecessor(C& c) {
+    void recycle_as_child_of(C& c) {
         reset_parent(&c);
     }
 
-    void recycle_as_predecessor() {
+    void recycle_as_continuation() {
         m_type = task_type::continuation;
     }
 

--- a/examples/migration/recursive_fibonacci/task_emulation_layer.h
+++ b/examples/migration/recursive_fibonacci/task_emulation_layer.h
@@ -70,7 +70,7 @@ public:
     virtual void execute() = 0;
 
     template <typename C, typename... Args>
-    C* allocate_continuation(std::uint64_t ref, Args&&... args) {
+    C* allocate_predecessor(std::uint64_t ref, Args&&... args) {
         C* continuation = new C{std::forward<Args>(args)...};
         continuation->m_type = task_type::continuation;
         continuation->reset_parent(reset_parent());
@@ -79,33 +79,33 @@ public:
     }
 
     template <typename F, typename... Args>
-    F create_child_of_continuation(Args&&... args) {
-        return create_child_of_continuation_impl<F>(std::forward<Args>(args)...);
+    F create_child(Args&&... args) {
+        return create_child_impl<F>(std::forward<Args>(args)...);
     }
 
     template <typename F, typename... Args>
-    F create_child_of_continuation_safe(Args&&... args) {
+    F create_child_and_increment(Args&&... args) {
         add_reference();
-        return create_child_of_continuation_impl<F>(std::forward<Args>(args)...);
+        return create_child_impl<F>(std::forward<Args>(args)...);
     }
 
     template <typename F, typename... Args>
-    F* allocate_child_of_continuation(Args&&... args) {
-        return allocate_child_of_continuation_impl<F>(std::forward<Args>(args)...);
+    F* allocate_child(Args&&... args) {
+        return allocate_child_impl<F>(std::forward<Args>(args)...);
     }
 
     template <typename F, typename... Args>
-    F* allocate_child_of_continuation_safe(Args&&... args) {
+    F* allocate_child_and_increment(Args&&... args) {
         add_reference();
-        return allocate_child_of_continuation_impl<F>(std::forward<Args>(args)...);
+        return allocate_child_impl<F>(std::forward<Args>(args)...);
     }
 
     template <typename C>
-    void recycle_as_child_of_continuation(C& c) {
+    void recycle_as_child_of_predecessor(C& c) {
         reset_parent(&c);
     }
 
-    void recycle_as_continuation() {
+    void recycle_as_predecessor() {
         m_type = task_type::continuation;
     }
 
@@ -134,7 +134,7 @@ private:
     friend F* allocate_root_task(tbb::task_group& tg, Args&&... args);
 
     template <typename F, typename... Args>
-    F create_child_of_continuation_impl(Args&&... args) {
+    F create_child_impl(Args&&... args) {
         F obj{std::forward<Args>(args)...};
         obj.m_type = task_type::created;
         obj.reset_parent(this);
@@ -142,7 +142,7 @@ private:
     }
 
     template <typename F, typename... Args>
-    F* allocate_child_of_continuation_impl(Args&&... args) {
+    F* allocate_child_impl(Args&&... args) {
         F* obj = new F{std::forward<Args>(args)...};
         obj->m_type = task_type::allocated;
         obj->reset_parent(this);

--- a/examples/migration/recursive_fibonacci/task_emulation_layer.h
+++ b/examples/migration/recursive_fibonacci/task_emulation_layer.h
@@ -56,36 +56,48 @@ public:
         base_task* parent_snapshot = m_parent;
         const_cast<base_task*>(this)->execute();
         if (m_parent && parent_snapshot == m_parent && m_child_counter == 0) {
-            m_parent->release();
+            if (m_parent->remove_reference() == 0) {
+                m_parent->operator()();
+                delete m_parent;
+            }
+        }
+
+        if (m_child_counter == 0 && m_type == task_type::allocated) {
+            delete this;
         }
     }
 
     virtual void execute() = 0;
 
     template <typename C, typename... Args>
-    C* create_continuation(std::uint64_t ref, Args&&... args) {
+    C* allocate_continuation(std::uint64_t ref, Args&&... args) {
         C* continuation = new C{std::forward<Args>(args)...};
+        continuation->m_type = task_type::continuation;
         continuation->reset_parent(reset_parent());
         continuation->m_child_counter = ref;
         return continuation;
     }
 
-    // Will not increment parent reference
     template <typename F, typename... Args>
     F create_child_of_continuation(Args&&... args) {
-        F obj{std::forward<Args>(args)...};
-        obj.reset_parent(this);
-        return obj;
+        return create_child_of_continuation_impl<F>(std::forward<Args>(args)...);
     }
 
-    // Will increment parent reference
     template <typename F, typename... Args>
     F create_child_of_continuation_safe(Args&&... args) {
-        this->reserve();
+        add_reference();
+        return create_child_of_continuation_impl<F>(std::forward<Args>(args)...);
+    }
 
-        F obj{std::forward<Args>(args)...};
-        obj.reset_parent(this);
-        return obj;
+    template <typename F, typename... Args>
+    F* allocate_child_of_continuation(Args&&... args) {
+        return allocate_child_of_continuation_impl<F>(std::forward<Args>(args)...);
+    }
+
+    template <typename F, typename... Args>
+    F* allocate_child_of_continuation_safe(Args&&... args) {
+        add_reference();
+        return allocate_child_of_continuation_impl<F>(std::forward<Args>(args)...);
     }
 
     template <typename C>
@@ -93,24 +105,48 @@ public:
         reset_parent(&c);
     }
 
-    void recycle_as_continuation() {}
+    void recycle_as_continuation() {
+        m_type = task_type::continuation;
+    }
 
-protected:
-    void reserve() {
+    void add_reference() {
         ++m_child_counter;
     }
+
+    std::uint64_t remove_reference() {
+        return --m_child_counter;
+    }
+
+protected:
+    enum class task_type {
+        created,
+        allocated,
+        continuation
+    };
+
+    task_type m_type;
 
 private:
     template <typename F, typename... Args>
     friend F create_root_task(tbb::task_group& tg, Args&&... args);
 
+    template <typename F, typename... Args>
+    friend F* allocate_root_task(tbb::task_group& tg, Args&&... args);
 
-    void release() {
-        if (--m_child_counter == 0) {
-            operator()();
-            // Free will be called only for continuations
-            delete this;
-        }
+    template <typename F, typename... Args>
+    F create_child_of_continuation_impl(Args&&... args) {
+        F obj{std::forward<Args>(args)...};
+        obj.m_type = task_type::created;
+        obj.reset_parent(this);
+        return obj;
+    }
+
+    template <typename F, typename... Args>
+    F* allocate_child_of_continuation_impl(Args&&... args) {
+        F* obj = new F{std::forward<Args>(args)...};
+        obj->m_type = task_type::allocated;
+        obj->reset_parent(this);
+        return obj;
     }
 
     base_task* reset_parent(base_task* ptr = nullptr) {
@@ -126,7 +162,8 @@ private:
 class root_task : public base_task {
 public:
     root_task(tbb::task_group& tg) : m_tg(tg), m_callback(m_tg.defer([] { /* Create empty callback to preserve reference for wait. */})) {
-        reserve();
+        add_reference();
+        m_type = base_task::task_type::continuation;
     }
 
 private:
@@ -141,13 +178,32 @@ private:
 template <typename F, typename... Args>
 F create_root_task(tbb::task_group& tg, Args&&... args) {
     F obj{std::forward<Args>(args)...};
+    obj.m_type = base_task::task_type::created;
     obj.reset_parent(new root_task{tg});
+    return obj;
+}
+
+template <typename F, typename... Args>
+F* allocate_root_task(tbb::task_group& tg, Args&&... args) {
+    F* obj = new F{std::forward<Args>(args)...};
+    obj->m_type = base_task::task_type::allocated;
+    obj->reset_parent(new root_task{tg});
     return obj;
 }
 
 template <typename F>
 void run_task(F&& f) {
     tg_pool[tbb::this_task_arena::current_thread_index()].run(std::forward<F>(f));
+}
+
+template <typename F>
+void run_task(F* f) {
+    tg_pool[tbb::this_task_arena::current_thread_index()].run(std::ref(*f));
+}
+
+template <typename F>
+void run_and_wait(tbb::task_group& tg, F* f) {
+   tg.run_and_wait(std::ref(*f));
 }
 } // namespace task_emulation
 


### PR DESCRIPTION
### Description 
Extend migration example to support `recycle_as_continuation` and dynamic children creation. Add ability to allocate "compute" to prolong their life time as a continuation.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
