### PR TITLE
Remove unused JPEG reading functionality from the Tachyone example

### DIFF
--- a/examples/parallel_for/tachyon/src/jpeg.cpp
+++ b/examples/parallel_for/tachyon/src/jpeg.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -61,66 +61,6 @@
 #include "imageio.hpp" /* error codes etc */
 #include "jpeg.hpp" /* the protos for this file */
 
-#if !defined(USEJPEG)
-
 int readjpeg(char *name, int *xres, int *yres, unsigned char **imgdata) {
     return IMAGEUNSUP;
 }
-
-#else
-
-#include "jpeglib.hpp" /* the IJG jpeg library headers */
-
-int readjpeg(char *name, int *xres, int *yres, unsigned char **imgdata) {
-    FILE *ifp;
-    struct jpeg_decompress_struct cinfo; /* JPEG decompression struct */
-    struct jpeg_error_mgr jerr; /* JPEG Error handler */
-    JSAMPROW row_pointer[1]; /* output row buffer */
-    int row_stride; /* physical row width in output buf */
-
-    /* open input file before doing any JPEG decompression setup */
-    if ((ifp = fopen(name, "rb")) == nullptr)
-        return IMAGEBADFILE; /* Could not open image, return error */
-
-    /*
-   * Note: The Independent JPEG Group's library does not have a way
-   *       of returning errors without the use of setjmp/longjmp.
-   *       This is a problem in multi-threaded environment, since setjmp
-   *       and longjmp are declared thread-unsafe by many vendors currently.
-   *       For now, JPEG decompression errors will result in the "default"
-   *       error handling provided by the JPEG library, which is an error
-   *       message and a fatal call to exit().  I'll have to work around this
-   *       or find a reasonably thread-safe way of doing setjmp/longjmp..
-   */
-
-    cinfo.err = jpeg_std_error(&jerr); /* Set JPEG error handler to default */
-
-    jpeg_create_decompress(&cinfo); /* Create decompression context */
-    jpeg_stdio_src(&cinfo, ifp); /* Set input mechanism to stdio type */
-    jpeg_read_header(&cinfo, TRUE); /* Read the JPEG header for info */
-    jpeg_start_decompress(&cinfo); /* Prepare for actual decompression */
-
-    *xres = cinfo.output_width; /* set returned image width */
-    *yres = cinfo.output_height; /* set returned image height */
-
-    /* Calculate the size of a row in the image */
-    row_stride = cinfo.output_width * cinfo.output_components;
-
-    /* Allocate the image buffer which will be returned to the ray tracer */
-    *imgdata = (unsigned char *)malloc(row_stride * cinfo.output_height);
-
-    /* decompress the JPEG, one scanline at a time into the buffer */
-    while (cinfo.output_scanline < cinfo.output_height) {
-        row_pointer[0] = &((*imgdata)[(cinfo.output_scanline) * row_stride]);
-        jpeg_read_scanlines(&cinfo, row_pointer, 1);
-    }
-
-    jpeg_finish_decompress(&cinfo); /* Tell the JPEG library to cleanup */
-    jpeg_destroy_decompress(&cinfo); /* Destroy JPEG decompression context */
-
-    fclose(ifp); /* Close the input file */
-
-    return IMAGENOERR; /* No fatal errors */
-}
-
-#endif


### PR DESCRIPTION
### Description 
Only leave the stub function, since libjpeg is not used in this example.

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
