### PR TITLE
Omit tests that takes too long for emscripten 

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -593,39 +593,39 @@ if (TARGET TBB::tbbmalloc)
         endif()
         # ----------------------------------------------------------------------------------------
         # Whitebox testing
+	if (NOT TBB_EMSCRIPTEN)
+	    add_executable(test_malloc_whitebox tbbmalloc/test_malloc_whitebox.cpp)
 
-        add_executable(test_malloc_whitebox tbbmalloc/test_malloc_whitebox.cpp)
-
-        target_include_directories(test_malloc_whitebox
-            PRIVATE
-            ${CMAKE_CURRENT_SOURCE_DIR}/../include
-            ${CMAKE_CURRENT_SOURCE_DIR}/..
-            ${CMAKE_CURRENT_SOURCE_DIR})
-        target_compile_definitions(test_malloc_whitebox PRIVATE __TBBMALLOC_BUILD)
-        target_compile_options(test_malloc_whitebox
-            PRIVATE
-            ${TBB_CXX_STD_FLAG}
-            ${TBB_WARNING_SUPPRESS}
-            ${TBB_TEST_COMPILE_FLAGS}
-            ${TBB_COMMON_COMPILE_FLAGS}
-            ${TBBMALLOC_LIB_COMPILE_FLAGS}
-        )
-        if (ANDROID_PLATFORM)
-            add_test(NAME test_malloc_whitebox
-                    COMMAND ${CMAKE_COMMAND}
-                            -DBINARIES_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
-                            -DTEST_NAME=test_malloc_whitebox
-                            -P ${PROJECT_SOURCE_DIR}/cmake/android/test_launcher.cmake)
-        else()
-            add_test(NAME test_malloc_whitebox COMMAND test_malloc_whitebox --force-colors=1)
-        endif()
-        if (COMMAND target_link_options)
-            target_link_options(test_malloc_whitebox PRIVATE ${TBB_COMMON_LINK_FLAGS})
-        else()
-            target_link_libraries(test_malloc_whitebox PRIVATE ${TBB_COMMON_LINK_FLAGS})
-        endif()
-        target_link_libraries(test_malloc_whitebox PRIVATE Threads::Threads ${TBB_COMMON_LINK_LIBS})
-
+            target_include_directories(test_malloc_whitebox
+                PRIVATE
+                ${CMAKE_CURRENT_SOURCE_DIR}/../include
+                ${CMAKE_CURRENT_SOURCE_DIR}/..
+                ${CMAKE_CURRENT_SOURCE_DIR})
+            target_compile_definitions(test_malloc_whitebox PRIVATE __TBBMALLOC_BUILD)
+            target_compile_options(test_malloc_whitebox
+                PRIVATE
+                ${TBB_CXX_STD_FLAG}
+                ${TBB_WARNING_SUPPRESS}
+                ${TBB_TEST_COMPILE_FLAGS}
+                ${TBB_COMMON_COMPILE_FLAGS}
+                ${TBBMALLOC_LIB_COMPILE_FLAGS}
+            )
+            if (ANDROID_PLATFORM)
+                add_test(NAME test_malloc_whitebox
+                        COMMAND ${CMAKE_COMMAND}
+                                -DBINARIES_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+                                -DTEST_NAME=test_malloc_whitebox
+                                -P ${PROJECT_SOURCE_DIR}/cmake/android/test_launcher.cmake)
+            else()
+                add_test(NAME test_malloc_whitebox COMMAND test_malloc_whitebox --force-colors=1)
+            endif()
+            if (COMMAND target_link_options)
+                target_link_options(test_malloc_whitebox PRIVATE ${TBB_COMMON_LINK_FLAGS})
+            else()
+                target_link_libraries(test_malloc_whitebox PRIVATE ${TBB_COMMON_LINK_FLAGS})
+            endif()
+            target_link_libraries(test_malloc_whitebox PRIVATE Threads::Threads ${TBB_COMMON_LINK_LIBS})
+	endif()
         # ------------------------------------------------------------------------------------------
 
         # Define TBB malloc conformance tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2024 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -593,7 +593,7 @@ if (TARGET TBB::tbbmalloc)
         endif()
         # ----------------------------------------------------------------------------------------
         # Whitebox testing
