### PR TITLE
Better rvalues support for parallel_reduce algorithm

### DIFF
--- a/include/oneapi/tbb/parallel_reduce.h
+++ b/include/oneapi/tbb/parallel_reduce.h
@@ -35,7 +35,7 @@ inline namespace d0 {
 
 template <typename Body, typename Range>
 concept parallel_reduce_body = splittable<Body> &&
-                               requires( Body& body, const Range& range, Body&& rhs ) {
+                               requires( Body& body, const Range& range, Body& rhs ) {
                                    body(range);
                                    body.join(rhs);
                                };

--- a/include/oneapi/tbb/parallel_reduce.h
+++ b/include/oneapi/tbb/parallel_reduce.h
@@ -35,9 +35,9 @@ inline namespace d0 {
 
 template <typename Body, typename Range>
 concept parallel_reduce_body = splittable<Body> &&
-                               requires( Body& body, const Range& range, Body& rhs ) {
+                               requires( Body& body, const Range& range, Body&& rhs ) {
                                    body(range);
-                                   body.join(rhs);
+                                   body.join(std::move(rhs));
                                };
 
 template <typename Function, typename Range, typename Value>
@@ -390,14 +390,15 @@ public:
         , my_value(other.my_identity_element)
     { }
     void operator()(Range& range) {
-        my_value = tbb::detail::invoke(my_real_body, range, const_cast<const Value&>(my_value));
+        my_value = tbb::detail::invoke(my_real_body, range, std::move(my_value));
     }
+
     void join( lambda_reduce_body& rhs ) {
-        my_value = tbb::detail::invoke(my_reduction, const_cast<const Value&>(my_value),
-                                                     const_cast<const Value&>(rhs.my_value));
+        my_value = tbb::detail::invoke(my_reduction, std::move(my_value), std::move(rhs.my_value));
     }
-    Value result() const {
-        return my_value;
+
+    Value&& result() noexcept {
+        return std::move(my_value);
     }
 };
 
@@ -411,7 +412,7 @@ public:
     - \code Body::~Body(); \endcode                     Destructor
     - \code void Body::operator()( Range& r ); \endcode Function call operator applying body to range \c r
                                                         and accumulating the result
-    - \code void Body::join( Body& b ); \endcode        Join results.
+    - \code void Body::join( Body&& b ); \endcode        Join results.
                                                         The result in \c b should be merged into the result of \c this
 **/
 
@@ -514,7 +515,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const __TBB_DEFAULT_PARTITIONER>
                           ::run(range, body, __TBB_DEFAULT_PARTITIONER() );
-    return body.result();
+    return std::move(body.result());
 }
 
 //! Parallel iteration with reduction and simple_partitioner.
@@ -527,7 +528,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const simple_partitioner>
                           ::run(range, body, partitioner );
-    return body.result();
+    return std::move(body.result());
 }
 
 //! Parallel iteration with reduction and auto_partitioner
@@ -540,7 +541,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const auto_partitioner>
                           ::run( range, body, partitioner );
-    return body.result();
+    return std::move(body.result());
 }
 
 //! Parallel iteration with reduction and static_partitioner
@@ -553,7 +554,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const static_partitioner>
                                         ::run( range, body, partitioner );
-    return body.result();
+    return std::move(body.result());
 }
 
 //! Parallel iteration with reduction and affinity_partitioner
@@ -566,7 +567,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,affinity_partitioner>
                                         ::run( range, body, partitioner );
-    return body.result();
+    return std::move(body.result());
 }
 
 //! Parallel iteration with reduction, default partitioner and user-supplied context.
@@ -579,7 +580,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const __TBB_DEFAULT_PARTITIONER>
                           ::run( range, body, __TBB_DEFAULT_PARTITIONER(), context );
-    return body.result();
+    return std::move(body.result());
 }
 
 //! Parallel iteration with reduction, simple partitioner and user-supplied context.
@@ -592,7 +593,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const simple_partitioner>
                           ::run( range, body, partitioner, context );
-    return body.result();
+    return std::move(body.result());
 }
 
 //! Parallel iteration with reduction, auto_partitioner and user-supplied context
@@ -605,7 +606,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const auto_partitioner>
                           ::run( range, body, partitioner, context );
