### PR TITLE
Fix flow graph reservation documentation

### DIFF
--- a/doc/main/tbb_userguide/Flow_Graph_Reservation.rst
+++ b/doc/main/tbb_userguide/Flow_Graph_Reservation.rst
@@ -63,7 +63,7 @@ messages and do not support ``try_get()`` or ``try_reserve()``.
        broadcast_node<int> bn(g);
        buffer_node<int> buf1(g);
        buffer_node<int> buf2(g);
-       typedef join_node<tuple<int,int> reserving> join_type;
+       typedef join_node<tuple<int,int>, reserving> join_type;
        join_type jn(g);
        buffer_node<join_type::output_type> buf_out(g);
        join_type::output_type tuple_out;
@@ -71,9 +71,9 @@ messages and do not support ``try_get()`` or ``try_reserve()``.
 
 
        // join_node predecessors are both reservable buffer_nodes
-       make_edge(buf1,input_port<0>jn));
-       make_edge(bn,input_port<0>jn));      // attach a broadcast_node
-       make_edge(buf2,input_port<1>jn));
+       make_edge(buf1,input_port<0>(jn));
+       make_edge(bn,input_port<0>(jn));      // attach a broadcast_node
+       make_edge(buf2,input_port<1>(jn));
        make_edge(jn, buf_out);
        bn.try_put(2);
        buf1.try_put(3);
@@ -81,7 +81,7 @@ messages and do not support ``try_get()`` or ``try_reserve()``.
        buf2.try_put(7);
        g.wait_for_all();
        while (buf_out.try_get(tuple_out)) {
-           printf("join_node output == (%d,%d)\n",get<0>tuple_out), get<1>tuple_out) );
+           printf("join_node output == (%d,%d)\n",get<0>(tuple_out), get<1>(tuple_out) );
        }
        if(buf1.try_get(icnt)) printf("buf1 had %d\n", icnt);
        else printf("buf1 was empty\n");


### PR DESCRIPTION
### Description 

Example in Flow graph reservation can not be compiled. Fix it.

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [x] updated in current PR
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users

### Other information