-	if (NOT TBB_EMSCRIPTEN)
+        if (NOT TBB_EMSCRIPTEN)
 	    add_executable(test_malloc_whitebox tbbmalloc/test_malloc_whitebox.cpp)
 
             target_include_directories(test_malloc_whitebox
@@ -625,7 +625,7 @@ if (TARGET TBB::tbbmalloc)
                 target_link_libraries(test_malloc_whitebox PRIVATE ${TBB_COMMON_LINK_FLAGS})
             endif()
             target_link_libraries(test_malloc_whitebox PRIVATE Threads::Threads ${TBB_COMMON_LINK_LIBS})
-	endif()
+        endif()
         # ------------------------------------------------------------------------------------------
 
         # Define TBB malloc conformance tests

--- a/test/conformance/conformance_blocked_rangeNd.cpp
+++ b/test/conformance/conformance_blocked_rangeNd.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2017-2021 Intel Corporation
+    Copyright (c) 2017-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/conformance/conformance_blocked_rangeNd.cpp
+++ b/test/conformance/conformance_blocked_rangeNd.cpp
@@ -245,6 +245,7 @@ TEST_CASE("Serial test") {
     SerialTest<N>();
 }
 
+#if !EMSCRIPTEN
 //! Testing blocked_rangeNd interface with parallel_for
 //! \brief \ref requirement
 TEST_CASE("Parallel test") {
@@ -253,6 +254,7 @@ TEST_CASE("Parallel test") {
         ParallelTest<N>();
     }
 }
+#endif
 
 //! Testing blocked_rangeNd with proportional splitting
 //! \brief \ref interface \ref requirement

--- a/test/conformance/conformance_parallel_for.cpp
+++ b/test/conformance/conformance_parallel_for.cpp
@@ -399,7 +399,9 @@ TEST_CASE("Flog test") {
     Flog<parallel_tag, 10>();
     Flog<parallel_tag, 100>();
     Flog<parallel_tag, 1000>();
+#if !EMSCRIPTEN    
     Flog<parallel_tag, 10000>();
+#endif
 }
 
 //! Testing parallel for with different types and step

--- a/test/conformance/conformance_parallel_for.cpp
+++ b/test/conformance/conformance_parallel_for.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_collaborative_call_once.cpp
+++ b/test/tbb/test_collaborative_call_once.cpp
@@ -206,6 +206,7 @@ TEST_CASE("only calls once - move only argument") {
     }
 }
 
+#if !EMSCRIPTEN
 //! Stress test for functor to be called only once
 //! \brief \ref interface \ref requirement \ref stress
 TEST_CASE("only calls once - stress test") {
@@ -246,7 +247,7 @@ TEST_CASE("only calls once - stress test") {
         });
     }
 }
-
+#endif
 #if TBB_USE_EXCEPTIONS
 
 //! Test for collaborative_call_once exception handling
@@ -324,6 +325,7 @@ TEST_CASE("handles exceptions - stress test") {
 
 #endif
 
+#if !EMSCRIPTEN
 //! Test for multiple help from moonlighting threads
 //! \brief \ref interface \ref requirement
 TEST_CASE("multiple help") {
@@ -341,6 +343,7 @@ TEST_CASE("multiple help") {
         });
     });
 }
+#endif
 
 //! Test for collaborative work from different arenas
 //! \brief \ref interface \ref requirement

--- a/test/tbb/test_collaborative_call_once.cpp
+++ b/test/tbb/test_collaborative_call_once.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2022 Intel Corporation
+    Copyright (c) 2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_collaborative_call_once.cpp
+++ b/test/tbb/test_collaborative_call_once.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2024 Intel Corporation
+    Copyright (c) 2022-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_eh_algorithms.cpp
+++ b/test/tbb/test_eh_algorithms.cpp
@@ -401,7 +401,7 @@ TEST_CASE("parallel_for and parallel_reduce exception handling test #0") {
         }
     }
 }
