### PR TITLE
Added the TBB_OPENMP_FLAG to IntelLLVM.cmake file

### DIFF
--- a/cmake/compilers/IntelLLVM.cmake
+++ b/cmake/compilers/IntelLLVM.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/compilers/IntelLLVM.cmake
+++ b/cmake/compilers/IntelLLVM.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2021-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/compilers/IntelLLVM.cmake
+++ b/cmake/compilers/IntelLLVM.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,5 +20,6 @@ if (WIN32)
 else()
     include(${CMAKE_CURRENT_LIST_DIR}/Clang.cmake)
     set(TBB_IPO_COMPILE_FLAGS $<$<NOT:$<CONFIG:Debug>>:-ipo>)
+    set(TBB_OPENMP_FLAG -qopenmp)
 endif()
 set(TBB_IPO_LINK_FLAGS ${TBB_IPO_LINK_FLAGS} ${TBB_IPO_COMPILE_FLAGS})

--- a/cmake/compilers/IntelLLVM.cmake
+++ b/cmake/compilers/IntelLLVM.cmake
@@ -14,6 +14,7 @@
 
 if (WIN32)
     include(${CMAKE_CURRENT_LIST_DIR}/MSVC.cmake)
+    set(TBB_OPENMP_FLAG /Qopenmp)
     set(TBB_IPO_COMPILE_FLAGS $<$<NOT:$<CONFIG:Debug>>:/Qipo>)
     set(TBB_IPO_LINK_FLAGS $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>)
 else()


### PR DESCRIPTION
### Description 

This fix  is required to address the  ERROR **icx-cl: error: Use of '/Qiopenmp' recommended over '-openmp'** 
This functionality is tested internally and working fine.

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_

### Tests

- [ ] added - _required for new features and some bug fixes_


### Documentation

- [ ] not needed

### Breaks backward compatibility

- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
