### PR TITLE
Show patch version in the version string

### DIFF
--- a/include/oneapi/tbb/version.h
+++ b/include/oneapi/tbb/version.h
@@ -35,7 +35,11 @@
 // Suffix string
 #define __TBB_VERSION_SUFFIX ""
 // Full official version string
-#define TBB_VERSION_STRING __TBB_STRING(TBB_VERSION_MAJOR) "." __TBB_STRING(TBB_VERSION_MINOR) __TBB_VERSION_SUFFIX
+#define TBB_VERSION_STRING              \
+    __TBB_STRING(TBB_VERSION_MAJOR) "." \
+    __TBB_STRING(TBB_VERSION_MINOR) "." \
+    __TBB_STRING(TBB_VERSION_PATCH)     \
+    __TBB_VERSION_SUFFIX
 
 // OneAPI oneTBB specification version
 #define ONETBB_SPEC_VERSION "1.0"


### PR DESCRIPTION
### Description 
Current version string's output follows such pattern "\<major\>.\<minor\>\<suffix\>". For some reason "path" version is omitted. This patch makes the pattern like "\<major\>.\<minor\>.\<patch\>\<suffix\>" (for example `2021.11` -> `2021.11.0`).


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
