### PR TITLE
Refactor node structure. Replace nodes in parallel_for and parallel_reduce

### DIFF
--- a/include/oneapi/tbb/parallel_for.h
+++ b/include/oneapi/tbb/parallel_for.h
@@ -61,7 +61,7 @@ template<typename Range, typename Body, typename Partitioner>
 struct start_for : public task {
     Range my_range;
     const Body my_body;
-    node* my_parent;
+    wait_tree_node_interface* my_wait_tree_node;
 
     typename Partitioner::task_partition_type my_partition;
     small_object_allocator my_allocator;
@@ -74,7 +74,7 @@ struct start_for : public task {
     start_for( const Range& range, const Body& body, Partitioner& partitioner, small_object_allocator& alloc ) :
         my_range(range),
         my_body(body),
-        my_parent(nullptr),
+        my_wait_tree_node(nullptr),
         my_partition(partitioner),
         my_allocator(alloc) {}
     //! Splitting constructor used to generate children.
@@ -82,7 +82,7 @@ struct start_for : public task {
     start_for( start_for& parent_, typename Partitioner::split_type& split_obj, small_object_allocator& alloc ) :
         my_range(parent_.my_range, get_range_split_object<Range>(split_obj)),
         my_body(parent_.my_body),
-        my_parent(nullptr),
+        my_wait_tree_node(nullptr),
         my_partition(parent_.my_partition, split_obj),
         my_allocator(alloc) {}
     //! Construct right child from the given range as response to the demand.
@@ -90,7 +90,7 @@ struct start_for : public task {
     start_for( start_for& parent_, const Range& r, depth_t d, small_object_allocator& alloc ) :
         my_range(r),
         my_body(parent_.my_body),
-        my_parent(nullptr),
+        my_wait_tree_node(nullptr),
         my_partition(parent_.my_partition, split()),
         my_allocator(alloc)
     {
@@ -106,10 +106,9 @@ struct start_for : public task {
             small_object_allocator alloc{};
             start_for& for_task = *alloc.new_object<start_for>(range, body, partitioner, alloc);
 
-            // defer creation of the wait node until task allocation succeeds
-            wait_node wn;
-            for_task.my_parent = &wn;
-            execute_and_wait(for_task, context, wn.m_wait, context);
+            wait_context_node wn{1};
+            for_task.my_wait_tree_node = &wn;
+            execute_and_wait(for_task, context, wn.get_context(), context);
         }
     }
     //! Run body for range, serves as callback for partitioner
@@ -135,7 +134,7 @@ private:
         start_for& right_child = *alloc.new_object<start_for>(ed, std::forward<Args>(constructor_args)..., alloc);
 
         // New root node as a continuation and ref count. Left and right child attach to the new parent.
-        right_child.my_parent = my_parent = alloc.new_object<tree_node>(ed, my_parent, 2, alloc);
+        right_child.my_wait_tree_node = my_wait_tree_node = alloc.new_object<partitioner_node>(ed, my_wait_tree_node, 2, alloc);
         // Spawn the right sibling
         right_child.spawn_self(ed);
     }
@@ -149,13 +148,13 @@ private:
 template<typename Range, typename Body, typename Partitioner>
 void start_for<Range, Body, Partitioner>::finalize(const execution_data& ed) {
     // Get the current parent and allocator an object destruction
-    node* parent = my_parent;
+    wait_tree_node_interface* wait_tree_node = my_wait_tree_node;
     auto allocator = my_allocator;
     // Task execution finished - destroy it
     this->~start_for();
     // Unwind the tree decrementing the parent`s reference count
 
-    fold_tree<tree_node>(parent, ed);
+    wait_tree_node->release(1, ed);
     allocator.deallocate(this, ed);
 
 }

--- a/include/oneapi/tbb/partitioner.h
+++ b/include/oneapi/tbb/partitioner.h
@@ -113,36 +113,15 @@ template<typename Range, typename Body, typename Partitioner> struct start_scan;
 template<typename Range, typename Body, typename Partitioner> struct start_reduce;
 template<typename Range, typename Body, typename Partitioner> struct start_deterministic_reduce;
 
-struct node {
-    node* my_parent{};
-    std::atomic<int> m_ref_count{};
-
-    node() = default;
-    node(node* parent, int ref_count) :
-        my_parent{parent}, m_ref_count{ref_count} {
-        __TBB_ASSERT(ref_count > 0, "The ref count must be positive");
-    }
-};
-
-struct wait_node : node {
-    wait_node() : node{ nullptr, 1 } {}
-    wait_context m_wait{1};
-};
-
-//! Join task node that contains shared flag for stealing feedback
-struct tree_node : public node {
-    small_object_allocator m_allocator;
-    std::atomic<bool> m_child_stolen{false};
-
-    tree_node(node* parent, int ref_count, small_object_allocator& alloc)
-        : node{parent, ref_count}
+class partitioner_node : public reference_node {
+public:
+    partitioner_node(wait_tree_node_interface* parent, std::uint32_t ref_count, small_object_allocator& alloc)
+        : reference_node{static_cast<reference_node*>(parent), ref_count}
         , m_allocator{alloc} {}
-
-    void join(task_group_context*) {/*dummy, required only for reduction algorithms*/};
 
     template <typename Task>
     static void mark_task_stolen(Task &t) {
-        std::atomic<bool> &flag = static_cast<tree_node*>(t.my_parent)->m_child_stolen;
+        std::atomic<bool> &flag = static_cast<partitioner_node*>(t.my_wait_tree_node)->m_child_stolen;
 #if TBB_USE_PROFILING_TOOLS
         // Threading tools respect lock prefix but report false-positive data-race via plain store
         flag.exchange(true);
@@ -152,34 +131,28 @@ struct tree_node : public node {
     }
     template <typename Task>
     static bool is_peer_stolen(Task &t) {
-        return static_cast<tree_node*>(t.my_parent)->m_child_stolen.load(std::memory_order_relaxed);
+        return static_cast<partitioner_node*>(t.my_wait_tree_node)->m_child_stolen.load(std::memory_order_relaxed);
     }
+
+    template <typename Task>
+    static bool is_concurrent_task(Task &t) {
+        return static_cast<partitioner_node*>(t.my_wait_tree_node)->get_num_child() >= 2;
+    }
+
+protected:
+    small_object_allocator m_allocator;
+
+private:
+    void destroy(const d1::execution_data& ed) override {
+        m_allocator.delete_object(this, ed);
+    }
+
+    void destroy() override {
+        __TBB_ASSERT(false, "Overaload without d1::execution_data is called");
+    }
+
+    std::atomic<bool> m_child_stolen{false};
 };
-
-// Context used to check cancellation state during reduction join process
-template<typename TreeNodeType>
-void fold_tree(node* n, const execution_data& ed) {
-    for (;;) {
-        __TBB_ASSERT(n, nullptr);
-        __TBB_ASSERT(n->m_ref_count.load(std::memory_order_relaxed) > 0, "The refcount must be positive.");
-        call_itt_task_notify(releasing, n);
-        if (--n->m_ref_count > 0) {
-            return;
-        }
-        node* parent = n->my_parent;
-        if (!parent) {
-            break;
-        };
-
-        call_itt_task_notify(acquired, n);
-        TreeNodeType* self = static_cast<TreeNodeType*>(n);
-        self->join(ed.context);
-        self->m_allocator.delete_object(self, ed);
-        n = parent;
-    }
-    // Finish parallel for execution when the root (last node) is reached
-    static_cast<wait_node*>(n)->m_wait.release();
-}
 
 //! Depth is a relative depth of recursive division inside a range pool. Relative depth allows
 //! infinite absolute depth of the recursion for heavily unbalanced workloads with range represented
@@ -408,7 +381,7 @@ struct dynamic_grainsize_mode : Mode {
     bool check_being_stolen(Task &t, const execution_data& ed) { // part of old should_execute_range()
         if( !(self().my_divisor / Mode::my_partition::factor) ) { // if not from the top P tasks of binary tree
             self().my_divisor = 1; // TODO: replace by on-stack flag (partition_state's member)?
-            if( is_stolen_task(ed) && t.my_parent->m_ref_count >= 2 ) { // runs concurrently with the left task
+            if( is_stolen_task(ed) && partitioner_node::is_concurrent_task(t) ) { // runs concurrently with the left task
 #if __TBB_USE_OPTIONAL_RTTI
                 // RTTI is available, check whether the cast is valid
                 // TODO: TBB_REVAMP_TODO __TBB_ASSERT(dynamic_cast<tree_node*>(t.m_parent), 0);
@@ -416,7 +389,7 @@ struct dynamic_grainsize_mode : Mode {
                 // - initial value of my_divisor != 0 (protected by separate assertion)
                 // - is_stolen_task() always returns false for the root task.
 #endif
-                tree_node::mark_task_stolen(t);
+                partitioner_node::mark_task_stolen(t);
                 if( !my_max_depth ) my_max_depth++;
                 my_max_depth += __TBB_DEMAND_DEPTH_ADD;
                 return true;
@@ -461,7 +434,7 @@ struct dynamic_grainsize_mode : Mode {
                 self().my_divisor = 0; // once for each task; depth will be decreased in align_depth()
                 return true;
             }
-            else if ( tree_node::is_peer_stolen(t) ) {
+            else if ( partitioner_node::is_peer_stolen(t) ) {
                 my_max_depth += __TBB_DEMAND_DEPTH_ADD;
                 return true;
             }
@@ -490,7 +463,7 @@ public:
     }
     template <typename Task>
     bool check_for_demand(Task& t) {
-        if (tree_node::is_peer_stolen(t)) {
+        if (partitioner_node::is_peer_stolen(t)) {
             my_max_depth += __TBB_DEMAND_DEPTH_ADD;
             return true;
         } else return false;


### PR DESCRIPTION
### Description 
Refactor node structure to reuse it latter for scalability improvements in the library. E.g., https://github.com/oneapi-src/oneTBB/pull/1310 


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
