### PR TITLE
[TBBConfig] Search libraries only in explicitly pointed locations

### DIFF
--- a/cmake/config_generation.cmake
+++ b/cmake/config_generation.cmake
@@ -92,6 +92,7 @@ set(_tbbbind_bin_version ${tbb_gen_cfg_TBBBIND_BINARY_VERSION})
                 NAMES \${_tbb_component}\${_bin_version}.dll
                 PATHS \${_tbb_root}
                 PATH_SUFFIXES \"redist/\${_tbb_intel_arch}/\${_tbb_subdir}\" \"bin\${_tbb_arch_suffix}/\${_tbb_subdir}\" \"bin\${_tbb_arch_suffix}/\" \"bin\"
+                NO_DEFAULT_PATH
             )
 
             if (EXISTS \"\${_tbb_debug_lib}\")
@@ -99,6 +100,7 @@ set(_tbbbind_bin_version ${tbb_gen_cfg_TBBBIND_BINARY_VERSION})
                     NAMES \${_tbb_component}\${_bin_version}_debug.dll
                     PATHS \${_tbb_root}
                     PATH_SUFFIXES \"redist/\${_tbb_intel_arch}/\${_tbb_subdir}\" \"bin\${_tbb_arch_suffix}/\${_tbb_subdir}\" \"bin\${_tbb_arch_suffix}/\" \"bin\"
+                    NO_DEFAULT_PATH
                 )
             endif()
 ")

--- a/cmake/templates/TBBConfig.cmake.in
+++ b/cmake/templates/TBBConfig.cmake.in
@@ -65,6 +65,7 @@ foreach (_tbb_component ${TBB_FIND_COMPONENTS})
         NAMES @TBB_LIB_PREFIX@${_tbb_component}${_bin_version}.@TBB_LIB_EXT@
         PATHS ${_tbb_root}
         PATH_SUFFIXES "@TBB_LIB_REL_PATH@/${_tbb_intel_arch}/${_tbb_subdir}" "@TBB_LIB_REL_PATH@${_tbb_arch_suffix}/${_tbb_subdir}" "@TBB_LIB_REL_PATH@${_tbb_arch_suffix}" "@TBB_LIB_REL_PATH@"
+        NO_DEFAULT_PATH
     )
 
     if (NOT TBB_FIND_RELEASE_ONLY)
@@ -72,6 +73,7 @@ foreach (_tbb_component ${TBB_FIND_COMPONENTS})
             NAMES @TBB_LIB_PREFIX@${_tbb_component}${_bin_version}_debug.@TBB_LIB_EXT@
             PATHS ${_tbb_root}
             PATH_SUFFIXES "@TBB_LIB_REL_PATH@/${_tbb_intel_arch}/${_tbb_subdir}" "@TBB_LIB_REL_PATH@${_tbb_arch_suffix}/${_tbb_subdir}" "@TBB_LIB_REL_PATH@${_tbb_arch_suffix}" "@TBB_LIB_REL_PATH@"
+            NO_DEFAULT_PATH
         )
     endif()
 


### PR DESCRIPTION
### Description 
When oneTBB is packaged in layout, where libraries are stored in following structure:
\- lib
-- cmake/
-- tbb12.lib 
\- lib32
-- cmake/
-- tbb12.lib

A try to load 32 Bit version of oneTBB will result in loading 64 bit version due to logic of library search when using `find_library`. To resolve that we can use `NO_DEFAULT_PATH` property since we don't expect for library to be found outside `TBBROOT` location.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
