### PR TITLE
Fixed typo (maybe?) in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,7 @@ else()
     message(WARNING "TBB compiler settings not found ${TBB_COMPILER_SETTINGS_FILE}")
 endif()
 
-if (TBB_FIND_PACKAGE OR TBB_DIR)
+if (TBB_FIND_PACKAGE AND TBB_DIR)
     # Allow specifying external TBB to test with.
     # Do not add main targets and installation instructions in that case.
     message(STATUS "Using external TBB for testing")


### PR DESCRIPTION
### Description 
Currently TBB attempts a find package and excludes the entire build part of the CMake setup when *either* `TBB_FIND_PACKAGE` *or* `TBB_DIR` are defined. This is an issue when using `FetchContent` with `OVERRIDE_FIND_PACKAGE` as CMake declares `TBB_DIR` to equal `${CMAKE_BINARY_DIR}/CMakeFiles/pkgRedirects/`. It also strikes me as strange that the library could skip compilation and just find itself without the request of the user. It makes more sense that both these variables must be set for the library to skip compilation.


Fixes #1323 

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [x] Unknown