-    return body.result();
+    return std::move(body.result());
 }
 
 //! Parallel iteration with reduction, static_partitioner and user-supplied context
@@ -618,7 +619,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const static_partitioner>
                                         ::run( range, body, partitioner, context );
-    return body.result();
+    return std::move(body.result());
 }
 
 //! Parallel iteration with reduction, affinity_partitioner and user-supplied context
@@ -631,7 +632,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,affinity_partitioner>
                                         ::run( range, body, partitioner, context );
-    return body.result();
+    return std::move(body.result());
 }
 
 //! Parallel iteration with deterministic reduction and default simple partitioner.
@@ -704,7 +705,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_deterministic_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>, const simple_partitioner>
                           ::run(range, body, partitioner);
-    return body.result();
+    return std::move(body.result());
 }
 
 //! Parallel iteration with deterministic reduction and static partitioner.
@@ -716,7 +717,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
     lambda_reduce_body<Range, Value, RealBody, Reduction> body(identity, real_body, reduction);
     start_deterministic_reduce<Range, lambda_reduce_body<Range, Value, RealBody, Reduction>, const static_partitioner>
         ::run(range, body, partitioner);
-    return body.result();
+    return std::move(body.result());
 }
 
 //! Parallel iteration with deterministic reduction, default simple partitioner and user-supplied context.
@@ -739,7 +740,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
     lambda_reduce_body<Range, Value, RealBody, Reduction> body(identity, real_body, reduction);
     start_deterministic_reduce<Range, lambda_reduce_body<Range, Value, RealBody, Reduction>, const simple_partitioner>
         ::run(range, body, partitioner, context);
-    return body.result();
+    return std::move(body.result());
 }
 
 //! Parallel iteration with deterministic reduction, static partitioner and user-supplied context.
@@ -752,7 +753,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
     lambda_reduce_body<Range, Value, RealBody, Reduction> body(identity, real_body, reduction);
     start_deterministic_reduce<Range, lambda_reduce_body<Range, Value, RealBody, Reduction>, const static_partitioner>
         ::run(range, body, partitioner, context);
-    return body.result();
+    return std::move(body.result());
 }
 //@}
 

--- a/include/oneapi/tbb/parallel_reduce.h
+++ b/include/oneapi/tbb/parallel_reduce.h
@@ -37,21 +37,21 @@ template <typename Body, typename Range>
 concept parallel_reduce_body = splittable<Body> &&
                                requires( Body& body, const Range& range, Body&& rhs ) {
                                    body(range);
-                                   body.join(std::move(rhs));
+                                   body.join(rhs);
                                };
 
 template <typename Function, typename Range, typename Value>
 concept parallel_reduce_function = std::invocable<const std::remove_reference_t<Function>&,
-                                                  const Range&, const Value&> &&
+                                                  const Range&, Value&&> &&
                                    std::convertible_to<std::invoke_result_t<const std::remove_reference_t<Function>&,
-                                                                            const Range&, const Value&>,
+                                                                            const Range&, Value&&>,
                                                         Value>;
 
 template <typename Combine, typename Value>
 concept parallel_reduce_combine = std::invocable<const std::remove_reference_t<Combine>&,
-                                                 const Value&, const Value&> &&
+                                                 Value&&, Value&&> &&
                                   std::convertible_to<std::invoke_result_t<const std::remove_reference_t<Combine>&,
-                                                                           const Value&, const Value&>,
+                                                                           Value&&, Value&&>,
                                                       Value>;
 
 } // namespace d0
@@ -397,7 +397,7 @@ public:
         my_value = tbb::detail::invoke(my_reduction, std::move(my_value), std::move(rhs.my_value));
     }
 
-    Value&& result() noexcept {
+    __TBB_nodiscard Value&& result() && noexcept {
         return std::move(my_value);
     }
 };
@@ -515,7 +515,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const __TBB_DEFAULT_PARTITIONER>
                           ::run(range, body, __TBB_DEFAULT_PARTITIONER() );
-    return std::move(body.result());
+    return std::move(body).result();
 }
 
 //! Parallel iteration with reduction and simple_partitioner.
@@ -528,7 +528,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const simple_partitioner>
                           ::run(range, body, partitioner );
