### PR TITLE
Increase yields multiplier on APPLE platforms

### DIFF
--- a/src/tbb/scheduler_common.h
+++ b/src/tbb/scheduler_common.h
@@ -268,12 +268,7 @@ public:
     // no worse than 2x the optimal spin time. Or perhaps a time-slice quantum is the right amount.
     stealing_loop_backoff(int num_workers, int yields_multiplier)
         : my_pause_threshold{ 2 * (num_workers + 1) }
-#if __APPLE__
-        // threshold value tuned separately for macOS due to high cost of sched_yield there
-        , my_yield_threshold{10 * yields_multiplier}
-#else
         , my_yield_threshold{100 * yields_multiplier}
-#endif
         , my_pause_count{}
         , my_yield_count{}
     {}

--- a/src/tbb/scheduler_common.h
+++ b/src/tbb/scheduler_common.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description 
The yield multiplier for MacOS was set 10 times less than other Linux/Win platforms. This was done due to high cost of sched_yield in macOS. Latest experiments on Mac system indicate this can be made to be the same multiplier (100) across all platforms.


### Type of change

- [x ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
