### PR TITLE
Detect binutils version to disable waitpkg/tpause intrinsic if GNU assembler is too old.

### DIFF
--- a/cmake/compilers/GNU.cmake
+++ b/cmake/compilers/GNU.cmake
@@ -36,17 +36,16 @@ if (NOT CMAKE_GENERATOR MATCHES "Ninja" AND NOT CMAKE_CXX_DEPENDS_USE_COMPILER)
 endif()
 
 
-# Binutils < 2.31.1 does not support the "tpause" instruction.
-# When compiling with a modern version of GCC (which does support it), but then
-# relying on an outdated assembler will fail in the assembler.
-# Here we will invoke the GNU assembler to get the version number and
+# Binutils < 2.31.1 do not support the tpause instruction.
+# When compiling with a modern version of GCC (supporting it) but
+# relying on an outdated assembler, the assembler fails.
+# The following code invokes the GNU assembler to get the version number and
 # convert it to an integer that can be used in the C++ code to compare
 # against, and disable the __TBB_WAITPKG_INTRINSICS_PRESENT macro.
-# Unfortunately, binutils only reports the MAJOR.MINOR version, without patch,
-# so the check we effectively implement is version >=2.32 (instead of >=2.31.1).
+# Binutils only report the version in the MAJOR.MINOR format, 
+# therefore the version checked is >=2.32 (instead of >=2.31.1).
 # Capturing the output in CMake can be done like below. The version information
-# will written to either stdout or stderr; for me it's stderr, but let's just
-# grab both to be sure.
+# is written to either stdout or stderr. Here, both are used. 
 execute_process(
     COMMAND ${CMAKE_CXX_COMPILER} -xc -c /dev/null -Wa,-v -o/dev/null
     OUTPUT_VARIABLE ASSEMBLER_VERSION_LINE_OUT

--- a/cmake/compilers/GNU.cmake
+++ b/cmake/compilers/GNU.cmake
@@ -55,19 +55,16 @@ execute_process(
     ERROR_STRIP_TRAILING_WHITESPACE
 )
 set(ASSEMBLER_VERSION_LINE ${ASSEMBLER_VERSION_LINE_OUT}${ASSEMBLER_VERSION_LINE_ERR})
-string(REGEX REPLACE "GNU assembler version ([0-9]+\\.[0-9]+).*" "\\1" GNU_ASSEMBLER_VERSION "${ASSEMBLER_VERSION_LINE}")
-string(FIND ${GNU_ASSEMBLER_VERSION} "." DOT_POSITION)
-if(DOT_POSITION EQUAL -1)
-    message(FATAL_ERROR "Invalid version string format: ${GNU_ASSEMBLER_VERSION}")
-endif()
+string(REGEX REPLACE "GNU assembler version ([0-9]+)\\.([0-9]+).*" "\\1" _tbb_gnu_asm_major_version "${ASSEMBLER_VERSION_LINE}")
+string(REGEX REPLACE "GNU assembler version ([0-9]+)\\.([0-9]+).*" "\\2" _tbb_gnu_asm_minor_version "${ASSEMBLER_VERSION_LINE}")
+unset(ASSEMBLER_VERSION_LINE_OUT)
+unset(ASSEMBLER_VERSION_LINE_ERR)
+unset(ASSEMBLER_VERSION_LINE)
+message(TRACE "Extracted GNU asssembler version: major=${_tbb_gnu_asm_major_version} minor=${_tbb_gnu_asm_minor_version}")
 
-# Extract the major and minor version numbers (without relying on REGEX to support older CMake versions <3.9)
-string(SUBSTRING ${GNU_ASSEMBLER_VERSION} 0 ${DOT_POSITION} GNU_ASSEMBLER_MAJOR_VERSION)
-string(SUBSTRING ${GNU_ASSEMBLER_VERSION} ${DOT_POSITION} -1 DOT_AND_MINOR_VERSION)
-string(SUBSTRING ${DOT_AND_MINOR_VERSION} 1 -1 GNU_ASSEMBLER_MINOR_VERSION)
-math(EXPR GNU_ASSEMBLER_VERSION_NUMBER  "${GNU_ASSEMBLER_MAJOR_VERSION} * 1000 + ${GNU_ASSEMBLER_MINOR_VERSION}")
-set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} "-DGNU_AS_VERSION=${GNU_ASSEMBLER_VERSION_NUMBER}")
-message(STATUS "GNU Assembler version: ${GNU_ASSEMBLER_VERSION}  (${GNU_ASSEMBLER_VERSION_NUMBER})")
+math(EXPR _tbb_gnu_asm_version_number  "${_tbb_gnu_asm_major_version} * 1000 + ${_tbb_gnu_asm_minor_version}")
+set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} "-D__TBB_GNU_ASM_VERSION=${_tbb_gnu_asm_version_number}")
+message(STATUS "GNU Assembler version: ${_tbb_gnu_asm_major_version}.${_tbb_gnu_asm_minor_version}  (${_tbb_gnu_asm_version_number})")
 
 # Enable Intel(R) Transactional Synchronization Extensions (-mrtm) and WAITPKG instructions support (-mwaitpkg) on relevant processors
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "(AMD64|amd64|i.86|x86)")