-    return std::move(body.result());
+    return std::move(body).result();
 }
 
 //! Parallel iteration with reduction and auto_partitioner
@@ -541,7 +541,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const auto_partitioner>
                           ::run( range, body, partitioner );
-    return std::move(body.result());
+    return std::move(body).result();
 }
 
 //! Parallel iteration with reduction and static_partitioner
@@ -554,7 +554,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const static_partitioner>
                                         ::run( range, body, partitioner );
-    return std::move(body.result());
+    return std::move(body).result();
 }
 
 //! Parallel iteration with reduction and affinity_partitioner
@@ -567,7 +567,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,affinity_partitioner>
                                         ::run( range, body, partitioner );
-    return std::move(body.result());
+    return std::move(body).result();
 }
 
 //! Parallel iteration with reduction, default partitioner and user-supplied context.
@@ -580,7 +580,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const __TBB_DEFAULT_PARTITIONER>
                           ::run( range, body, __TBB_DEFAULT_PARTITIONER(), context );
-    return std::move(body.result());
+    return std::move(body).result();
 }
 
 //! Parallel iteration with reduction, simple partitioner and user-supplied context.
@@ -593,7 +593,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const simple_partitioner>
                           ::run( range, body, partitioner, context );
-    return std::move(body.result());
+    return std::move(body).result();
 }
 
 //! Parallel iteration with reduction, auto_partitioner and user-supplied context
@@ -606,7 +606,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const auto_partitioner>
                           ::run( range, body, partitioner, context );
-    return std::move(body.result());
+    return std::move(body).result();
 }
 
 //! Parallel iteration with reduction, static_partitioner and user-supplied context
@@ -619,7 +619,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,const static_partitioner>
                                         ::run( range, body, partitioner, context );
-    return std::move(body.result());
+    return std::move(body).result();
 }
 
 //! Parallel iteration with reduction, affinity_partitioner and user-supplied context
@@ -632,7 +632,7 @@ Value parallel_reduce( const Range& range, const Value& identity, const RealBody
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>,affinity_partitioner>
                                         ::run( range, body, partitioner, context );
-    return std::move(body.result());
+    return std::move(body).result();
 }
 
 //! Parallel iteration with deterministic reduction and default simple partitioner.
@@ -705,7 +705,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
     lambda_reduce_body<Range,Value,RealBody,Reduction> body(identity, real_body, reduction);
     start_deterministic_reduce<Range,lambda_reduce_body<Range,Value,RealBody,Reduction>, const simple_partitioner>
                           ::run(range, body, partitioner);
-    return std::move(body.result());
+    return std::move(body).result();
 }
 
 //! Parallel iteration with deterministic reduction and static partitioner.
@@ -717,7 +717,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
     lambda_reduce_body<Range, Value, RealBody, Reduction> body(identity, real_body, reduction);
     start_deterministic_reduce<Range, lambda_reduce_body<Range, Value, RealBody, Reduction>, const static_partitioner>
         ::run(range, body, partitioner);
-    return std::move(body.result());
+    return std::move(body).result();
 }
 
 //! Parallel iteration with deterministic reduction, default simple partitioner and user-supplied context.
@@ -740,7 +740,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
     lambda_reduce_body<Range, Value, RealBody, Reduction> body(identity, real_body, reduction);
     start_deterministic_reduce<Range, lambda_reduce_body<Range, Value, RealBody, Reduction>, const simple_partitioner>
         ::run(range, body, partitioner, context);
-    return std::move(body.result());
+    return std::move(body).result();
 }
 
 //! Parallel iteration with deterministic reduction, static partitioner and user-supplied context.
@@ -753,7 +753,7 @@ Value parallel_deterministic_reduce( const Range& range, const Value& identity, 
     lambda_reduce_body<Range, Value, RealBody, Reduction> body(identity, real_body, reduction);
     start_deterministic_reduce<Range, lambda_reduce_body<Range, Value, RealBody, Reduction>, const static_partitioner>
         ::run(range, body, partitioner, context);
-    return std::move(body.result());
+    return std::move(body).result();
 }
 //@}
 

