### PR TITLE
Allow pkg-config search for hwloc for cross-compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ cmake_minimum_required(VERSION 3.1)
 
 # Enable CMake policies
 
+if (POLICY CMP0068)
+    # RPATH settings do not affect install_name on macOS since CMake 3.9
+    cmake_policy(SET CMP0068 NEW)
+endif()
+
 if (POLICY CMP0091)
     # The NEW behavior for this policy is to not place MSVC runtime library flags in the default
     # CMAKE_<LANG>_FLAGS_<CONFIG> cache entries and use CMAKE_MSVC_RUNTIME_LIBRARY abstraction instead.
@@ -104,7 +109,7 @@ option(TBBMALLOC_BUILD "Enable tbbmalloc build" ON)
 cmake_dependent_option(TBBMALLOC_PROXY_BUILD "Enable tbbmalloc_proxy build" ON "TBBMALLOC_BUILD" OFF)
 option(TBB_CPF "Enable preview features of the library" OFF)
 option(TBB_FIND_PACKAGE "Enable search for external oneTBB using find_package instead of build from sources" OFF)
-option(TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH "Disable HWLOC automatic search by pkg-config tool" OFF)
+option(TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH "Disable HWLOC automatic search by pkg-config tool" ${CMAKE_CROSSCOMPILING})
 option(TBB_ENABLE_IPO "Enable Interprocedural Optimization (IPO) during the compilation" ON)
 option(TBB_FUZZ_TESTING "Enable fuzz testing" OFF)
 

--- a/cmake/hwloc_detection.cmake
+++ b/cmake/hwloc_detection.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,8 +46,6 @@ endforeach()
 unset(HWLOC_TARGET_NAME)
 
 if (NOT HWLOC_TARGET_EXPLICITLY_DEFINED AND
-    # No hwloc auto detection for cross compilation
-    NOT CMAKE_CROSSCOMPILING AND
     NOT TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH
 )
     find_package(PkgConfig QUIET)

--- a/src/tbbbind/CMakeLists.txt
+++ b/src/tbbbind/CMakeLists.txt
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (DEFINED CMAKE_SKIP_BUILD_RPATH)
-    set(CMAKE_SKIP_BUILD_RPATH_OLD_VALUE ${CMAKE_SKIP_BUILD_RPATH})
-endif()
 set(CMAKE_SKIP_BUILD_RPATH TRUE)
 
 function(tbbbind_build TBBBIND_NAME REQUIRED_HWLOC_TARGET)
@@ -106,10 +103,3 @@ else()
     tbbbind_build(tbbbind_2_5 HWLOC::hwloc_2_5 )
 endif()
 
-
-if (DEFINED CMAKE_SKIP_BUILD_RPATH_OLD_VALUE)
-    set(CMAKE_SKIP_BUILD_RPATH ${CMAKE_SKIP_BUILD_RPATH_OLD_VALUE})
-    unset(CMAKE_SKIP_BUILD_RPATH_OLD_VALUE)
-else()
-    unset(CMAKE_SKIP_BUILD_RPATH)
-endif()


### PR DESCRIPTION
### Description 
Allows to use pkg-config during cross-compilation, while default behavior is still as is - hwloc is not searched.

This is useful for Conan package manager, which can cross-compile oneTBB with static hwloc. Currently, it's not allowed, because Conan has to pass explicitly `CMAKE_HWLOC_*` variables, which lead to creation of hwloc shared import library, but hwloc is built as static one.

- [X] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_
- [X] improvement - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
@isaevil 
