### PR TITLE
Add task arena worker block time

### DIFF
--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -395,9 +395,11 @@ bool arena::is_top_priority() const {
     return my_is_top_priority.load(std::memory_order_relaxed);
 }
 
-bool arena::try_join() {
+bool arena::try_join(bool should_join) {
     if (num_workers_active() < my_num_workers_allotted.load(std::memory_order_relaxed)) {
-        my_references += arena::ref_worker;
+        if (should_join) {
+            my_references += arena::ref_worker;
+        }
         return true;
     }
     return false;

--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -395,11 +395,9 @@ bool arena::is_top_priority() const {
     return my_is_top_priority.load(std::memory_order_relaxed);
 }
 
-bool arena::try_join(bool should_join) {
-    if (num_workers_active() < my_num_workers_allotted.load(std::memory_order_relaxed)) {
-        if (should_join) {
-            my_references += arena::ref_worker;
-        }
+bool arena::try_join() {
+    if (is_joinable()) {
+        my_references += arena::ref_worker;
         return true;
     }
     return false;

--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -385,7 +385,7 @@ public:
 
     bool is_top_priority() const;
 
-    bool try_join();
+    bool try_join(bool should_join);
 
     void set_allotment(unsigned allotment);
 

--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -385,7 +385,11 @@ public:
 
     bool is_top_priority() const;
 
-    bool try_join(bool should_join);
+    bool is_joinable() const {
+        return num_workers_active() < my_num_workers_allotted.load(std::memory_order_relaxed);
+    }
+
+    bool try_join();
 
     void set_allotment(unsigned allotment);
 

--- a/src/tbb/governor.h
+++ b/src/tbb/governor.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -137,6 +137,8 @@ public:
 #if __TBB_WAITPKG_INTRINSICS_PRESENT
     static bool wait_package_enabled() { return cpu_features.waitpkg_enabled; }
 #endif
+
+    static bool hybrid_cpu() { return cpu_features.hybrid; }
 
     static bool rethrow_exception_broken() { return is_rethrow_broken; }
 

--- a/src/tbb/misc.h
+++ b/src/tbb/misc.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -211,6 +211,7 @@ T1 atomic_update(std::atomic<T1>& dst, T1 newValue, Pred compare) {
 struct cpu_features_type {
     bool rtm_enabled{false};
     bool waitpkg_enabled{false};
+    bool hybrid{false};
 };
 
 void detect_cpu_features(cpu_features_type& cpu_features);

--- a/src/tbb/thread_dispatcher.h
+++ b/src/tbb/thread_dispatcher.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2022-2023 Intel Corporation
+    Copyright (c) 2022-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ public:
     thread_dispatcher_client* create_client(arena& a);
     void register_client(thread_dispatcher_client* client);
     bool try_unregister_client(thread_dispatcher_client* client, std::uint64_t aba_epoch, unsigned priority);
+    bool is_any_client_in_need();
 
     void adjust_job_count_estimate(int delta);
     void release(bool blocking_terminate);
@@ -66,8 +67,8 @@ private:
     void insert_client(thread_dispatcher_client& client);
     void remove_client(thread_dispatcher_client& client);
     bool is_client_alive(thread_dispatcher_client* client);
-    thread_dispatcher_client* client_in_need(client_list_type* clients, thread_dispatcher_client* hint);
-    thread_dispatcher_client* client_in_need(thread_dispatcher_client* prev);
+    thread_dispatcher_client* client_in_need(client_list_type* clients, thread_dispatcher_client* hint, bool should_join);
+    thread_dispatcher_client* client_in_need(thread_dispatcher_client* prev, bool should_join = true);
 
     friend class threading_control_impl;
     static constexpr unsigned num_priority_levels = d1::num_priority_levels;

--- a/src/tbb/thread_dispatcher.h
+++ b/src/tbb/thread_dispatcher.h
@@ -67,8 +67,8 @@ private:
     void insert_client(thread_dispatcher_client& client);
     void remove_client(thread_dispatcher_client& client);
     bool is_client_alive(thread_dispatcher_client* client);
-    thread_dispatcher_client* client_in_need(client_list_type* clients, thread_dispatcher_client* hint, bool should_join);
-    thread_dispatcher_client* client_in_need(thread_dispatcher_client* prev, bool should_join = true);
+    thread_dispatcher_client* client_in_need(client_list_type* clients, thread_dispatcher_client* hint);
+    thread_dispatcher_client* client_in_need(thread_dispatcher_client* prev);
 
     friend class threading_control_impl;
     static constexpr unsigned num_priority_levels = d1::num_priority_levels;

--- a/src/tbb/thread_dispatcher_client.h
+++ b/src/tbb/thread_dispatcher_client.h
@@ -29,9 +29,14 @@ public:
     thread_dispatcher_client(arena& a, std::uint64_t aba_epoch) : my_arena(a), my_aba_epoch(aba_epoch) {}
 
     // Interface of communication with thread pool
-    bool try_join(bool should_join) {
-        return my_arena.try_join(should_join);
+    bool try_join() {
+        return my_arena.try_join();
     }
+
+    bool is_joinable() {
+        return my_arena.is_joinable();
+    }
+
     void process(thread_data& td) {
         my_arena.process(td);
     }

--- a/src/tbb/thread_dispatcher_client.h
+++ b/src/tbb/thread_dispatcher_client.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2022-2023 Intel Corporation
+    Copyright (c) 2022-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -29,8 +29,8 @@ public:
     thread_dispatcher_client(arena& a, std::uint64_t aba_epoch) : my_arena(a), my_aba_epoch(aba_epoch) {}
 
     // Interface of communication with thread pool
-    bool try_join() {
-        return my_arena.try_join();
+    bool try_join(bool should_join) {
+        return my_arena.try_join(should_join);
     }
     void process(thread_data& td) {
         my_arena.process(td);

--- a/src/tbb/thread_request_serializer.cpp
+++ b/src/tbb/thread_request_serializer.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2022-2023 Intel Corporation
+    Copyright (c) 2022-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -37,8 +37,8 @@ void thread_request_serializer::update(int delta) {
     if (prev_pending_delta == pending_delta_base) {
         delta = int(my_pending_delta.exchange(pending_delta_base) & delta_mask) - int(pending_delta_base);
         mutex_type::scoped_lock lock(my_mutex);
-        my_total_request += delta;
-        delta = limit_delta(delta, my_soft_limit, my_total_request);
+        my_total_request.store(my_total_request.load(std::memory_order_relaxed) + delta, std::memory_order_release);
+        delta = limit_delta(delta, my_soft_limit, my_total_request.load(std::memory_order_relaxed));
         my_thread_dispatcher.adjust_job_count_estimate(delta);
     }
 }
@@ -46,7 +46,7 @@ void thread_request_serializer::update(int delta) {
 void thread_request_serializer::set_active_num_workers(int soft_limit) {
     mutex_type::scoped_lock lock(my_mutex);
     int delta = soft_limit - my_soft_limit;
-    delta = limit_delta(delta, my_total_request, soft_limit);
+    delta = limit_delta(delta, my_total_request.load(std::memory_order_relaxed), soft_limit);
     my_thread_dispatcher.adjust_job_count_estimate(delta);
     my_soft_limit = soft_limit;
 }
@@ -108,6 +108,8 @@ void thread_request_serializer_proxy::set_active_num_workers(int soft_limit) {
         }
     }
 }
+
+int thread_request_serializer_proxy::num_workers_requested() { return my_serializer.num_workers_requested(); }
 
 void thread_request_serializer_proxy::update(int delta) { my_serializer.update(delta); }
 

--- a/src/tbb/thread_request_serializer.cpp
+++ b/src/tbb/thread_request_serializer.cpp
@@ -37,7 +37,7 @@ void thread_request_serializer::update(int delta) {
     if (prev_pending_delta == pending_delta_base) {
         delta = int(my_pending_delta.exchange(pending_delta_base) & delta_mask) - int(pending_delta_base);
         mutex_type::scoped_lock lock(my_mutex);
-        my_total_request.store(my_total_request.load(std::memory_order_relaxed) + delta, std::memory_order_release);
+        my_total_request.store(my_total_request.load(std::memory_order_relaxed) + delta, std::memory_order_relaxed);
         delta = limit_delta(delta, my_soft_limit, my_total_request.load(std::memory_order_relaxed));
         my_thread_dispatcher.adjust_job_count_estimate(delta);
     }

--- a/src/tbb/thread_request_serializer.h
+++ b/src/tbb/thread_request_serializer.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2022-2023 Intel Corporation
+    Copyright (c) 2022-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ class thread_request_serializer : public thread_request_observer {
 public:
     thread_request_serializer(thread_dispatcher& td, int soft_limit);
     void set_active_num_workers(int soft_limit);
+    int num_workers_requested() { return my_total_request.load(std::memory_order_acquire); }
     bool is_no_workers_avaliable() { return my_soft_limit == 0; }
 
 private:
@@ -48,7 +49,7 @@ private:
 
     thread_dispatcher& my_thread_dispatcher;
     int my_soft_limit{ 0 };
-    int my_total_request{ 0 };
+    std::atomic<int> my_total_request{ 0 };
     // my_pending_delta is set to pending_delta_base to have ability to hold negative values
     // consider increase base since thead number will be bigger than 1 << 15
     static constexpr std::uint64_t pending_delta_base = 1 << 15;
@@ -63,6 +64,7 @@ public:
     thread_request_serializer_proxy(thread_dispatcher& td, int soft_limit);
     void register_mandatory_request(int mandatory_delta);
     void set_active_num_workers(int soft_limit);
+    int num_workers_requested();
 
 private:
     void update(int delta) override;

--- a/src/tbb/thread_request_serializer.h
+++ b/src/tbb/thread_request_serializer.h
@@ -39,7 +39,7 @@ class thread_request_serializer : public thread_request_observer {
 public:
     thread_request_serializer(thread_dispatcher& td, int soft_limit);
     void set_active_num_workers(int soft_limit);
-    int num_workers_requested() { return my_total_request.load(std::memory_order_acquire); }
+    int num_workers_requested() { return my_total_request.load(std::memory_order_relaxed); }
     bool is_no_workers_avaliable() { return my_soft_limit == 0; }
 
 private:

--- a/src/tbb/threading_control.cpp
+++ b/src/tbb/threading_control.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2022-2023 Intel Corporation
+    Copyright (c) 2022-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -162,6 +162,10 @@ void threading_control_impl::adjust_demand(threading_control_client tc_client, i
     auto& c = *tc_client.get_pm_client();
     my_thread_request_serializer->register_mandatory_request(mandatory_delta);
     my_permit_manager->adjust_demand(c, mandatory_delta, workers_delta);
+}
+
+bool threading_control_impl::is_any_other_client_active() {
+    return my_thread_request_serializer->num_workers_requested() > 0 ? my_thread_dispatcher->is_any_client_in_need() : false;
 }
 
 thread_control_monitor& threading_control_impl::get_waiting_threads_monitor() {
@@ -387,6 +391,10 @@ unsigned threading_control::max_num_workers() {
 
 void threading_control::adjust_demand(threading_control_client client, int mandatory_delta, int workers_delta) {
     my_pimpl->adjust_demand(client, mandatory_delta, workers_delta);
+}
+
+bool threading_control::is_any_other_client_active() {
+    return my_pimpl->is_any_other_client_active();
 }
 
 thread_control_monitor& threading_control::get_waiting_threads_monitor() {

--- a/src/tbb/threading_control.h
+++ b/src/tbb/threading_control.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2022-2023 Intel Corporation
+    Copyright (c) 2022-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ public:
     unsigned max_num_workers();
 
     void adjust_demand(threading_control_client, int mandatory_delta, int workers_delta);
+    bool is_any_other_client_active();
 
     thread_control_monitor& get_waiting_threads_monitor();
 
@@ -116,6 +117,7 @@ public:
     static unsigned max_num_workers();
 
     void adjust_demand(threading_control_client client, int mandatory_delta, int workers_delta);
+    bool is_any_other_client_active();
 
     thread_control_monitor& get_waiting_threads_monitor();
 


### PR DESCRIPTION
### Description 
Add `threading_control::is_any_other_client_active()` to verify if other arenas are requesting workers.

Add hybrid CPU detection at initialization.

On non-hybrid CPUs, make workers block for 1ms before leaving the arena, unless
- more work becomes available in the arena (&rArr; unblock and stay in the arena);
- other arenas are requesting workers (&rArr; unblock and leave the arena immediately).

Fixes performance degradation on large systems when CPU power state demotion is disabled.

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed (done manually)

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
