### PR TITLE
Fix tests compilation on OpenBSD

### DIFF
--- a/test/tbb/test_eh_thread.cpp
+++ b/test/tbb/test_eh_thread.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2020-2022 Intel Corporation
+    Copyright (c) 2020-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_eh_thread.cpp
+++ b/test/tbb/test_eh_thread.cpp
@@ -34,7 +34,7 @@
 // On Windows there is no real thread number limit beside available memory.
 // Therefore, the test for thread limit is unreasonable.
 // TODO: enable limitThreads with sanitizer under docker
-#if TBB_USE_EXCEPTIONS && !_WIN32 && !__ANDROID__ && !__OpenBSD__
+#if TBB_USE_EXCEPTIONS && !_WIN32 && !__ANDROID__
 
 #include <limits.h>
 #include <sys/types.h>
@@ -75,7 +75,7 @@ public:
         mValid = false;
         pthread_attr_t attr;
         // Limit the stack size not to consume all virtual memory on 32 bit platforms.
-        std::size_t stacksize = utils::max(128*1024, PTHREAD_STACK_MIN);
+        std::size_t stacksize = utils::max(std::size_t(128*1024), std::size_t(PTHREAD_STACK_MIN));
         if (pthread_attr_init(&attr) == 0 && pthread_attr_setstacksize(&attr, stacksize) == 0) {
             mValid = pthread_create(&mHandle, &attr, thread_routine, /* arg = */ nullptr) == 0;
         }

--- a/test/tbb/test_eh_thread.cpp
+++ b/test/tbb/test_eh_thread.cpp
@@ -34,7 +34,7 @@
 // On Windows there is no real thread number limit beside available memory.
 // Therefore, the test for thread limit is unreasonable.
 // TODO: enable limitThreads with sanitizer under docker
-#if TBB_USE_EXCEPTIONS && !_WIN32 && !__ANDROID__
+#if TBB_USE_EXCEPTIONS && !_WIN32 && !__ANDROID__ && !__OpenBSD__
 
 #include <limits.h>
 #include <sys/types.h>

--- a/test/tbbmalloc/test_malloc_compliance.cpp
+++ b/test/tbbmalloc/test_malloc_compliance.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbbmalloc/test_malloc_compliance.cpp
+++ b/test/tbbmalloc/test_malloc_compliance.cpp
@@ -21,6 +21,10 @@
 
 #define __STDC_LIMIT_MACROS 1 // to get SIZE_MAX from stdint.h
 
+// There is no RLIMIT_AS on OpenBSD.
+// Therefore, the tests for memory limit is unreasonable.
+#if !__OpenBSD__
+
 #include "common/test.h"
 
 #include "common/utils.h"
@@ -1091,3 +1095,4 @@ TEST_CASE("MAIN TEST") {
 }
 
 #endif /* __TBB_WIN8UI_SUPPORT	 */
+#endif /* Enable test */

--- a/test/tbbmalloc/test_malloc_compliance.cpp
+++ b/test/tbbmalloc/test_malloc_compliance.cpp
@@ -21,10 +21,6 @@
 
 #define __STDC_LIMIT_MACROS 1 // to get SIZE_MAX from stdint.h
 
-// There is no RLIMIT_AS on OpenBSD.
-// Therefore, the tests for memory limit is unreasonable.
-#if !__OpenBSD__
-
 #include "common/test.h"
 
 #include "common/utils.h"
@@ -33,6 +29,10 @@
 #include "common/memory_usage.h"
 
 #include "oneapi/tbb/detail/_config.h"
+
+// There is no RLIMIT_AS on OpenBSD.
+// Therefore, the tests for memory limit is unreasonable.
+#if !__OpenBSD__
 
 #define __TBB_NO_IMPLICIT_LINKAGE 1
 #include "tbb/scalable_allocator.h"


### PR DESCRIPTION
### Description 
This test won't work on OpenBSD because it doesn't have RLIMIT_AS. So this patch disables this test.

#1015 
- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
