### PR TITLE
Minor waiter code refactoring

### DIFF
--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -429,8 +429,7 @@ void arena::advertise_new_work() {
             workers_delta = 1;
         }
 
-        bool wakeup_workers = is_mandatory_needed || are_workers_needed;
-        request_workers(mandatory_delta, workers_delta, wakeup_workers);
+        request_workers(mandatory_delta, workers_delta, /* wakeup_threads = */ true);
     }
 }
 

--- a/src/tbb/waiters.h
+++ b/src/tbb/waiters.h
@@ -114,6 +114,7 @@ protected:
     void sleep(std::uintptr_t uniq_tag, Pred wakeup_condition) {
         my_arena.get_waiting_threads_monitor().wait<thread_control_monitor::thread_context>(wakeup_condition,
             market_context{uniq_tag, &my_arena});
+        reset_wait();
     }
 };
 
@@ -139,7 +140,6 @@ public:
         auto wakeup_condition = [&] { return !my_arena.is_empty() || !my_wait_ctx.continue_execution(); };
 
         sleep(std::uintptr_t(&my_wait_ctx), wakeup_condition);
-        my_backoff.reset_wait();
     }
 
     d1::wait_context* wait_ctx() {
@@ -176,11 +176,6 @@ public:
         auto wakeup_condition = [&] { return !my_arena.is_empty() || sp->m_is_owner_recalled.load(std::memory_order_relaxed); };
 
         sleep(std::uintptr_t(sp), wakeup_condition);
-        my_backoff.reset_wait();
-    }
-
-    void reset_wait() {
-        my_backoff.reset_wait();
     }
 
     d1::wait_context* wait_ctx() {


### PR DESCRIPTION
### Description 
* In `advertise_new_work`, remove a check that is the same as the if-condition.
* Put the backoff reset directly into `sleep`, instead of always doing it after calling `sleep`.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
