### PR TITLE
Minor spelling error corrected on line 45 : strunt -> struct

### DIFF
--- a/examples/concurrent_hash_map/count_strings/count_strings.cpp
+++ b/examples/concurrent_hash_map/count_strings/count_strings.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/concurrent_hash_map/count_strings/count_strings.cpp
+++ b/examples/concurrent_hash_map/count_strings/count_strings.cpp
@@ -42,7 +42,7 @@ private:
         (sizeof(std::size_t) == sizeof(unsigned)) ? 2654435769U : 11400714819323198485ULL);
 
     std::hash<CharT> char_hash;
-}; // strunt hash<std::basic_string>
+}; // struct hash<std::basic_string>
 
 } // namespace std
 


### PR DESCRIPTION
### Description 
Minor spelling error corrected on line 45 : strunt -> struct.


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users


### Other information
