### PR TITLE
Correct `MyHashCompare` example in concurrent_hash_map page

### DIFF
--- a/doc/main/tbb_userguide/concurrent_hash_map.rst
+++ b/doc/main/tbb_userguide/concurrent_hash_map.rst
@@ -30,14 +30,14 @@ string occurs in the array ``Data``.
 
    // Structure that defines hashing and comparison operations for user's type.
    struct MyHashCompare {
-       static size_t hash( const string& x ) {
+       size_t hash( const string& x ) const {
            size_t h = 0;
            for( const char* s = x.c_str(); *s; ++s )
                h = (h*17)^*s;
            return h;
        }
        //! True if strings are equal
-       static bool equal( const string& x, const string& y ) {
+       bool equal( const string& x, const string& y ) const {
            return x==y;
        }
    };


### PR DESCRIPTION
### Description 
Requirements from [HashCompare](https://spec.oneapi.io/versions/latest/elements/oneTBB/source/named_requirements/containers/hash_compare.html) state that `hash` and `equals` should be regular class functions as opposed to `static`, and have `const` modifiers at the end. The example in `concurrent_hash_map.h` isn't consistent with this (or with the [More on HashCompare](https://oneapi-src.github.io/oneTBB/main/tbb_userguide/More_on_HashCompare.html) page).

Signed off by: Daniel Bashir <dbashir@hmc.edu>


Fixes # - N/A

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [x] updated in # - 1339 (this PR)
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
N/A

### Other information
N/A