-
+#if !EMSCRIPTEN
 //! Testing parallel_for and parallel_reduce exception handling
 //! \brief \ref error_guessing
 TEST_CASE("parallel_for and parallel_reduce exception handling test #1") {
@@ -487,7 +487,7 @@ TEST_CASE("parallel_for and parallel_reduce exception handling test #4") {
 }
 
 #endif /* TBB_USE_EXCEPTIONS */
-
+#endif
 class ParForBodyToCancel {
 public:
     void operator()( const range_type& ) const {

--- a/test/tbb/test_eh_algorithms.cpp
+++ b/test/tbb/test_eh_algorithms.cpp
@@ -698,6 +698,7 @@ TEST_CASE("parallel_for and parallel_reduce cancellation test #1") {
     }
 }
 
+#if !EMSCRIPTEN
 //! Testing parallel_for and parallel_reduce cancellation
 //! \brief \ref error_guessing
 TEST_CASE("parallel_for and parallel_reduce cancellation test #2") {
@@ -718,6 +719,7 @@ TEST_CASE("parallel_for and parallel_reduce cancellation test #2") {
         }
     }
 }
+#endif
 
 //! Testing parallel_for and parallel_reduce cancellation
 //! \brief \ref error_guessing
@@ -1033,6 +1035,7 @@ void Test5_parallel_for_each () {
     }
 } // void Test5_parallel_for_each ()
 
+#if !EMSCRIPTEN
 //! Testing parallel_for_each exception handling
 //! \brief \ref error_guessing
 TEST_CASE("parallel_for_each exception handling test #1") {
@@ -1053,6 +1056,7 @@ TEST_CASE("parallel_for_each exception handling test #1") {
         }
     }
 }
+#endif
 
 //! Testing parallel_for_each exception handling
 //! \brief \ref error_guessing
@@ -1075,6 +1079,7 @@ TEST_CASE("parallel_for_each exception handling test #2") {
     }
 }
 
+#if !EMSCRIPTEN
 //! Testing parallel_for_each exception handling
 //! \brief \ref error_guessing
 TEST_CASE("parallel_for_each exception handling test #3") {
@@ -1095,6 +1100,7 @@ TEST_CASE("parallel_for_each exception handling test #3") {
         }
     }
 }
+#endif
 
 //! Testing parallel_for_each exception handling
 //! \brief \ref error_guessing
@@ -1117,6 +1123,7 @@ TEST_CASE("parallel_for_each exception handling test #4") {
     }
 }
 
+#if !EMSCRIPTEN
 //! Testing parallel_for_each exception handling
 //! \brief \ref error_guessing
 TEST_CASE("parallel_for_each exception handling test #5") {
@@ -1139,7 +1146,7 @@ TEST_CASE("parallel_for_each exception handling test #5") {
         }
     }
 }
-
+#endif
 #endif /* TBB_USE_EXCEPTIONS */
 
 class ParForEachBodyToCancel {
@@ -1237,6 +1244,7 @@ TEST_CASE("parallel_for_each cancellation test #1") {
     }
 }
 
+#if !EMSCRIPTEN
 //! Testing parallel_for_each cancellation test
 //! \brief \ref error_guessing
 TEST_CASE("parallel_for_each cancellation test #2") {
@@ -1257,7 +1265,7 @@ TEST_CASE("parallel_for_each cancellation test #2") {
         }
     }
 }
-
+#endif
 ////////////////////////////////////////////////////////////////////////////////
 // Tests for tbb::parallel_pipeline
 ////////////////////////////////////////////////////////////////////////////////
@@ -1608,6 +1616,7 @@ void TestWithDifferentFiltersAndConcurrency() {
 #endif
 }
 
