### PR TITLE
Fix control variable initialization

### DIFF
--- a/src/tbb/governor.cpp
+++ b/src/tbb/governor.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -42,6 +42,8 @@ namespace detail {
 namespace r1 {
 
 void clear_address_waiter_table();
+void global_control_acquire();
+void global_control_release();
 
 //! global_control.cpp contains definition
 bool remove_and_check_if_empty(d1::global_control& gc);
@@ -60,6 +62,7 @@ namespace system_topology {
 //------------------------------------------------------------------------
 
 void governor::acquire_resources () {
+    global_control_acquire();
 #if __TBB_USE_POSIX
     int status = theTLS.create(auto_terminate);
 #else
@@ -85,6 +88,7 @@ void governor::release_resources () {
 
     system_topology::destroy();
     dynamic_unlink_all();
+    global_control_release();
 }
 
 rml::tbb_server* governor::create_rml_server ( rml::tbb_client& client ) {


### PR DESCRIPTION
### Description 
Fixes initialization order bug stated in https://github.com/oneapi-src/oneTBB/issues/1341#issuecomment-2054095330

Fixes #1341

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@pavelkumbrasev

### Other information
