### PR TITLE
CMake: Bump required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 # Enable CMake policies
 
@@ -41,12 +41,6 @@ if (APPLE)
     if (NOT CMAKE_C_OSX_DEPLOYMENT_TARGET_FLAG)
         set(CMAKE_C_OSX_DEPLOYMENT_TARGET_FLAG "-mmacosx-version-min=" CACHE STRING "Minimum macOS version flag")
     endif()
-endif()
-
-# Until CMake 3.4.0 FindThreads.cmake requires C language enabled.
-# Enable C language before CXX to avoid possible override of CMAKE_SIZEOF_VOID_P.
-if (CMAKE_VERSION VERSION_LESS 3.4)
-    enable_language(C)
 endif()
 
 file(READ include/oneapi/tbb/version.h _tbb_version_info)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(tbb_examples CXX)
 

--- a/examples/common/gui/CMakeLists.txt
+++ b/examples/common/gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/common/gui/CMakeLists.txt
+++ b/examples/common/gui/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 set(EXAMPLES_UI_MODE "con" CACHE STRING "EXAMPLES_UI_MODE")
 

--- a/examples/concurrent_hash_map/count_strings/CMakeLists.txt
+++ b/examples/concurrent_hash_map/count_strings/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/concurrent_hash_map/count_strings/CMakeLists.txt
+++ b/examples/concurrent_hash_map/count_strings/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(count_strings CXX)
 

--- a/examples/concurrent_priority_queue/shortpath/CMakeLists.txt
+++ b/examples/concurrent_priority_queue/shortpath/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/concurrent_priority_queue/shortpath/CMakeLists.txt
+++ b/examples/concurrent_priority_queue/shortpath/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(shortpath CXX)
 

--- a/examples/getting_started/sub_string_finder/CMakeLists.txt
+++ b/examples/getting_started/sub_string_finder/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/getting_started/sub_string_finder/CMakeLists.txt
+++ b/examples/getting_started/sub_string_finder/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(sub_string_finder_simple CXX)
 project(sub_string_finder_extended CXX)

--- a/examples/graph/binpack/CMakeLists.txt
+++ b/examples/graph/binpack/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/graph/binpack/CMakeLists.txt
+++ b/examples/graph/binpack/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(binpack CXX)
 

--- a/examples/graph/cholesky/CMakeLists.txt
+++ b/examples/graph/cholesky/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/graph/cholesky/CMakeLists.txt
+++ b/examples/graph/cholesky/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(cholesky CXX)
 

--- a/examples/graph/dining_philosophers/CMakeLists.txt
+++ b/examples/graph/dining_philosophers/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/graph/dining_philosophers/CMakeLists.txt
+++ b/examples/graph/dining_philosophers/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(dining_philosophers CXX)
 

--- a/examples/graph/fgbzip2/CMakeLists.txt
+++ b/examples/graph/fgbzip2/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(fgbzip2 CXX)
 

--- a/examples/graph/logic_sim/CMakeLists.txt
+++ b/examples/graph/logic_sim/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/graph/logic_sim/CMakeLists.txt
+++ b/examples/graph/logic_sim/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(logic_sim CXX)
 

--- a/examples/graph/som/CMakeLists.txt
+++ b/examples/graph/som/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/graph/som/CMakeLists.txt
+++ b/examples/graph/som/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include(../../common/cmake/common.cmake)
 project(som CXX)

--- a/examples/migration/recursive_fibonacci/CMakeLists.txt
+++ b/examples/migration/recursive_fibonacci/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(recursive_fibonacci CXX)
 

--- a/examples/parallel_for/game_of_life/CMakeLists.txt
+++ b/examples/parallel_for/game_of_life/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/parallel_for/game_of_life/CMakeLists.txt
+++ b/examples/parallel_for/game_of_life/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(game_of_life CXX)
 

--- a/examples/parallel_for/polygon_overlay/CMakeLists.txt
+++ b/examples/parallel_for/polygon_overlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/parallel_for/polygon_overlay/CMakeLists.txt
+++ b/examples/parallel_for/polygon_overlay/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(polygon_overlay CXX)
 

--- a/examples/parallel_for/seismic/CMakeLists.txt
+++ b/examples/parallel_for/seismic/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/parallel_for/seismic/CMakeLists.txt
+++ b/examples/parallel_for/seismic/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(seismic CXX)
 

--- a/examples/parallel_for/tachyon/CMakeLists.txt
+++ b/examples/parallel_for/tachyon/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/parallel_for/tachyon/CMakeLists.txt
+++ b/examples/parallel_for/tachyon/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(tachyon CXX)
 

--- a/examples/parallel_for_each/parallel_preorder/CMakeLists.txt
+++ b/examples/parallel_for_each/parallel_preorder/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/parallel_for_each/parallel_preorder/CMakeLists.txt
+++ b/examples/parallel_for_each/parallel_preorder/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(parallel_preorder CXX)
 

--- a/examples/parallel_pipeline/square/CMakeLists.txt
+++ b/examples/parallel_pipeline/square/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/parallel_pipeline/square/CMakeLists.txt
+++ b/examples/parallel_pipeline/square/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(square CXX)
 

--- a/examples/parallel_reduce/convex_hull/CMakeLists.txt
+++ b/examples/parallel_reduce/convex_hull/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/parallel_reduce/convex_hull/CMakeLists.txt
+++ b/examples/parallel_reduce/convex_hull/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(convex_hull_bench CXX)
 project(convex_hull_sample CXX)

--- a/examples/parallel_reduce/pi/CMakeLists.txt
+++ b/examples/parallel_reduce/pi/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(pi CXX)
 

--- a/examples/parallel_reduce/primes/CMakeLists.txt
+++ b/examples/parallel_reduce/primes/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/parallel_reduce/primes/CMakeLists.txt
+++ b/examples/parallel_reduce/primes/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(primes CXX)
 

--- a/examples/task_arena/fractal/CMakeLists.txt
+++ b/examples/task_arena/fractal/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/task_arena/fractal/CMakeLists.txt
+++ b/examples/task_arena/fractal/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(fractal CXX)
 

--- a/examples/task_group/sudoku/CMakeLists.txt
+++ b/examples/task_group/sudoku/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/task_group/sudoku/CMakeLists.txt
+++ b/examples/task_group/sudoku/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(sudoku CXX)
 

--- a/examples/test_all/fibonacci/CMakeLists.txt
+++ b/examples/test_all/fibonacci/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 Intel Corporation
+# Copyright (c) 2019-2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/test_all/fibonacci/CMakeLists.txt
+++ b/examples/test_all/fibonacci/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(fibonacci CXX)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,9 @@ function(tbb_add_test)
     add_executable(${_tbb_test_TARGET_NAME} ${_tbb_test_SUBDIR}/${_tbb_test_NAME}.cpp)
     target_include_directories(${_tbb_test_TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_SOURCE_DIR})
 
+    # cmake>=3.4 no longer adds flags to export symbols from executables (CMP0065)
+    set_property(TARGET ${_tbb_test_TARGET_NAME} PROPERTY ENABLE_EXPORTS TRUE)
+
     target_compile_options(${_tbb_test_TARGET_NAME}
         PRIVATE
         ${TBB_CXX_STD_FLAG}


### PR DESCRIPTION
Signed-off-by: Julien Schueller <schueller@phimeca.com>

Bump cmake version to 3.5 to avoid this deprecation message:

```
CMake Deprecation Warning at CMakeLists.txt:15 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

It should be old enough:
https://cmake.org/pipermail/cmake/2016-March/062947.html

### Description 
_Add a comprehensive description of proposed changes_


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