--- a/cmake/compilers/GNU.cmake
+++ b/cmake/compilers/GNU.cmake
@@ -43,7 +43,7 @@ endif()
 # convert it to an integer that can be used in the C++ code to compare
 # against, and disable the __TBB_WAITPKG_INTRINSICS_PRESENT macro.
 # Unfortunately, binutils only reports the MAJOR.MINOR version, without patch,
-# so the check we effectively implement is version >2.32 (instead of >=2.31.1).
+# so the check we effectively implement is version >=2.32 (instead of >=2.31.1).
 # Capturing the output in CMake can be done like below. The version information
 # will written to either stdout or stderr; for me it's stderr, but let's just
 # grab both to be sure.

--- a/cmake/compilers/GNU.cmake
+++ b/cmake/compilers/GNU.cmake
@@ -36,16 +36,17 @@ if (NOT CMAKE_GENERATOR MATCHES "Ninja" AND NOT CMAKE_CXX_DEPENDS_USE_COMPILER)
 endif()
 
 
-# Binutils < 2.31.1 do not support the tpause instruction.
-# When compiling with a modern version of GCC (supporting it) but
-# relying on an outdated assembler, the assembler fails.
-# The following code invokes the GNU assembler to get the version number and
-# convert it to an integer that can be used in the C++ code to compare
-# against, and disable the __TBB_WAITPKG_INTRINSICS_PRESENT macro.
-# Binutils only report the version in the MAJOR.MINOR format, 
-# therefore the version checked is >=2.32 (instead of >=2.31.1).
-# Capturing the output in CMake can be done like below. The version information
-# is written to either stdout or stderr. Here, both are used. 
+# Binutils < 2.31.1 do not support the tpause instruction. When compiling with
+# a modern version of GCC (supporting it) but relying on an outdated assembler,
+# will result in an error reporting "no such instruction: tpause".
+# The following code invokes the GNU assembler to extract the version number
+# and convert it to an integer that can be used in the C++ code to compare
+# against, and conditionally disable the __TBB_WAITPKG_INTRINSICS_PRESENT
+# macro if the version is incompatible. Binutils only report the version in the
+# MAJOR.MINOR format, therefore the version checked is >=2.32 (instead of
+# >=2.31.1). Capturing the output in CMake can be done like below. The version
+# information is written to either stdout or stderr. To not make any
+# assumptions, both are captured.
 execute_process(
     COMMAND ${CMAKE_CXX_COMPILER} -xc -c /dev/null -Wa,-v -o/dev/null
     OUTPUT_VARIABLE ASSEMBLER_VERSION_LINE_OUT

--- a/cmake/compilers/GNU.cmake
+++ b/cmake/compilers/GNU.cmake
@@ -60,7 +60,7 @@ string(REGEX REPLACE "GNU assembler version ([0-9]+)\\.([0-9]+).*" "\\2" _tbb_gn
 unset(ASSEMBLER_VERSION_LINE_OUT)
 unset(ASSEMBLER_VERSION_LINE_ERR)
 unset(ASSEMBLER_VERSION_LINE)
-message(TRACE "Extracted GNU asssembler version: major=${_tbb_gnu_asm_major_version} minor=${_tbb_gnu_asm_minor_version}")
+message(TRACE "Extracted GNU assembler version: major=${_tbb_gnu_asm_major_version} minor=${_tbb_gnu_asm_minor_version}")
 
 math(EXPR _tbb_gnu_asm_version_number  "${_tbb_gnu_asm_major_version} * 1000 + ${_tbb_gnu_asm_minor_version}")
 set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} "-D__TBB_GNU_ASM_VERSION=${_tbb_gnu_asm_version_number}")

