### PR TITLE
cmake apple framework support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,9 @@ option(TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH "Disable HWLOC automatic search by pkg
 option(TBB_ENABLE_IPO "Enable Interprocedural Optimization (IPO) during the compilation" ON)
 option(TBB_FUZZ_TESTING "Enable fuzz testing" OFF)
 option(TBB_INSTALL "Enable installation" ON)
+if(APPLE)
+option(TBB_BUILD_APPLE_FRAMEWORKS "Build as Apple Frameworks" OFF)
+endif()
 
 if (NOT DEFINED BUILD_SHARED_LIBS)
     set(BUILD_SHARED_LIBS ON)

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -19,6 +19,7 @@ TBB_INSTALL_VARS:BOOL - Enable auto-generated vars installation(packages generat
 TBB_VALGRIND_MEMCHECK:BOOL - Enable scan for memory leaks using Valgrind (OFF by default)
 TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH - Disable HWLOC automatic search by pkg-config tool (OFF by default)
 TBB_ENABLE_IPO - Enable Interprocedural Optimization (IPO) during the compilation (ON by default)
+TBB_BUILD_APPLE_FRAMEWORKS - Enable building Apple .frameworks instead of dylibs, only available on Apple platform. (OFF by default)
 ```
 
 ## Configure, Build, and Test

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -19,7 +19,7 @@ TBB_INSTALL_VARS:BOOL - Enable auto-generated vars installation(packages generat
 TBB_VALGRIND_MEMCHECK:BOOL - Enable scan for memory leaks using Valgrind (OFF by default)
 TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH - Disable HWLOC automatic search by pkg-config tool (OFF by default)
 TBB_ENABLE_IPO - Enable Interprocedural Optimization (IPO) during the compilation (ON by default)
-TBB_BUILD_APPLE_FRAMEWORKS - Enable building Apple .frameworks instead of dylibs, only available on Apple platform. (OFF by default)
+TBB_BUILD_APPLE_FRAMEWORKS - Enable the Apple* frameworks instead of dylibs, only available on the Apple platform. (OFF by default)
 ```
 
 ## Configure, Build, and Test

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2024 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -35,7 +35,11 @@ macro(tbb_install_target target)
                 COMPONENT runtime
             ARCHIVE
                 DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT devel)
+                COMPONENT devel
+            FRAMEWORK
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT runtime
+                OPTIONAL)
 
         if (BUILD_SHARED_LIBS)
             install(TARGETS ${target}

--- a/cmake/vars_utils.cmake
+++ b/cmake/vars_utils.cmake
@@ -29,8 +29,8 @@ macro(tbb_gen_vars target)
     if (NOT TBB_BUILD_APPLE_FRAMEWORKS)
         set(BIN_PATH $<TARGET_FILE_DIR:${target}>)
     else()
-        # For Apple frameworks, the binaries are placed in a framework bundle. 
-        # When using an Apple framework, you refer to the bundle, not the binary inside, so we take the bundle's path and go up one level.
+        # For Apple* frameworks, the binaries are placed in a framework bundle. 
+        # When using an Apple* framework, you refer to the bundle, not the binary inside, so we take the bundle's path and go up one level.
         # This path will then be used to generate the vars file, and the contents of the vars file will use the bundle's parent directory.
         set(BIN_PATH $<TARGET_BUNDLE_DIR:${target}>/..)
     endif()

--- a/cmake/vars_utils.cmake
+++ b/cmake/vars_utils.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2024 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/vars_utils.cmake
+++ b/cmake/vars_utils.cmake
@@ -26,12 +26,20 @@ get_filename_component(TBB_VARS_TEMPLATE_NAME ${PROJECT_SOURCE_DIR}/integration/
 string(REPLACE ".in" "" TBB_VARS_NAME ${TBB_VARS_TEMPLATE_NAME})
 
 macro(tbb_gen_vars target)
+    if (NOT TBB_BUILD_APPLE_FRAMEWORKS)
+        set(BIN_PATH $<TARGET_FILE_DIR:${target}>)
+    else()
+        # For Apple frameworks, the binaries are placed in a framework bundle. 
+        # When using an Apple framework, you refer to the bundle, not the binary inside, so we take the bundle's path and go up one level.
+        # This path will then be used to generate the vars file, and the contents of the vars file will use the bundle's parent directory.
+        set(BIN_PATH $<TARGET_BUNDLE_DIR:${target}>/..)
+    endif()
     if (${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
         add_custom_command(TARGET ${target} POST_BUILD COMMAND
             ${CMAKE_COMMAND}
             -DBINARY_DIR=${CMAKE_BINARY_DIR}
             -DSOURCE_DIR=${PROJECT_SOURCE_DIR}
-            -DBIN_PATH=$<TARGET_FILE_DIR:${target}>
+            -DBIN_PATH=${BIN_PATH}
             -DVARS_TEMPLATE=${TBB_VARS_TEMPLATE}
             -DVARS_NAME=${TBB_VARS_NAME}
             -DTBB_INSTALL_VARS=${TBB_INSTALL_VARS}

--- a/src/tbb/CMakeLists.txt
+++ b/src/tbb/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2024 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/tbb/CMakeLists.txt
+++ b/src/tbb/CMakeLists.txt
@@ -191,7 +191,6 @@ if (TBB_INSTALL)
             COMPONENT devel)
 endif()
 
-# not useful when bundled into a framework
-if (COMMAND tbb_gen_vars AND NOT TBB_BUILD_APPLE_FRAMEWORKS)
+if (COMMAND tbb_gen_vars)
     tbb_gen_vars(tbb)
 endif()

--- a/src/tbb/CMakeLists.txt
+++ b/src/tbb/CMakeLists.txt
@@ -126,6 +126,16 @@ target_link_libraries(tbb
     ${TBB_COMMON_LINK_LIBS}
 )
 
+if(TBB_BUILD_APPLE_FRAMEWORKS)
+    set_target_properties(tbb PROPERTIES
+        FRAMEWORK TRUE
+        FRAMEWORK_VERSION ${TBB_BINARY_VERSION}.${TBB_BINARY_MINOR_VERSION}
+        XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.intel.tbb
+        MACOSX_FRAMEWORK_IDENTIFIER com.intel.tbb
+        MACOSX_FRAMEWORK_BUNDLE_VERSION ${TBB_BINARY_VERSION}.${TBB_BINARY_MINOR_VERSION}
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${TBB_BINARY_VERSION})
+endif()
+
 tbb_install_target(tbb)
 
 if (TBB_INSTALL)
@@ -181,6 +191,7 @@ if (TBB_INSTALL)
             COMPONENT devel)
 endif()
 
-if (COMMAND tbb_gen_vars)
+# not useful when bundled into a framework
+if (COMMAND tbb_gen_vars AND NOT TBB_BUILD_APPLE_FRAMEWORKS)
     tbb_gen_vars(tbb)
 endif()

--- a/src/tbbmalloc/CMakeLists.txt
+++ b/src/tbbmalloc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2024 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/tbbmalloc/CMakeLists.txt
+++ b/src/tbbmalloc/CMakeLists.txt
@@ -109,5 +109,15 @@ target_link_libraries(tbbmalloc
     ${TBB_COMMON_LINK_LIBS}
 )
 
-tbb_install_target(tbbmalloc)
+if(TBB_BUILD_APPLE_FRAMEWORKS)
+    set_target_properties(tbbmalloc PROPERTIES 
+        FRAMEWORK TRUE
+        FRAMEWORK_VERSION ${TBBMALLOC_BINARY_VERSION}.${TBB_BINARY_MINOR_VERSION}
+        XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.intel.tbbmalloc
+        MACOSX_FRAMEWORK_IDENTIFIER com.intel.tbbmalloc
+        MACOSX_FRAMEWORK_BUNDLE_VERSION ${TBBMALLOC_BINARY_VERSION}.${TBB_BINARY_MINOR_VERSION}
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${TBBMALLOC_BINARY_VERSION}
+    )
+endif()
 
+tbb_install_target(tbbmalloc)

--- a/src/tbbmalloc_proxy/CMakeLists.txt
+++ b/src/tbbmalloc_proxy/CMakeLists.txt
@@ -90,4 +90,14 @@ target_link_libraries(tbbmalloc_proxy
     ${TBB_COMMON_LINK_LIBS}
 )
 
+if(TBB_BUILD_APPLE_FRAMEWORKS)
+    set_target_properties(tbbmalloc_proxy PROPERTIES 
+        FRAMEWORK TRUE
+        FRAMEWORK_VERSION ${TBBMALLOC_BINARY_VERSION}.${TBB_BINARY_MINOR_VERSION}
+        XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.intel.tbbmalloc-proxy
+        MACOSX_FRAMEWORK_IDENTIFIER com.intel.tbbmalloc-proxy
+        MACOSX_FRAMEWORK_BUNDLE_VERSION ${TBBMALLOC_BINARY_VERSION}.${TBB_BINARY_MINOR_VERSION}
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${TBBMALLOC_BINARY_VERSION})
+endif()
+
 tbb_install_target(tbbmalloc_proxy)

--- a/src/tbbmalloc_proxy/CMakeLists.txt
+++ b/src/tbbmalloc_proxy/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022 Intel Corporation
+# Copyright (c) 2020-2024 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,10 @@ function(tbb_add_test)
         ${TBB_COMMON_COMPILE_FLAGS}
     )
 
+    if (TBB_BUILD_APPLE_FRAMEWORKS)
+        add_compile_definitions(TBB_USE_APPLE_FRAMEWORKS)
+    endif()
+
     if (ANDROID_PLATFORM)
         # Expand the linker rpath by the CMAKE_LIBRARY_OUTPUT_DIRECTORY path since clang compiler from Android SDK
         # doesn't respect the -L flag.

--- a/test/common/utils_dynamic_libs.h
+++ b/test/common/utils_dynamic_libs.h
@@ -47,7 +47,7 @@ namespace utils {
 #define EXT ".dll"
 #else
 #if TBB_USE_APPLE_FRAMEWORKS
-#define PREFIX // When build as Apple* Framework, the binary has no lib prefix
+#define PREFIX // When built as Apple* Framework, the binary has no lib prefix
 #else
 #define PREFIX "lib"
 #endif

--- a/test/common/utils_dynamic_libs.h
+++ b/test/common/utils_dynamic_libs.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -38,11 +38,11 @@ namespace utils {
 #define SUFFIX2 "_debug"
 #endif /* TBB_USE_DEBUG */
 
-#if (_WIN32||_WIN64)
+#if (_WIN32 || _WIN64)
 #if __MINGW32__
-    #define PREFIX "lib"
+#define PREFIX "lib"
 #else
-    #define PREFIX
+#define PREFIX
 #endif
 #define EXT ".dll"
 #else
@@ -60,8 +60,8 @@ namespace utils {
 // Android SDK build system does not support .so file name versioning
 #elif __FreeBSD__ || __NetBSD__ || __sun || _AIX || __ANDROID__
 #define EXT ".so"
-#elif __unix__  // Order of these elif's matters!
-#define EXT __TBB_STRING(.so.2)
+#elif __unix__ // Order of these elif's matters!
+#define EXT __TBB_STRING(.so .2)
 #else
 #error Unknown OS
 #endif
@@ -79,7 +79,7 @@ namespace utils {
 #if _WIN32 || _WIN64
 using LIBRARY_HANDLE = HMODULE;
 #else
-using LIBRARY_HANDLE = void*;
+using LIBRARY_HANDLE = void *;
 #endif
 
 #if _WIN32 || _WIN64
@@ -90,53 +90,51 @@ using LIBRARY_HANDLE = void*;
 #define TEST_LIBRARY_NAME(base) PREFIX base SUFFIX1 ".so"
 #endif
 
-LIBRARY_HANDLE OpenLibrary(const char *name)
-{
+LIBRARY_HANDLE OpenLibrary(const char *name) {
 #if _WIN32 || _WIN64
 #if __TBB_WIN8UI_SUPPORT
-    TCHAR wlibrary[MAX_PATH];
-    if (MultiByteToWideChar(CP_UTF8, 0, name, -1, wlibrary, MAX_PATH) == 0) return false;
-    return ::LoadPackagedLibrary(wlibrary, 0);
+  TCHAR wlibrary[MAX_PATH];
+  if (MultiByteToWideChar(CP_UTF8, 0, name, -1, wlibrary, MAX_PATH) == 0)
+    return false;
+  return ::LoadPackagedLibrary(wlibrary, 0);
 #else
-    return ::LoadLibrary(name);
+  return ::LoadLibrary(name);
 #endif
 #else
-    return dlopen(name, RTLD_NOW|RTLD_GLOBAL);
+  return dlopen(name, RTLD_NOW | RTLD_GLOBAL);
 #endif
 }
 
-void CloseLibrary(LIBRARY_HANDLE lib)
-{
+void CloseLibrary(LIBRARY_HANDLE lib) {
 #if _WIN32 || _WIN64
-    BOOL ret = FreeLibrary(lib);
-    REQUIRE_MESSAGE(ret, "FreeLibrary must be successful");
+  BOOL ret = FreeLibrary(lib);
+  REQUIRE_MESSAGE(ret, "FreeLibrary must be successful");
 #else
-    int ret = dlclose(lib);
-    REQUIRE_MESSAGE(ret == 0, "dlclose must be successful");
+  int ret = dlclose(lib);
+  REQUIRE_MESSAGE(ret == 0, "dlclose must be successful");
 #endif
 }
 
 typedef void (*FunctionAddress)();
 
 template <typename FunctionPointer>
-void GetAddress(utils::LIBRARY_HANDLE lib, const char *name, FunctionPointer& func)
-{
+void GetAddress(utils::LIBRARY_HANDLE lib, const char *name,
+                FunctionPointer &func) {
 #if _WIN32 || _WIN64
-    func = (FunctionPointer)(void*)GetProcAddress(lib, name);
+  func = (FunctionPointer)(void *)GetProcAddress(lib, name);
 #else
-    func = (FunctionPointer)dlsym(lib, name);
+  func = (FunctionPointer)dlsym(lib, name);
 #endif
-    REQUIRE_MESSAGE(func, "Can't find required symbol in dynamic library");
+  REQUIRE_MESSAGE(func, "Can't find required symbol in dynamic library");
 }
 
-FunctionAddress GetAddress(utils::LIBRARY_HANDLE lib, const char *name)
-{
-    FunctionAddress func;
-    GetAddress(lib, name, func);
-    return func;
+FunctionAddress GetAddress(utils::LIBRARY_HANDLE lib, const char *name) {
+  FunctionAddress func;
+  GetAddress(lib, name, func);
+  return func;
 }
 
-}  // namespace utils
+} // namespace utils
 
 #endif // __TBB_DYNAMIC_LOAD_ENABLED
 #endif // __TBB_test_common_utils_dynamic_libs_H_

--- a/test/common/utils_dynamic_libs.h
+++ b/test/common/utils_dynamic_libs.h
@@ -47,13 +47,13 @@ namespace utils {
 #define EXT ".dll"
 #else
 #if TBB_USE_APPLE_FRAMEWORKS
-#define PREFIX // When build as Apple Framework, the binary has no lib prefix
+#define PREFIX // When build as Apple* Framework, the binary has no lib prefix
 #else
 #define PREFIX "lib"
 #endif
 #if __APPLE__
 #if TBB_USE_APPLE_FRAMEWORKS
-#define EXT // When build as Apple Framework, the binary has no lib prefix
+#define EXT // When built as Apple* Framework, the binary has no extension
 #else
 #define EXT ".dylib"
 #endif

--- a/test/common/utils_dynamic_libs.h
+++ b/test/common/utils_dynamic_libs.h
@@ -46,9 +46,17 @@ namespace utils {
 #endif
 #define EXT ".dll"
 #else
+#if TBB_USE_APPLE_FRAMEWORKS
+#define PREFIX // When build as Apple Framework, the binary has no lib prefix
+#else
 #define PREFIX "lib"
+#endif
 #if __APPLE__
+#if TBB_USE_APPLE_FRAMEWORKS
+#define EXT // When build as Apple Framework, the binary has no lib prefix
+#else
 #define EXT ".dylib"
+#endif
 // Android SDK build system does not support .so file name versioning
 #elif __FreeBSD__ || __NetBSD__ || __sun || _AIX || __ANDROID__
 #define EXT ".so"
@@ -58,10 +66,15 @@ namespace utils {
 #error Unknown OS
 #endif
 #endif
+#if TBB_USE_APPLE_FRAMEWORKS
+#define MALLOCFRAMEWORK "tbbmalloc.framework/"
+#else
+#define MALLOCFRAMEWORK
+#endif
 
 // Form the names of the TBB memory allocator binaries.
-#define MALLOCLIB_NAME1 PREFIX "tbbmalloc" SUFFIX1 EXT
-#define MALLOCLIB_NAME2 PREFIX "tbbmalloc" SUFFIX2 EXT
+#define MALLOCLIB_NAME1 MALLOCFRAMEWORK PREFIX "tbbmalloc" SUFFIX1 EXT
+#define MALLOCLIB_NAME2 MALLOCFRAMEWORK PREFIX "tbbmalloc" SUFFIX2 EXT
 
 #if _WIN32 || _WIN64
 using LIBRARY_HANDLE = HMODULE;

--- a/test/common/utils_dynamic_libs.h
+++ b/test/common/utils_dynamic_libs.h
@@ -38,11 +38,11 @@ namespace utils {
 #define SUFFIX2 "_debug"
 #endif /* TBB_USE_DEBUG */
 
-#if (_WIN32 || _WIN64)
+#if (_WIN32||_WIN64)
 #if __MINGW32__
-#define PREFIX "lib"
+    #define PREFIX "lib"
 #else
-#define PREFIX
+    #define PREFIX
 #endif
 #define EXT ".dll"
 #else
@@ -60,8 +60,8 @@ namespace utils {
 // Android SDK build system does not support .so file name versioning
 #elif __FreeBSD__ || __NetBSD__ || __sun || _AIX || __ANDROID__
 #define EXT ".so"
-#elif __unix__ // Order of these elif's matters!
-#define EXT __TBB_STRING(.so .2)
+#elif __unix__  // Order of these elif's matters!
+#define EXT __TBB_STRING(.so.2)
 #else
 #error Unknown OS
 #endif
@@ -79,7 +79,7 @@ namespace utils {
 #if _WIN32 || _WIN64
 using LIBRARY_HANDLE = HMODULE;
 #else
-using LIBRARY_HANDLE = void *;
+using LIBRARY_HANDLE = void*;
 #endif
 
 #if _WIN32 || _WIN64
@@ -90,51 +90,53 @@ using LIBRARY_HANDLE = void *;
 #define TEST_LIBRARY_NAME(base) PREFIX base SUFFIX1 ".so"
 #endif
 
-LIBRARY_HANDLE OpenLibrary(const char *name) {
+LIBRARY_HANDLE OpenLibrary(const char *name)
+{
 #if _WIN32 || _WIN64
 #if __TBB_WIN8UI_SUPPORT
-  TCHAR wlibrary[MAX_PATH];
-  if (MultiByteToWideChar(CP_UTF8, 0, name, -1, wlibrary, MAX_PATH) == 0)
-    return false;
-  return ::LoadPackagedLibrary(wlibrary, 0);
+    TCHAR wlibrary[MAX_PATH];
+    if (MultiByteToWideChar(CP_UTF8, 0, name, -1, wlibrary, MAX_PATH) == 0) return false;
+    return ::LoadPackagedLibrary(wlibrary, 0);
 #else
-  return ::LoadLibrary(name);
+    return ::LoadLibrary(name);
 #endif
 #else
-  return dlopen(name, RTLD_NOW | RTLD_GLOBAL);
+    return dlopen(name, RTLD_NOW|RTLD_GLOBAL);
 #endif
 }
 
-void CloseLibrary(LIBRARY_HANDLE lib) {
+void CloseLibrary(LIBRARY_HANDLE lib)
+{
 #if _WIN32 || _WIN64
-  BOOL ret = FreeLibrary(lib);
-  REQUIRE_MESSAGE(ret, "FreeLibrary must be successful");
+    BOOL ret = FreeLibrary(lib);
+    REQUIRE_MESSAGE(ret, "FreeLibrary must be successful");
 #else
-  int ret = dlclose(lib);
-  REQUIRE_MESSAGE(ret == 0, "dlclose must be successful");
+    int ret = dlclose(lib);
+    REQUIRE_MESSAGE(ret == 0, "dlclose must be successful");
 #endif
 }
 
 typedef void (*FunctionAddress)();
 
 template <typename FunctionPointer>
-void GetAddress(utils::LIBRARY_HANDLE lib, const char *name,
-                FunctionPointer &func) {
+void GetAddress(utils::LIBRARY_HANDLE lib, const char *name, FunctionPointer& func)
+{
 #if _WIN32 || _WIN64
-  func = (FunctionPointer)(void *)GetProcAddress(lib, name);
+    func = (FunctionPointer)(void*)GetProcAddress(lib, name);
 #else
-  func = (FunctionPointer)dlsym(lib, name);
+    func = (FunctionPointer)dlsym(lib, name);
 #endif
-  REQUIRE_MESSAGE(func, "Can't find required symbol in dynamic library");
+    REQUIRE_MESSAGE(func, "Can't find required symbol in dynamic library");
 }
 
-FunctionAddress GetAddress(utils::LIBRARY_HANDLE lib, const char *name) {
-  FunctionAddress func;
-  GetAddress(lib, name, func);
-  return func;
+FunctionAddress GetAddress(utils::LIBRARY_HANDLE lib, const char *name)
+{
+    FunctionAddress func;
+    GetAddress(lib, name, func);
+    return func;
 }
 
-} // namespace utils
+}  // namespace utils
 
 #endif // __TBB_DYNAMIC_LOAD_ENABLED
 #endif // __TBB_test_common_utils_dynamic_libs_H_


### PR DESCRIPTION
### Description 
Add cmake option TBB_BUILD_APPLE_FRAMEWORKS to build oneTBB as Apple Frameworks.
This is needed to be able to create iOS compatible app bundles which need to embed TBB as framework, as using dylibs is prohibited by Apple.

Fixes #1252

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [x] updated in this PR
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@isaevil 

### Other information
I've also ran into various integer type mismatches when building (mainly long <-> int) when I was working on this (using a M2 MacBook Pro). Not sure if I should include these fixes (just static_cast'ing to the expected types) in this PR or not?