--- a/include/oneapi/tbb/parallel_reduce.h
+++ b/include/oneapi/tbb/parallel_reduce.h
@@ -412,7 +412,7 @@ public:
     - \code Body::~Body(); \endcode                     Destructor
     - \code void Body::operator()( Range& r ); \endcode Function call operator applying body to range \c r
                                                         and accumulating the result
-    - \code void Body::join( Body&& b ); \endcode        Join results.
+    - \code void Body::join( Body& b ); \endcode        Join results.
                                                         The result in \c b should be merged into the result of \c this
 **/
 

--- a/include/oneapi/tbb/parallel_reduce.h
+++ b/include/oneapi/tbb/parallel_reduce.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/conformance/conformance_parallel_reduce.cpp
+++ b/test/conformance/conformance_parallel_reduce.cpp
@@ -57,30 +57,23 @@ struct ReduceBody {
     }
 };
 
-// The type that is copyable and can be stored in the container
-// that would be copied only in the empty state.
 template <typename T>
-class NeverCopyWrapper {
+class MoveOnlyWrapper {
 public:
-    NeverCopyWrapper() = default;
-    NeverCopyWrapper(const T& obj) : my_obj(obj) {}
+    MoveOnlyWrapper() = default;
+    MoveOnlyWrapper(const T& obj) : my_obj(obj) {}
 
-    NeverCopyWrapper(NeverCopyWrapper&&) = default;
-    NeverCopyWrapper& operator=(NeverCopyWrapper&&) = default;
+    MoveOnlyWrapper(MoveOnlyWrapper&&) = default;
+    MoveOnlyWrapper& operator=(MoveOnlyWrapper&&) = default;
 
-    NeverCopyWrapper(const NeverCopyWrapper&) {
-        REQUIRE_MESSAGE(false, "Copy constructor of NeverCopyWrapper should never be called");
-    }
+    MoveOnlyWrapper(const MoveOnlyWrapper&) = delete;
+    MoveOnlyWrapper& operator=(const MoveOnlyWrapper&) = delete;
 
-    NeverCopyWrapper& operator=(const NeverCopyWrapper&) {
-        REQUIRE_MESSAGE(false, "Copy assignment of NeverCopyWrapper should never be called");
-        return *this;
-    }
 
-    bool operator==(const NeverCopyWrapper& other) const { return my_obj == other.my_obj; }
+    bool operator==(const MoveOnlyWrapper& other) const { return my_obj == other.my_obj; }
 private:
     T my_obj;
-}; // class NeverCopyWrapper
+}; // class MoveOnlyWrapper
 
 // The container wrapper that is copyable but the copy constructor fails if the source container is non-empty
 // If such an empty container is provided as an identity into parallel reduce algorithm with rvalue-friendly body,
