### PR TITLE
Fix build failure when using TBB_USE_EXCEPTIONS=0

### DIFF
--- a/src/tbb/exception.cpp
+++ b/src/tbb/exception.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -41,27 +41,12 @@ const char* user_abort::what() const noexcept(true) { return "User-initiated abo
 const char* missing_wait::what() const noexcept(true) { return "wait() was not called on the structured_task_group"; }
 
 #if TBB_USE_EXCEPTIONS
-    template <typename F>
-    /*[[noreturn]]*/ void do_throw_noexcept(F throw_func) noexcept {
-        throw_func();
-    }
-
-    /*[[noreturn]]*/ void do_throw_noexcept(void (*throw_func)()) noexcept {
-        throw_func();
-#if __GNUC__ == 7
-        // In release, GCC 7 loses noexcept attribute during tail call optimization.
-        // The following statement prevents tail call optimization.
-        volatile bool reach_this_point = true;
-        suppress_unused_warning(reach_this_point);
-#endif
-    }
-
     bool terminate_on_exception(); // defined in global_control.cpp and ipc_server.cpp
 
     template <typename F>
     /*[[noreturn]]*/ void do_throw(F throw_func) {
         if (terminate_on_exception()) {
-            do_throw_noexcept(throw_func);
+            std::terminate();
         }
         throw_func();
     }

--- a/src/tbb/task_dispatcher.h
+++ b/src/tbb/task_dispatcher.h
@@ -54,9 +54,6 @@ inline d1::task* get_self_recall_task(arena_slot& slot) {
     return t;
 }
 
-// Defined in exception.cpp
-/*[[noreturn]]*/void do_throw_noexcept(void (*throw_exception)()) noexcept;
-
 //------------------------------------------------------------------------
 // Suspend point
 //------------------------------------------------------------------------
@@ -356,7 +353,7 @@ d1::task* task_dispatcher::local_wait_for_all(d1::task* t, Waiter& waiter ) {
             break; // Exit exception loop;
         } catch (...) {
             if (global_control::active_value(global_control::terminate_on_exception) == 1) {
-                do_throw_noexcept([] { throw; });
+                std::terminate();
             }
             if (ed.context->cancel_group_execution()) {
                 /* We are the first to signal cancellation, so store the exception that caused it. */


### PR DESCRIPTION
### Description 
This is just an alternative (arguably simplifying) fix in comparison to [PR 864](https://github.com/oneapi-src/oneTBB/pull/864) and also discussed in [issue 1208](https://github.com/oneapi-src/oneTBB/issues/1208).  I did comment in PR 864, to describe what I've done here, but since 864 has been open for a long time, I thought it might be useful to show my suggested changes here and see if it gains any traction.

We get a link error from 'task_dispatcher.h's reference to 'do_throw_noexcept(...)', which is not defined when building with 'TBB_USE_EXCEPTIONS=0'.  E.g. -
```
cmake ... -DTBB_COMMON_COMPILE_FLAGS:STRING="/DTBB_USE_EXCEPTIONS=0" ...
```

Since any throw from a 'noexcept' function results in a 'std::terminate', and all current uses of 'do_throw_noexcept' do nothing more than throw a custom exception, 'do_throw_noexcept' is equivalent to 'std::terminate', and replacing with 'std::terminate' makes things a bit clearer & cleaner.

Fixes # - 1208

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
