### PR TITLE
Reverting workflow permissions restriction to reenable pages job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ on:
       - synchronize
       - reopened
 
-permissions: read-all
-
 env:
   BUILD_CONCURRENCY: 2
   MACOS_BUILD_CONCURRENCY: 3
@@ -83,8 +81,6 @@ jobs:
   pages:
     if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
-    permissions:
-      pages: write
     needs: [documentation]
     steps:
       - name: Checkout gh-pages


### PR DESCRIPTION
### Description 
Revert previous commits that restricted permissions for workflow jobs to read-only.  This is being done to reenable pages deployment.  A separate PR will reintroduce the permissions restrictions needed that also keep pages deployment functioning.


Fixes # - _issue number(s) if exists_

- [ ] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [X ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X ] No
- [ ] Unknown

### Notify the following users
@omalyshe 

### Other information