+#if !EMSCRIPTEN
 //! Testing parallel_pipeline exception handling
 //! \brief \ref error_guessing
 TEST_CASE("parallel_pipeline exception handling test #1") {
@@ -1631,7 +1640,7 @@ TEST_CASE("parallel_pipeline exception handling test #3") {
 TEST_CASE("parallel_pipeline exception handling test #4") {
     TestWithDifferentFiltersAndConcurrency<Test4_pipeline>();
 }
-
+#endif
 #endif /* TBB_USE_EXCEPTIONS */
 
 class FilterToCancel  {
@@ -1727,6 +1736,7 @@ TEST_CASE("parallel_pipeline cancellation test #1") {
     }
 }
 
+#if !EMSCRIPTEN
 //! Testing parallel_pipeline cancellation
 //! \brief \ref error_guessing
 TEST_CASE("parallel_pipeline cancellation test #2") {
@@ -1748,3 +1758,4 @@ TEST_CASE("parallel_pipeline cancellation test #2") {
         }
     }
 }
+#endif

--- a/test/tbb/test_eh_algorithms.cpp
+++ b/test/tbb/test_eh_algorithms.cpp
@@ -486,8 +486,8 @@ TEST_CASE("parallel_for and parallel_reduce exception handling test #4") {
     }
 }
 
-#endif /* TBB_USE_EXCEPTIONS */
 #endif
+#endif /* TBB_USE_EXCEPTIONS */
 class ParForBodyToCancel {
 public:
     void operator()( const range_type& ) const {

--- a/test/tbb/test_eh_algorithms.cpp
+++ b/test/tbb/test_eh_algorithms.cpp
@@ -1224,6 +1224,7 @@ void TestCancelation2_parallel_for_each () {
     RunCancellationTest<ParForEachWorker<body_to_cancel, Iterator>, Cancellator2>();
 }
 
+#if !EMSCRIPTEN
 //! Testing parallel_for_each cancellation test
 //! \brief \ref error_guessing
 TEST_CASE("parallel_for_each cancellation test #1") {
@@ -1244,7 +1245,6 @@ TEST_CASE("parallel_for_each cancellation test #1") {
     }
 }
 
-#if !EMSCRIPTEN
 //! Testing parallel_for_each cancellation test
 //! \brief \ref error_guessing
 TEST_CASE("parallel_for_each cancellation test #2") {
@@ -1266,6 +1266,7 @@ TEST_CASE("parallel_for_each cancellation test #2") {
     }
 }
 #endif
+
 ////////////////////////////////////////////////////////////////////////////////
 // Tests for tbb::parallel_pipeline
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/tbb/test_eh_algorithms.cpp
+++ b/test/tbb/test_eh_algorithms.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_eh_flow_graph.cpp
+++ b/test/tbb/test_eh_flow_graph.cpp
@@ -2017,6 +2017,7 @@ void TestOneThreadNum(int nThread) {
     );
 }
 
+#if !EMSCRIPTEN
 //! Test exceptions with parallelism
 //! \brief \ref error_guessing
 TEST_CASE("Testing several threads"){
@@ -2026,5 +2027,5 @@ TEST_CASE("Testing several threads"){
         TestOneThreadNum(nThread);
     }
 }
-
+#endif
 #endif // TBB_USE_EXCEPTIONS

--- a/test/tbb/test_eh_flow_graph.cpp
+++ b/test/tbb/test_eh_flow_graph.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_flow_graph_priorities.cpp
+++ b/test/tbb/test_flow_graph_priorities.cpp
@@ -842,6 +842,7 @@ TEST_CASE("Priority nodes take precedence"){
     }
 }
 
+#if !EMSCRIPTEN
 //! Test thread eager reaction
 //! \brief \ref error_guessing
 TEST_CASE("Thread eager reaction"){
@@ -849,6 +850,7 @@ TEST_CASE("Thread eager reaction"){
         ThreadsEagerReaction::test( static_cast<int>(p) );
     }
 }
+#endif
 
 //! Test prioritization under concurrency limits
 //! \brief \ref error_guessing
@@ -888,3 +890,4 @@ TEST_CASE("Exceptions") {
     Exceptions::test();
 }
 #endif
+

--- a/test/tbb/test_flow_graph_priorities.cpp
+++ b/test/tbb/test_flow_graph_priorities.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2018-2021 Intel Corporation
+    Copyright (c) 2018-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_global_control.cpp
+++ b/test/tbb/test_global_control.cpp
@@ -245,11 +245,13 @@ TEST_CASE("prolong lifetime advanced") {
 }
 #endif
 
