### PR TITLE
Setting write access for pages deployment job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
   pages:
     if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
     needs: [documentation]
     steps:
       - name: Checkout gh-pages


### PR DESCRIPTION
### Description 
PR #1306 set workflow wide permission to read-only, causing the pages job to fail due to missing write access.  This PR provides write access to pages for the pages job only.

- [X] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [X] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
@omalyshe 

### Other information
