### PR TITLE
Fix test_task crash/hang on RT Linux systems

### DIFF
--- a/test/common/utils_concurrency_limit.h
+++ b/test/common/utils_concurrency_limit.h
@@ -287,28 +287,6 @@ bool can_change_thread_priority() {
     return false;
 }
 
-void increase_thread_priority() {
-#if __unix__
-    pthread_t this_thread = pthread_self();
-    sched_param params;
-    params.sched_priority = sched_get_priority_max(SCHED_FIFO);
-    ASSERT(params.sched_priority != -1, nullptr);
-    int err = pthread_setschedparam(this_thread, SCHED_FIFO, &params);
-    ASSERT(err == 0, "Can not change thread priority.");
-#endif
-}
-
-void decrease_thread_priority() {
-#if __unix__
-    pthread_t this_thread = pthread_self();
-    sched_param params;
-    params.sched_priority = sched_get_priority_min(SCHED_FIFO);
-    ASSERT(params.sched_priority != -1, nullptr);
-    int err = pthread_setschedparam(this_thread, SCHED_FIFO, &params);
-    ASSERT(err == 0, "Can not change thread priority.");
-#endif
-}
-
 #if __unix__
 class increased_priority_guard {
 public:
@@ -331,6 +309,15 @@ private:
         int err = pthread_getschedparam(this_thread, &policy, &params);
         ASSERT(err == 0, nullptr);
         return std::make_pair(policy, params);
+    }
+
+    void increase_thread_priority() {
+        pthread_t this_thread = pthread_self();
+        sched_param params;
+        params.sched_priority = sched_get_priority_max(SCHED_FIFO);
+        ASSERT(params.sched_priority != -1, nullptr);
+        int err = pthread_setschedparam(this_thread, SCHED_FIFO, &params);
+        ASSERT(err == 0, "Can not change thread priority.");
     }
 
     std::pair<int, sched_param> m_backup;

--- a/test/common/utils_concurrency_limit.h
+++ b/test/common/utils_concurrency_limit.h
@@ -327,7 +327,7 @@ private:
     std::pair<int, sched_param> get_current_schedparam() {
         pthread_t this_thread = pthread_self();
         sched_param params;
-        int policy;
+        int policy = 0;
         int err = pthread_getschedparam(this_thread, &policy, &params);
         ASSERT(err == 0, nullptr);
         return std::make_pair(policy, params);

--- a/test/tbb/test_task.cpp
+++ b/test/tbb/test_task.cpp
@@ -771,7 +771,7 @@ TEST_CASE("Test with priority inversion") {
 
     auto high_priority_thread_func = [&] {
         // Increase external threads priority
-        utils::increase_thread_priority();
+        utils::increased_priority_guard guard{};
         // pin external threads
         test_arena.execute([]{});
         while (task_counter++ < critical_task_counter) {
@@ -796,7 +796,7 @@ TEST_CASE("Test with priority inversion") {
         high_priority_threads.emplace_back(high_priority_thread_func);
     }
 
-    utils::increase_thread_priority();
+    utils::increased_priority_guard guard{};
     while (task_counter++ < critical_task_counter) {
         submit(critical_task, test_arena, test_context, true);
         std::this_thread::sleep_for(std::chrono::milliseconds(1));

--- a/test/tbb/test_task.cpp
+++ b/test/tbb/test_task.cpp
@@ -772,6 +772,7 @@ TEST_CASE("Test with priority inversion") {
     auto high_priority_thread_func = [&] {
         // Increase external threads priority
         utils::increased_priority_guard guard{};
+        utils::suppress_unused_warning(guard);
         // pin external threads
         test_arena.execute([]{});
         while (task_counter++ < critical_task_counter) {
@@ -797,6 +798,7 @@ TEST_CASE("Test with priority inversion") {
     }
 
     utils::increased_priority_guard guard{};
+    utils::suppress_unused_warning(guard);
     while (task_counter++ < critical_task_counter) {
         submit(critical_task, test_arena, test_context, true);
         std::this_thread::sleep_for(std::chrono::milliseconds(1));


### PR DESCRIPTION
### Description 
"Test priority inversion" test case manually increases threads' priority (including main thread) to test priority inversion problem but never restore it.  That could lead to busy-waiting inside oneTBB on RT Linux kernels which is not expected. This patch restores previous priority after the test case completes.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
