### PR TITLE
Fix inline literals in Edges.rst.

### DIFF
--- a/doc/main/tbb_userguide/Edges.rst
+++ b/doc/main/tbb_userguide/Edges.rst
@@ -37,7 +37,7 @@ it and then connect that to the first node with an edge.
        g.wait_for_all();
 
 
-Now there are two ``function_node`` ``s``, ``n`` and ``m``. The call to ``make_edge`` creates
+Now there are two ``function_node`` s, ``n`` and ``m``. The call to ``make_edge`` creates
 an edge from ``n`` to ``m``. The node ``n`` is created with unlimited concurrency,
 while ``m`` has a concurrency limit of 1. The invocations of ``n`` can all
 proceed in parallel, while the invocations of ``m`` will be serialized.

--- a/doc/main/tbb_userguide/Edges.rst
+++ b/doc/main/tbb_userguide/Edges.rst
@@ -38,7 +38,7 @@ it and then connect that to the first node with an edge.
 
 
 Now there are two ``function_node`` ``s``, ``n`` and ``m``. The call to ``make_edge`` creates
-an edge from ``n`` to ``m``. The node n is created with unlimited concurrency,
+an edge from ``n`` to ``m``. The node ``n`` is created with unlimited concurrency,
 while ``m`` has a concurrency limit of 1. The invocations of ``n`` can all
 proceed in parallel, while the invocations of ``m`` will be serialized.
 Because there is an edge from ``n`` to ``m``, each value ``v``, returned by ``n``, will

--- a/doc/main/tbb_userguide/Edges.rst
+++ b/doc/main/tbb_userguide/Edges.rst
@@ -37,7 +37,7 @@ it and then connect that to the first node with an edge.
        g.wait_for_all();
 
 
-Now there are two ``function_node``s, ``n`` and ``m``. The call to ``make_edge`` creates
+Now there are two ``function_node`` ``s``, ``n`` and ``m``. The call to ``make_edge`` creates
 an edge from ``n`` to ``m``. The node n is created with unlimited concurrency,
 while ``m`` has a concurrency limit of 1. The invocations of ``n`` can all
 proceed in parallel, while the invocations of ``m`` will be serialized.


### PR DESCRIPTION
### Description 
I fixed PR#1177.

- [ ] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
