### PR TITLE
Fix thread request on arena::update_concurrency

### DIFF
--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -410,8 +410,11 @@ void arena::set_allotment(unsigned allotment) {
 }
 
 int arena::update_concurrency(unsigned allotment) {
-    set_allotment(allotment);
-    return allotment - static_cast<int>(my_num_workers_allotted.load(std::memory_order_relaxed));
+    int delta = allotment - my_num_workers_allotted.load(std::memory_order_relaxed);
+    if (delta != 0) {
+        my_num_workers_allotted.store(allotment, std::memory_order_relaxed);
+    }
+    return delta;
 }
 
 std::pair<int, int> arena::update_request(int mandatory_delta, int workers_delta) {


### PR DESCRIPTION
### Description 
Fix logic on `arena::update_concurrency`. Read previous allotment before update.


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
