### PR TITLE
Fix compilation error in mingw [-Werror=unused-value]

### DIFF
--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -34,7 +34,8 @@
     // Unify system calls
     #define dlopen( name, flags )   LoadLibrary( name )
     #define dlsym( handle, name )   GetProcAddress( handle, name )
-    #define dlclose( handle )       ( ! FreeLibrary( handle ) )
+    // FreeLibrary return bool value that is not used.
+    #define dlclose( handle )       (void)( ! FreeLibrary( handle ) )
     #define dlerror()               GetLastError()
 #ifndef PATH_MAX
     #define PATH_MAX                MAX_PATH


### PR DESCRIPTION
### Description 
FreeLibrary function returns a bool value that is discarded. This results in compilation error in mingw  due to -Werror=unused-value


Fixes #1314


### Type of change


- [x ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x ] not needed

### Breaks backward compatibility
- [x ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
@someoneinjd

### Other information
