### PR TITLE
Correct behavior on deactivated permit

### DIFF
--- a/src/tbb/tcm_adaptor.cpp
+++ b/src/tbb/tcm_adaptor.cpp
@@ -137,11 +137,7 @@ public:
             // The permit has changed during the reading, so the callback will be invoked soon one more time and
             // we can just skip this renegotiation iteration.
             if (!new_permit.flags.stale) {
-                __TBB_ASSERT(
-                    new_permit.state != TCM_PERMIT_STATE_INACTIVE || new_concurrency == 0,
-                    "TCM did not nullify resources while deactivating the permit"
-                );
-                delta = update_concurrency(new_concurrency);
+                delta = update_concurrency(new_permit.state != TCM_PERMIT_STATE_INACTIVE ? new_concurrency : 0);
             }
         }
         if (delta) {


### PR DESCRIPTION
### Description 
`new concurrency` value may still not be 0 if permit was deactivated (since there was no other demand for resources). This patch forces new concurrency to 0 when permit is deactivated.


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
