### PR TITLE
Fix small documentation issues

### DIFF
--- a/doc/main/reference/custom_mutex_chmap.rst
+++ b/doc/main/reference/custom_mutex_chmap.rst
@@ -13,7 +13,7 @@ The customizing mutex type for ``concurrent_hash_map``
 Description
 ***********
 
-oneTBB ``concurrnent_hash_map`` class uses reader-writer mutex
+oneTBB ``concurrent_hash_map`` class uses reader-writer mutex
 to provide thread safety and avoid data races for insert, lookup, and erasure operations. This feature adds an extra template parameter
 for ``concurrent_hash_map`` that allows to customize the type of the reader-writer mutex.
 

--- a/doc/main/tbb_userguide/concurrent_hash_map.rst
+++ b/doc/main/tbb_userguide/concurrent_hash_map.rst
@@ -113,7 +113,7 @@ destruction to end thread lifetime:
 ::
 
 
-           StringTable accessor a;
+           StringTable::accessor a;
            for( string* p=range.begin(); p!=range.end(); ++p ) {
                table.insert( a, *p );
                a->second += 1;


### PR DESCRIPTION
### Description 
I hereby want to fix small documentation issues I encountered while using oneTBB.


- [ ] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

Not done at the moment, I will reword my commit messages soon:)

### Type of change

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown
