### PR TITLE
Fix race in single task Fibonacci example

### DIFF
--- a/examples/migration/recursive_fibonacci/CMakeLists.txt
+++ b/examples/migration/recursive_fibonacci/CMakeLists.txt
@@ -33,7 +33,7 @@ set(EXECUTABLE "$<TARGET_FILE:recursive_fibonacci>")
 # `N` - specifies the fibonacci number which would be calculated.
 # `C` - cutoff that will be used to stop recursive split.
 # `I` - number of iteration to measure benchmark time.
-set(ARGS 30 16 20)
+set(ARGS 30 16 20 1)
 set(PERF_ARGS 50 5 20)
 
 add_execution_target(run_recursive_fibonacci recursive_fibonacci ${EXECUTABLE} "${ARGS}")

--- a/examples/migration/recursive_fibonacci/README.md
+++ b/examples/migration/recursive_fibonacci/README.md
@@ -20,4 +20,4 @@ recursive_fibonacci N C I T
 * `N` - specifies the fibonacci number which would be calculated.
 * `C` - cutoff that will be used to stop recursive split.
 * `I` - number of iteration to measure benchmark time.
-* `T` - enables extended testing
+* `T` - enables extended testing (recycle task in a loop).

--- a/examples/migration/recursive_fibonacci/README.md
+++ b/examples/migration/recursive_fibonacci/README.md
@@ -9,14 +9,15 @@ cmake --build .
 
 ## Running the sample
 ### Predefined make targets
-* `make run_recursive_fibonacci` - executes the example with predefined parameters.
+* `make run_recursive_fibonacci` - executes the example with predefined parameters (extended testing enabled).
 * `make perf_run_recursive_fibonacci` - executes the example with suggested parameters to measure the oneTBB performance.
 
 ### Application parameters
 Usage:
 ```
-recursive_fibonacci N C I
+recursive_fibonacci N C I T
 ```
 * `N` - specifies the fibonacci number which would be calculated.
 * `C` - cutoff that will be used to stop recursive split.
 * `I` - number of iteration to measure benchmark time.
+* `T` - enables extended testing

