### PR TITLE
For parallel_for_each iterator tag dispatch for move iterators + fix stack overflow on Windows

### DIFF
--- a/include/oneapi/tbb/parallel_for_each.h
+++ b/include/oneapi/tbb/parallel_for_each.h
@@ -414,7 +414,7 @@ struct move_iterator_dispatch_helper {
 };
 
 // Until C++23, std::move_iterator::iterator_concept always defines
-// to std::input_iterator tag and hence std::forward_iterator concept
+// to std::input_iterator_tag and hence std::forward_iterator concept
 // always evaluates to false, so std::move_iterator dispatch should be
 // made according to the base iterator type.
 template <typename It>

--- a/include/oneapi/tbb/parallel_for_each.h
+++ b/include/oneapi/tbb/parallel_for_each.h
@@ -409,12 +409,31 @@ using tag = typename std::iterator_traits<It>::iterator_category;
 
 #if __TBB_CPP20_PRESENT
 template <typename It>
-using iterator_tag_dispatch =
+struct move_iterator_dispatch_helper {
+    using type = It;
+};
+
+// Until C++23, std::move_iterator::iterator_concept always defines
+// to std::input_iterator tag and hence std::forward_iterator concept
+// always evaluates to false, so std::move_iterator dispatch should be
+// made according to the base iterator type.
+template <typename It>
+struct move_iterator_dispatch_helper<std::move_iterator<It>> {
+    using type = It;
+};
+
+template <typename It>
+using iterator_tag_dispatch_impl =
     std::conditional_t<std::random_access_iterator<It>,
                        std::random_access_iterator_tag,
                        std::conditional_t<std::forward_iterator<It>,
                                           std::forward_iterator_tag,
                                           std::input_iterator_tag>>;
+
+template <typename It>
+using iterator_tag_dispatch =
+    iterator_tag_dispatch_impl<typename move_iterator_dispatch_helper<It>::type>;
+
 #else
 template<typename It>
 using iterator_tag_dispatch = typename

--- a/test/conformance/conformance_parallel_for_each.cpp
+++ b/test/conformance/conformance_parallel_for_each.cpp
@@ -102,10 +102,8 @@ public:
     void do_action_and_feed(oneapi::tbb::feeder<ForEachInvokeItem>& feeder) const {
         CHECK_MESSAGE(change_vector.size() % 2 == 0, "incorrect test setup");
         std::size_t shift = change_vector.size() / 2;
-        std::cout << "Process " << real_value << std::endl;
         ++change_vector[real_value];
         if (real_value < shift) {
-            std::cout << "Add " << real_value + shift << std::endl;
             feeder.add(ForEachInvokeItem(real_value + shift, change_vector));
         }
     }

--- a/test/tbb/test_parallel_for_each.cpp
+++ b/test/tbb/test_parallel_for_each.cpp
@@ -290,10 +290,10 @@ template <typename Category>
 void test_with_cpp20_iterator() {
     constexpr std::size_t n = 1'000'000;
 
-    no_copy_move elements[n];
+    std::vector<no_copy_move> elements(n);
 
-    cpp20_iterator<no_copy_move, Category> begin(elements);
-    cpp20_iterator<no_copy_move, Category> end(elements + n);
+    cpp20_iterator<no_copy_move, Category> begin(elements.data());
+    cpp20_iterator<no_copy_move, Category> end(elements.data() + n);
 
     oneapi::tbb::parallel_for_each(begin, end, [](no_copy_move& element) {
         element.item = 42;


### PR DESCRIPTION
### Description 
Until C++23, std::move_iterator::iterator_concept is always std::input_iterator_tag so we need to do dispatch according to base iterator category.


Fixes # - _issue number(s) if exists_

- [ ] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
