### PR TITLE
Add const overload for tbb::combinable combine_each

### DIFF
--- a/include/oneapi/tbb/combinable.h
+++ b/include/oneapi/tbb/combinable.h
@@ -51,9 +51,13 @@ public:
     template <typename CombineFunc>
     T combine(CombineFunc f_combine) { return my_ets.combine(f_combine); }
 
-    // combine_func_t has signature void(T) or void(const T&)
+    // combine_func_t has signature void(T)
     template <typename CombineFunc>
     void combine_each(CombineFunc f_combine) { my_ets.combine_each(f_combine); }
+
+    // combine_func_t has signature void(const T&)
+    template <typename CombineFunc>
+    void combine_each(CombineFunc f_combine) const { my_ets.combine_each(f_combine); }
 };
 
 } // namespace d1

--- a/include/oneapi/tbb/enumerable_thread_specific.h
+++ b/include/oneapi/tbb/enumerable_thread_specific.h
@@ -1027,9 +1027,17 @@ public:
         return my_result;
     }
 
-    // combine_func_t takes T by value or by [const] reference, and returns nothing
+    // combine_func_t takes T by value and returns nothing
     template <typename CombineFunc>
     void combine_each(CombineFunc f_combine) {
+        for(iterator ci = begin(); ci != end(); ++ci) {
+            f_combine( *ci );
+        }
+    }
+
+    // combine_func_t takes T by [const] reference and returns nothing
+    template <typename CombineFunc>
+    void combine_each(CombineFunc f_combine) const {
         for(iterator ci = begin(); ci != end(); ++ci) {
             f_combine( *ci );
         }


### PR DESCRIPTION
### Description 
Add a const overload for combine_each in combinable.h and enumerable_thread_specific.h as the ets object would also need a const overload. This is my first pull request to oneTBB and decided to work on issue #957  as it is a small change.


Fixes #957 

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [x] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [x] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