--- a/examples/migration/recursive_fibonacci/fibonacci.cpp
+++ b/examples/migration/recursive_fibonacci/fibonacci.cpp
@@ -49,7 +49,7 @@ int main(int argc, char* argv[]) {
     int numbers = argc > 1 ? strtol(argv[1], nullptr, 0) : 50;
     cutoff = argc > 2 ? strtol(argv[2], nullptr, 0) : 16;
     unsigned long ntrial = argc > 3 ? (unsigned long)strtoul(argv[3], nullptr, 0) : 20;
-    tesing_enabled =  argc > 4 ? (bool)strtol(argv[4], nullptr, 0) : false;
+    tesing_enabled = argc > 4 ? (bool)strtol(argv[4], nullptr, 0) : false;
 
     auto res = measure(fibonacci_two_tasks, numbers, ntrial);
     std::cout << "Fibonacci two tasks impl N = " << res.first << " Avg time = " << res.second

--- a/examples/migration/recursive_fibonacci/fibonacci.cpp
+++ b/examples/migration/recursive_fibonacci/fibonacci.cpp
@@ -22,7 +22,7 @@
 #include <utility>
 
 int cutoff;
-bool tesing_enabled;
+bool testing_enabled;
 
 template <typename F>
 std::pair</* result */ unsigned long, /* time */ unsigned long> measure(F&& f,
@@ -49,7 +49,7 @@ int main(int argc, char* argv[]) {
     int numbers = argc > 1 ? strtol(argv[1], nullptr, 0) : 50;
     cutoff = argc > 2 ? strtol(argv[2], nullptr, 0) : 16;
     unsigned long ntrial = argc > 3 ? (unsigned long)strtoul(argv[3], nullptr, 0) : 20;
-    tesing_enabled = argc > 4 ? (bool)strtol(argv[4], nullptr, 0) : false;
+    testing_enabled = argc > 4 ? (bool)strtol(argv[4], nullptr, 0) : false;
 
     auto res = measure(fibonacci_two_tasks, numbers, ntrial);
     std::cout << "Fibonacci two tasks impl N = " << res.first << " Avg time = " << res.second

--- a/examples/migration/recursive_fibonacci/fibonacci.cpp
+++ b/examples/migration/recursive_fibonacci/fibonacci.cpp
@@ -22,6 +22,7 @@
 #include <utility>
 
 int cutoff;
+bool tesing_enabled;
 
 template <typename F>
 std::pair</* result */ unsigned long, /* time */ unsigned long> measure(F&& f,
@@ -48,6 +49,7 @@ int main(int argc, char* argv[]) {
     int numbers = argc > 1 ? strtol(argv[1], nullptr, 0) : 50;
     cutoff = argc > 2 ? strtol(argv[2], nullptr, 0) : 16;
     unsigned long ntrial = argc > 3 ? (unsigned long)strtoul(argv[3], nullptr, 0) : 20;
+    tesing_enabled =  argc > 4 ? (bool)strtol(argv[4], nullptr, 0) : false;
 
     auto res = measure(fibonacci_two_tasks, numbers, ntrial);
     std::cout << "Fibonacci two tasks impl N = " << res.first << " Avg time = " << res.second

--- a/examples/migration/recursive_fibonacci/fibonacci_single_task.h
+++ b/examples/migration/recursive_fibonacci/fibonacci_single_task.h
@@ -24,7 +24,7 @@
 #include <utility>
 
 extern int cutoff;
-extern bool tesing_enabled;
+extern bool testing_enabled;
 
 long serial_fib_1(int n) {
     return n < 2 ? n : serial_fib_1(n - 1) + serial_fib_1(n - 2);
@@ -49,7 +49,7 @@ struct single_fib_task : task_emulation::base_task {
             case state::sum : {
                 *x = x_l + x_r;
 
-                if (tesing_enabled) {
+                if (testing_enabled) {
                     if (n == cutoff && num_recycles > 0) {
                         --num_recycles;
                         bypass = compute_impl();

--- a/examples/migration/recursive_fibonacci/fibonacci_single_task.h
+++ b/examples/migration/recursive_fibonacci/fibonacci_single_task.h
@@ -32,7 +32,8 @@ long serial_fib_1(int n) {
 struct single_fib_task : task_emulation::base_task {
     enum class state {
         compute,
-        sum
+        sum,
+        print_status
     };
 
     single_fib_task(int n, int* x) : n(n), x(x), s(state::compute)
@@ -46,6 +47,16 @@ struct single_fib_task : task_emulation::base_task {
             }
             case state::sum : {
                 *x = x_l + x_r;
+
+                // Recycling
+                this->s = state::print_status;
+                this->recycle_as_continuation();
+                this->operator()();
+
+                break;
+            }
+            case state::print_status: {
+                std::cout << std::to_string(n) + "\n";
                 break;
             }
         }

--- a/examples/migration/recursive_fibonacci/fibonacci_single_task.h
+++ b/examples/migration/recursive_fibonacci/fibonacci_single_task.h
@@ -24,6 +24,7 @@
 #include <utility>
 
 extern int cutoff;
+extern bool tesing_enabled;
 
 long serial_fib_1(int n) {
     return n < 2 ? n : serial_fib_1(n - 1) + serial_fib_1(n - 2);
@@ -32,8 +33,7 @@ long serial_fib_1(int n) {
 struct single_fib_task : task_emulation::base_task {
     enum class state {
         compute,
-        sum,
-        print_status
+        sum
     };
 
     single_fib_task(int n, int* x) : n(n), x(x), s(state::compute)
@@ -48,15 +48,13 @@ struct single_fib_task : task_emulation::base_task {
             case state::sum : {
                 *x = x_l + x_r;
 
-                // Recycling
-                this->s = state::print_status;
-                this->recycle_as_continuation();
-                this->operator()();
+                if (tesing_enabled) {
+                    if (n == cutoff && num_recycles > 0) {
+                        --num_recycles;
+                        compute_impl();
+                    }
+                }
 
-                break;
-            }
-            case state::print_status: {
-                std::cout << std::to_string(n) + "\n";
                 break;
             }
         }
@@ -90,6 +88,7 @@ struct single_fib_task : task_emulation::base_task {
     state s;
 
     int x_l{ 0 }, x_r{ 0 };
+    int num_recycles{5};
 };
 
 int fibonacci_single_task(int n) {

--- a/examples/migration/recursive_fibonacci/fibonacci_single_task.h
+++ b/examples/migration/recursive_fibonacci/fibonacci_single_task.h
@@ -39,10 +39,11 @@ struct single_fib_task : task_emulation::base_task {
     single_fib_task(int n, int* x) : n(n), x(x), s(state::compute)
     {}
 
-    void execute() override {
+    task_emulation::base_task* execute() override {
+        task_emulation::base_task* bypass = nullptr;
         switch (s) {
             case state::compute : {
-                compute_impl();
+                bypass = compute_impl();
                 break;
             }
             case state::sum : {
@@ -51,35 +52,30 @@ struct single_fib_task : task_emulation::base_task {
                 if (tesing_enabled) {
                     if (n == cutoff && num_recycles > 0) {
                         --num_recycles;
-                        compute_impl();
+                        bypass = compute_impl();
                     }
                 }
 
                 break;
             }
         }
+        return bypass;
     }
 
-    void compute_impl() {
+    task_emulation::base_task* compute_impl() {
+        task_emulation::base_task* bypass = nullptr;
         if (n < cutoff) {
             *x = serial_fib_1(n);
         }
         else {
-            auto bypass = this->allocate_child_and_increment<single_fib_task>(n - 2, &x_r);
+            bypass = this->allocate_child_and_increment<single_fib_task>(n - 2, &x_r);
             task_emulation::run_task(this->allocate_child_and_increment<single_fib_task>(n - 1, &x_l));
 
             // Recycling
             this->s = state::sum;
             this->recycle_as_continuation();
-
-            // Bypass is not supported by task_emulation and next_task executed directly.
-            // However, the old-TBB bypass behavior can be achieved with
-            // `return task_group::defer()` (check Migration Guide).
-            // Consider submit another task if recursion call is not acceptable
-            // i.e. instead of Direct Body call
-            // submit task_emulation::run_task(this->allocate_child_and_increment<single_fib_task>(n - 2, &x_r));
-            bypass->operator()();
         }
+        return bypass;
     }
 
 

--- a/examples/migration/recursive_fibonacci/task_emulation_layer.h
+++ b/examples/migration/recursive_fibonacci/task_emulation_layer.h
@@ -53,21 +53,17 @@ public:
     virtual ~base_task() = default;
 
     void operator() () const {
-        base_task* parent_snapshot = m_parent;
         task_type type_snapshot = m_type;
 
         base_task* bypass = const_cast<base_task*>(this)->execute();
 
-        bool is_task_recycled_as_child = parent_snapshot != m_parent;
-        bool is_task_recycled_as_continuation = type_snapshot != m_type;
-
-        if (m_parent && !is_task_recycled_as_child && !is_task_recycled_as_continuation) {
+        if (m_parent && m_type != task_type::recycled) {
             if (m_parent->remove_child_reference() == 0) {
                 m_parent->operator()();
             }
         }
 
-        if (type_snapshot != task_type::stack_based && !is_task_recycled_as_child && !is_task_recycled_as_continuation) {
+        if (m_type == task_type::allocated) {
             delete this;
         }
 

--- a/examples/migration/recursive_fibonacci/task_emulation_layer.h
+++ b/examples/migration/recursive_fibonacci/task_emulation_layer.h
@@ -59,12 +59,9 @@ public:
         const_cast<base_task*>(this)->execute();
 
         if (m_parent && parent_snapshot == m_parent && type_snapshot == m_type) {
-            m_parent->add_self_ref();
             auto child_ref = m_parent->remove_child_reference() & (m_self_ref - 1);
             if (child_ref == 0) {
                 m_parent->operator()();
-            } else if (m_parent->remove_self_ref() == 0) {
-                delete m_parent;
             }
         }
 
@@ -112,6 +109,7 @@ public:
     }
 
     void recycle_as_continuation() {
+        add_self_ref();
         m_type = task_type::continuation;
     }
 


### PR DESCRIPTION
### Description 
There was a possibility that parent task will be deleted before it exit its body. This patch insures the lifetime of parent task and unblocks ability to recycle continuation several times.

This patch was validated with Thread Sanitizer.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
