### PR TITLE
Add NOMINMAX before windows.h in enumerable_thread_specific.h

### DIFF
--- a/include/oneapi/tbb/enumerable_thread_specific.h
+++ b/include/oneapi/tbb/enumerable_thread_specific.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -36,7 +36,15 @@
 #include "task.h" // for task::suspend_point
 
 #if _WIN32 || _WIN64
+#ifndef NOMINMAX
+#define NOMINMAX
+#define __TBB_DEFINED_NOMINMAX 1
+#endif
 #include <windows.h>
+#if __TBB_DEFINED_NOMINMAX
+#undef NOMINMAX
+#undef __TBB_DEFINED_NOMINMAX
+#endif
 #else
 #include <pthread.h>
 #endif


### PR DESCRIPTION
### Description 
Currently enumerable_thread_specific.h inclusion breaks `std::min()` and `std::max()` usage due to macro spreading from windows.h.  Technically, it may affect someone that relays on those macro and implicit presence of windows.h, it looks like a much less evil, as `std` not macro is a way to go and workaround is straightforward.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [x] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information