@@ -241,7 +234,7 @@ template <typename Runner, typename... PartitionerContext>
 void test_vector_of_lists_rvalue_reduce_basic(const Runner& runner, PartitionerContext&&... args) {
     constexpr std::size_t n_vectors = 10'000;
 
-    using inner_type = NeverCopyWrapper<int>;
+    using inner_type = MoveOnlyWrapper<int>;
     using list_type = EmptyCopyList<inner_type>;
     using vector_of_lists_type = std::vector<list_type>;
 

--- a/test/conformance/conformance_parallel_reduce.cpp
+++ b/test/conformance/conformance_parallel_reduce.cpp
@@ -69,7 +69,6 @@ public:
     MoveOnlyWrapper(const MoveOnlyWrapper&) = delete;
     MoveOnlyWrapper& operator=(const MoveOnlyWrapper&) = delete;
 
-
     bool operator==(const MoveOnlyWrapper& other) const { return my_obj == other.my_obj; }
 private:
     T my_obj;

--- a/test/conformance/conformance_parallel_reduce.cpp
+++ b/test/conformance/conformance_parallel_reduce.cpp
@@ -231,7 +231,7 @@ TEST_CASE("parallel_[deterministic_]reduce and std::invoke") {
 
 template <typename Runner, typename... PartitionerContext>
 void test_vector_of_lists_rvalue_reduce_basic(const Runner& runner, PartitionerContext&&... args) {
-    constexpr std::size_t n_vectors = 10'000;
+    constexpr std::size_t n_vectors = 10000;
 
     using inner_type = MoveOnlyWrapper<int>;
     using list_type = EmptyCopyList<inner_type>;

--- a/test/conformance/conformance_parallel_reduce.cpp
+++ b/test/conformance/conformance_parallel_reduce.cpp
@@ -102,15 +102,15 @@ public:
         return *this;
     }
 
-    std::list<T>::iterator insert(std::list<T>::const_iterator pos, T&& item) {
+    typename std::list<T>::iterator insert(typename std::list<T>::const_iterator pos, T&& item) {
         return my_list.insert(pos, std::move(item));
     }
 
-    void splice(std::list<T>::const_iterator pos, EmptyCopyList&& other) {
+    void splice(typename std::list<T>::const_iterator pos, EmptyCopyList&& other) {
         my_list.splice(pos, std::move(other.my_list));
     }
 
-    std::list<T>::const_iterator end() const { return my_list.end(); }
+    typename std::list<T>::const_iterator end() const { return my_list.end(); }
 
     bool operator==(const EmptyCopyList& other) const { return my_list == other.my_list; }
 

--- a/test/conformance/conformance_parallel_reduce.cpp
+++ b/test/conformance/conformance_parallel_reduce.cpp
@@ -329,6 +329,7 @@ void test_vector_of_lists_rvalue_deterministic_reduce() {
     test_vector_of_lists_rvalue_reduce_basic(runner, oneapi::tbb::static_partitioner{}, context);
 }
 
+//! \brief \ref interface \ref requirement
 TEST_CASE("test rvalue optimization") {
     test_vector_of_lists_rvalue_reduce();
     test_vector_of_lists_rvalue_deterministic_reduce();


### PR DESCRIPTION
### Description 
Adding the optimization for reduction of rvalues using `parallel_reduce` and `parallel_deterministic_reduce`.
Based on #171 , #169 and #1299.

This patch is intended to optimize operating with Value class in parallel reduce algorithm (lambda version). Example from #1299

```
// We want to efficiently reduce a number of std::set objects into single std::set containing unique values from each set
std::vector<std::set<int>> sets = ...;

parallel_reduce(blocked_range<size_t>(0, sets.size()),
                         std::set<int>{}, // Identity - empty set
                         [&](const blocked_range<size_t>& range, const std::set<int>& value) { // Second argument is required to be const Value& by the spec
                             std::set<int> result = value; // We are forced to do copy here since value is constant
                             
                             for (size_t i = range.begin(); i < range.end(); ++i) {
                                 result.merge(sets[i]); // set::merge is efficient since it transfers required node from one set to another
                             }
                             return result;
                         },
                         [](const std::set<int>& value1, const std::set<int>& value2) { // Both arguments are required to be const Value&
                             std::set<int> result = value1; // We are forced to do copy
                             result.insert(value2.begin(), value2.end()); // unable to use set::merge here since value2 is constant  
                         }                  
                         );
```

The spec forces the user to use inefficient copying instead of "moving" even if the input range preservation is not important for the user. "Body" version of parallel reduce allows to drop unnecessary copying:

```
struct Body {
    std::vector<std::set<int>>& sets;
    std::set<int> result;
    
    void operator()(const blocked_range<size_t>& range) {
        for (size_t i = range.begin(); i != range.end(); ++i) {
            result.merge(sets[i]); // only moving nodes
        }
    }
    
    void join(Body& rhs) {
        result.merge(rhs.result); // also only moving nodes
    }
};
```

The main goal of this patch is to allow rvalues optimization for lambda version of reduce.
This patch is NOT intended to allow reduction of move-only objects (such as `std::unique_ptr`s) since we still need to copy the identity value into each parallel_reduce leaf.

Specification change is also needed for this PR:
* Relax `ParallelReduceFunc` named requirement to allow `Value operator()(const Range& range, Value&& value) const`
* Relax `ParallelReduceReduction` named requirement to allow `Value operator()(Value&& x, Value&& y) const`.

This PR also contains simple test that I guess should be extended to better cover all overloads and algorithms.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [x] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [x] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@BenFrantzDale
@rfschtkt
Feel free to participate in review and discussions for this patch:)

### Other information