--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -335,7 +335,7 @@
 
 #define __TBB_TSX_INTRINSICS_PRESENT (__RTM__ || __INTEL_COMPILER || (_MSC_VER>=1700 && (__TBB_x86_64 || __TBB_x86_32)))
 
-#define __TBB_WAITPKG_INTRINSICS_PRESENT ((__INTEL_COMPILER >= 1900 || (__TBB_GCC_VERSION >= 110000 && GNU_AS_VERSION > 2031) || __TBB_CLANG_VERSION >= 120000) \
+#define __TBB_WAITPKG_INTRINSICS_PRESENT ((__INTEL_COMPILER >= 1900 || (__TBB_GCC_VERSION >= 110000 && GNU_AS_VERSION >= 2032) || __TBB_CLANG_VERSION >= 120000) \
                                          && (_WIN32 || _WIN64 || __unix__ || __APPLE__) && (__TBB_x86_32 || __TBB_x86_64) && !__ANDROID__)
 
 /** Internal TBB features & modes **/

--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -335,7 +335,7 @@
 
 #define __TBB_TSX_INTRINSICS_PRESENT (__RTM__ || __INTEL_COMPILER || (_MSC_VER>=1700 && (__TBB_x86_64 || __TBB_x86_32)))
 
-#define __TBB_WAITPKG_INTRINSICS_PRESENT ((__INTEL_COMPILER >= 1900 || (__TBB_GCC_VERSION >= 110000 && GNU_AS_VERSION >= 2032) || __TBB_CLANG_VERSION >= 120000) \
+#define __TBB_WAITPKG_INTRINSICS_PRESENT ((__INTEL_COMPILER >= 1900 || (__TBB_GCC_VERSION >= 110000 && __TBB_GNU_ASM_VERSION >= 2032) || __TBB_CLANG_VERSION >= 120000) \
                                          && (_WIN32 || _WIN64 || __unix__ || __APPLE__) && (__TBB_x86_32 || __TBB_x86_64) && !__ANDROID__)
 
 /** Internal TBB features & modes **/

--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -335,7 +335,7 @@
 
 #define __TBB_TSX_INTRINSICS_PRESENT (__RTM__ || __INTEL_COMPILER || (_MSC_VER>=1700 && (__TBB_x86_64 || __TBB_x86_32)))
 
-#define __TBB_WAITPKG_INTRINSICS_PRESENT ((__INTEL_COMPILER >= 1900 || __TBB_GCC_VERSION >= 110000 || __TBB_CLANG_VERSION >= 120000) \
+#define __TBB_WAITPKG_INTRINSICS_PRESENT ((__INTEL_COMPILER >= 1900 || (__TBB_GCC_VERSION >= 110000 && GNU_AS_VERSION > 2031) || __TBB_CLANG_VERSION >= 120000) \
                                          && (_WIN32 || _WIN64 || __unix__ || __APPLE__) && (__TBB_x86_32 || __TBB_x86_64) && !__ANDROID__)
 
 /** Internal TBB features & modes **/


### PR DESCRIPTION
Fixes #859 #1023.

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@mcmillan03 @kboyarinov @markdewing @phprus @isaevil @HorizonLiang @bsergean @pavelkumbrasev 

### Other information
