### PR TITLE
Fix parallel_for_each with C++20 iterators

### DIFF
--- a/include/oneapi/tbb/parallel_for_each.h
+++ b/include/oneapi/tbb/parallel_for_each.h
@@ -407,6 +407,15 @@ public:
 template<typename It>
 using tag = typename std::iterator_traits<It>::iterator_category;
 
+#if __TBB_CPP20_PRESENT
+template <typename It>
+using iterator_tag_dispatch =
+    std::conditional_t<std::random_access_iterator<It>,
+                       std::random_access_iterator_tag,
+                       std::conditional_t<std::forward_iterator<It>,
+                                          std::forward_iterator_tag,
+                                          std::input_iterator_tag>>;
+#else
 template<typename It>
 using iterator_tag_dispatch = typename
     std::conditional<
@@ -418,6 +427,7 @@ using iterator_tag_dispatch = typename
             std::input_iterator_tag
         >::type
     >::type;
+#endif // __TBB_CPP20_PRESENT
 
 template <typename Body, typename Iterator, typename Item>
 using feeder_is_required = tbb::detail::void_t<decltype(tbb::detail::invoke(std::declval<const Body>(),

--- a/test/tbb/test_parallel_for_each.cpp
+++ b/test/tbb/test_parallel_for_each.cpp
@@ -22,7 +22,7 @@
 //! \file test_parallel_for_each.cpp
 //! \brief Test for [algorithms.parallel_for_each]
 
-#if __TBB_CPP20_CONCEPTS_PRESENT
+#if __TBB_CPP20_PRESENT
 // Fancy iterator type that models the C++20 iterator type
 // that defines the real iterator category using iterator_concept type
 // and iterator_category is always std::input_iterator_type
@@ -119,7 +119,7 @@ struct cpp20_iterator {
 private:
     T* my_ptr = nullptr;
 }; // class cpp20_iterator
-#endif // __TBB_CPP20_CONCEPTS_PRESENT
+#endif // __TBB_CPP20_PRESENT
 
 //! Test forward access iterator support
 //! \brief \ref error_guessing \ref interface
@@ -270,6 +270,10 @@ TEST_CASE("parallel_for_each constraints") {
     test_pfor_each_body_constraints();
 }
 
+#endif // __TBB_CPP20_CONCEPTS_PRESENT
+
+#if __TBB_CPP20_PRESENT
+
 struct no_copy_move {
     no_copy_move() = default;
 
@@ -328,4 +332,4 @@ TEST_CASE("parallel_for_each with cpp20 iterator") {
     test_with_cpp20_iterator<std::random_access_iterator_tag>();
 }
 
-#endif // __TBB_CPP20_CONCEPTS_PRESENT
+#endif // __TBB_CPP20_PRESENT

--- a/test/tbb/test_parallel_for_each.cpp
+++ b/test/tbb/test_parallel_for_each.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2023 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -21,6 +21,105 @@
 
 //! \file test_parallel_for_each.cpp
 //! \brief Test for [algorithms.parallel_for_each]
+
+#if __TBB_CPP20_CONCEPTS_PRESENT
+// Fancy iterator type that models the C++20 iterator type
+// that defines the real iterator category using iterator_concept type
+// and iterator_category is always std::input_iterator_type
+// Similar iterators are used by C++20 ranges (e.g. std::ranges::iota_view::iterator)
+// parallel_for_each algorithm should detect such iterators with respect to iterator_concept value
+
+template <typename T, typename Category>
+struct cpp20_iterator {
+    static_assert(std::derived_from<Category, std::forward_iterator_tag>,
+                  "cpp20_iterator should be of at least forward iterator category");
+
+    using iterator_concept = Category;
+    using iterator_category = std::input_iterator_tag;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+
+    cpp20_iterator() = default;
+    explicit cpp20_iterator(T* ptr) : my_ptr(ptr) {}
+
+    T& operator*() const { return *my_ptr; }
+
+    cpp20_iterator& operator++() {
+        ++my_ptr;
+        return *this;
+    }
+
+    cpp20_iterator operator++(int) {
+        auto it = *this;
+        ++*this;
+        return it;
+    }
+
+    cpp20_iterator& operator--()
+        requires std::derived_from<Category, std::bidirectional_iterator_tag>
+    {
+        --my_ptr;
+        return *this;
+    }
+
+    cpp20_iterator operator--(int)
+        requires std::derived_from<Category, std::bidirectional_iterator_tag>
+    {
+        auto it = *this;
+        --*this;
+        return it;
+    }
+
+    cpp20_iterator& operator+=(difference_type n)
+        requires std::derived_from<Category, std::random_access_iterator_tag>
+    {
+        my_ptr += n;
+        return *this;
+    }
+
+    cpp20_iterator& operator-=(difference_type n)
+        requires std::derived_from<Category, std::random_access_iterator_tag>
+    {
+        my_ptr -= n;
+        return *this;
+    }
+
+    T& operator[](difference_type n) const
+        requires std::derived_from<Category, std::random_access_iterator_tag>
+    {
+        return my_ptr[n];
+    }
+
+    friend bool operator==(const cpp20_iterator&, const cpp20_iterator&) = default;
+
+    friend auto operator<=>(const cpp20_iterator&, const cpp20_iterator&)
+        requires std::derived_from<Category, std::random_access_iterator_tag> = default;
+
+    friend cpp20_iterator operator+(cpp20_iterator i, difference_type n)
+        requires std::derived_from<Category, std::random_access_iterator_tag>
+    {
+        return cpp20_iterator(i.my_ptr + n);
+    }
+
+    friend cpp20_iterator operator+(difference_type n, cpp20_iterator i)
+        requires std::derived_from<Category, std::random_access_iterator_tag>
+    {
+        return i + n;
+    }
+
+    friend cpp20_iterator operator-(cpp20_iterator i, difference_type n)
+        requires std::derived_from<Category, std::random_access_iterator_tag>
+    {
+        return cpp20_iterator(i.my_ptr - n);
+    }
+
+    friend difference_type operator-(const cpp20_iterator& x, const cpp20_iterator& y) {
+        return x.my_ptr - y.my_ptr;
+    }
+private:
+    T* my_ptr = nullptr;
+}; // class cpp20_iterator
+#endif // __TBB_CPP20_CONCEPTS_PRESENT
 
 //! Test forward access iterator support
 //! \brief \ref error_guessing \ref interface
@@ -169,6 +268,64 @@ TEST_CASE("parallel_for_each constraints") {
     test_pfor_each_iterator_constraints();
     test_pfor_each_container_based_sequence_constraints();
     test_pfor_each_body_constraints();
+}
+
+struct no_copy_move {
+    no_copy_move() = default;
+
+    no_copy_move(const no_copy_move&) = delete;
+    no_copy_move(no_copy_move&&) = delete;
+
+    no_copy_move& operator=(const no_copy_move&) = delete;
+    no_copy_move& operator=(no_copy_move&&) = delete;
+
+    int item = 0;
+};
+
+template <typename Category>
+void test_with_cpp20_iterator() {
+    constexpr std::size_t n = 1'000'000;
+
+    no_copy_move elements[n];
+
+    cpp20_iterator<no_copy_move, Category> begin(elements);
+    cpp20_iterator<no_copy_move, Category> end(elements + n);
+
+    oneapi::tbb::parallel_for_each(begin, end, [](no_copy_move& element) {
+        element.item = 42;
+    });
+
+    for (std::size_t index = 0; index < n; ++index) {
+        CHECK(elements[index].item == 42);
+    }
+}
+
+//! \brief \ref error_guessing \ref regression
+TEST_CASE("parallel_for_each with cpp20 iterator") {
+    // Test that parallel_for_each threats ignores iterator_category type
+    // if iterator_concept type is defined for iterator
+
+    // For input iterators parallel_for_each requires element to be
+    // copyable or movable so since cpp20_iterator is at least forward
+    // parallel_for_each should work with cpp20_iterator
+    // on non-copyable and non-movable type
+
+    // test cpp20_iterator implementation
+    using cpp20_forward_iterator = cpp20_iterator<int, std::forward_iterator_tag>;
+    using cpp20_bidirectional_iterator = cpp20_iterator<int, std::bidirectional_iterator_tag>;
+    using cpp20_random_access_iterator = cpp20_iterator<int, std::random_access_iterator_tag>;
+
+    static_assert(std::forward_iterator<cpp20_forward_iterator>);
+    static_assert(!std::bidirectional_iterator<cpp20_forward_iterator>);
+
+    static_assert(std::bidirectional_iterator<cpp20_bidirectional_iterator>);
+    static_assert(!std::random_access_iterator<cpp20_bidirectional_iterator>);
+
+    static_assert(std::random_access_iterator<cpp20_random_access_iterator>);
+
+    test_with_cpp20_iterator<std::forward_iterator_tag>();
+    test_with_cpp20_iterator<std::bidirectional_iterator_tag>();
+    test_with_cpp20_iterator<std::random_access_iterator_tag>();
 }
 
 #endif // __TBB_CPP20_CONCEPTS_PRESENT


### PR DESCRIPTION
### Description 
C++20  changed a bit an approach to determine the iterator category - now the new member type `iterator_concept` was introduced and now used as a primary type defining the iterator category. Previous `iterator_category` typedef can be defined now into "junior" category (typically `std::input_iterator_tag`).
Also C++20 introduced ranges and used this approach to define iterators for views. E.g `std::ranges::iota_view::iterator` - see [here ](https://en.cppreference.com/w/cpp/ranges/iota_view/iterator#:~:text=iterator_concept,type%20iterator_category.) for more details. 

Currently `parallel_for_each` algorithm uses the "legacy" approach and determines an iterator category based on `iterator_category` member type. For modern iterators (e.g. `std::ranges::iota_view::iterator`) it will result in using more strict and less efficient implementation for input iterators that implies copying of the entire range.

This PR changes the approach to use `std::random_access_iterator` (and other similar) concepts to determine the iterator category that respects both `iterator_concept` and `iterator_category` types.

We faced similar issue in oneDPL, see issue oneapi-src/oneDPL#1253 and PR oneapi-src/oneDPL#1266

Fixes # - _issue number(s) if exists_

- [ ] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