+#if !EMSCRIPTEN
 //! Testing multiple wait
 //! \brief \ref error_guessing
 TEST_CASE("prolong lifetime multiple wait") {
     TestBlockingTerminateNS::TestMultpleWait();
 }
+#endif
 
 //! \brief \ref regression
 TEST_CASE("test concurrent task_scheduler_handle destruction") {

--- a/test/tbb/test_global_control.cpp
+++ b/test/tbb/test_global_control.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_mutex.cpp
+++ b/test/tbb/test_mutex.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_mutex.cpp
+++ b/test/tbb/test_mutex.cpp
@@ -109,7 +109,6 @@ void TestTransaction(const char* name)
     REQUIRE_MESSAGE(n_transactions_attempted.load(std::memory_order_relaxed), "ERROR for " << name << ": transactions were never attempted");
 }
 
-
 //! \brief \ref error_guessing
 TEST_CASE("Transaction test") {
     if (have_TSX()) {
@@ -118,6 +117,7 @@ TEST_CASE("Transaction test") {
     }
 }
 #endif /* __TBB_TSX_TESTING_ENABLED_FOR_THIS_COMPILER */
+
 
 //! \brief \ref error_guessing
 TEST_CASE("test upgrade/downgrade with spin_rw_mutex") {
@@ -144,10 +144,12 @@ TEST_CASE("test spin_mutex with native threads") {
     test_with_native_threads::test<tbb::spin_mutex>();
 }
 
+#if !EMSCRIPTEN
 //! \brief \ref error_guessing
 TEST_CASE("test queuing_mutex with native threads") {
     test_with_native_threads::test<tbb::queuing_mutex>();
 }
+#endif
 
 //! \brief \ref error_guessing
 TEST_CASE("test mutex with native threads") {
@@ -160,11 +162,13 @@ TEST_CASE("test spin_rw_mutex with native threads") {
     test_with_native_threads::test_rw<tbb::spin_rw_mutex>();
 }
 
+#if !EMSCRIPTEN
 //! \brief \ref error_guessing
 TEST_CASE("test queuing_rw_mutex with native threads") {
     test_with_native_threads::test<tbb::queuing_rw_mutex>();
     test_with_native_threads::test_rw<tbb::queuing_rw_mutex>();
 }
+#endif
 
 //! \brief \ref error_guessing
 TEST_CASE("test rw_mutex with native threads") {
@@ -197,3 +201,4 @@ TEST_CASE("internal mutex concepts") {
                              tbb::null_rw_mutex, tbb::queuing_rw_mutex>);
 }
 #endif // __TBB_CPP20_CONCEPTS_PRESENT
+

--- a/test/tbb/test_resumable_tasks.cpp
+++ b/test/tbb/test_resumable_tasks.cpp
@@ -423,6 +423,7 @@ public:
 
 thread_local bool TestCaseGuard::m_local = false;
 
+#if !EMSCRIPTEN
 //! Nested test for suspend and resume
 //! \brief \ref error_guessing
 TEST_CASE("Nested test for suspend and resume") {
@@ -436,6 +437,7 @@ TEST_CASE("Nested arena") {
     TestCaseGuard guard;
     TestNestedArena();
 }
+#endif
 
 //! Test with external threads
 //! \brief \ref error_guessing
@@ -443,11 +445,13 @@ TEST_CASE("External threads") {
     TestNativeThread();
 }
 
+#if !EMSCRIPTEN
 //! Stress test with external threads
 //! \brief \ref stress
 TEST_CASE("Stress test with external threads") {
     TestCleanupMaster();
 }
+#endif
 
 //! Test with an arena observer
 //! \brief \ref error_guessing

--- a/test/tbb/test_resumable_tasks.cpp
+++ b/test/tbb/test_resumable_tasks.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description 
Omitting tests using macro "EMSCRIPTEN", so that CI doesn't take very long.


Fixes # - _issue number(s) if exists_

- [ ] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
