### PR TITLE
Second attempt at minimum permissions for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ on:
       - synchronize
       - reopened
 
+permissions: read-all
+
 env:
   BUILD_CONCURRENCY: 2
   MACOS_BUILD_CONCURRENCY: 3
@@ -80,6 +82,10 @@ jobs:
 
   pages:
     if: ${{ github.ref == 'refs/heads/master' }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     runs-on: ubuntu-latest
     needs: [documentation]
     steps:


### PR DESCRIPTION
Following OpenSSF Scorecard recommendations to set permissions for all CI jobs to read-only except where required. The documentation job needs write access to deploy.

### Description 
OpenSSFScorecard requires Token-Permissions to have the minimum access required to accomplish a job in the CI workflow, which for most jobs is read only access. #1306 and #1325 attempted to do this, but gh-pages deployment still did not have adequate access. This PR, following the example of https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages#deploying-github-pages-artifacts to set the permissions for the documentation job.  While we're not using the deploy-pages action the access required should be the same.


Fixes # - _issue number(s) if exists_

- [ ] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [X ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X ] not needed

### Breaks backward compatibility
- [ ] Yes
- [X ] No
- [ ] Unknown

### Notify the following users
@omalyshe 

### Other information
