### PR TITLE
Unify approach towards threads registration in TCM

### DIFF
--- a/include/oneapi/tbb/task_scheduler_observer.h
+++ b/include/oneapi/tbb/task_scheduler_observer.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/task_scheduler_observer.h
+++ b/include/oneapi/tbb/task_scheduler_observer.h
@@ -37,6 +37,7 @@ class observer_list;
 has the task scheduler initialized or is attached to an arena.
 Repeated calls with the same state are no-ops. **/
 TBB_EXPORT void __TBB_EXPORTED_FUNC observe(d1::task_scheduler_observer&, bool state = true);
+void observe(d1::task_scheduler_observer&, r1::arena&);
 }
 
 namespace d1 {
@@ -44,6 +45,7 @@ class task_scheduler_observer {
     friend class r1::observer_proxy;
     friend class r1::observer_list;
     friend void r1::observe(d1::task_scheduler_observer&, bool);
+    friend void r1::observe(d1::task_scheduler_observer&, r1::arena&);
 
     //! Pointer to the proxy holding this observer.
     /** Observers are proxied by the scheduler to maintain persistent lists of them. **/

--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -196,8 +196,6 @@ void arena::process(thread_data& tls) {
         return;
     }
 
-    my_tc_client.get_pm_client()->register_thread();
-
     __TBB_ASSERT( index >= my_num_reserved_slots, "Workers cannot occupy reserved slots" );
     tls.attach_arena(*this, index);
     // worker thread enters the dispatch loop to look for a work
@@ -236,8 +234,6 @@ void arena::process(thread_data& tls) {
     tls.my_inbox.detach();
     __TBB_ASSERT(tls.my_inbox.is_idle_state(true), nullptr);
     __TBB_ASSERT(is_alive(my_guard), nullptr);
-
-    my_tc_client.get_pm_client()->unregister_thread();
 
     // In contrast to earlier versions of TBB (before 3.0 U5) now it is possible
     // that arena may be temporarily left unpopulated by threads. See comments in

--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/market.cpp
+++ b/src/tbb/market.cpp
@@ -28,10 +28,6 @@ class tbb_permit_manager_client : public pm_client {
 public:
     tbb_permit_manager_client(arena& a) : pm_client(a) {}
 
-    void register_thread() override {}
-
-    void unregister_thread() override {}
-
     void set_allotment(unsigned allotment) {
         my_arena.set_allotment(allotment);
     }

--- a/src/tbb/market.cpp
+++ b/src/tbb/market.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/observer_proxy.cpp
+++ b/src/tbb/observer_proxy.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/observer_proxy.h
+++ b/src/tbb/observer_proxy.h
@@ -96,6 +96,7 @@ class observer_proxy {
     friend class d1::task_scheduler_observer;
     friend class observer_list;
     friend void observe(d1::task_scheduler_observer&, bool);
+    friend void observe(d1::task_scheduler_observer &t, arena&);
     //! Reference count used for garbage collection.
     /** 1 for reference from my task_scheduler_observer.
         1 for each task dispatcher's last observer pointer.

--- a/src/tbb/observer_proxy.h
+++ b/src/tbb/observer_proxy.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/pm_client.h
+++ b/src/tbb/pm_client.h
@@ -50,12 +50,6 @@ public:
         set_workers(min_max_workers.first, min_max_workers.second);
         return delta;
     }
-
-    virtual void register_thread() = 0;
-
-    virtual void unregister_thread() = 0;
-
-
 protected:
     void set_workers(int mn_w, int mx_w) {
         __TBB_ASSERT(mn_w >= 0, nullptr);

--- a/src/tbb/pm_client.h
+++ b/src/tbb/pm_client.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2022-2023 Intel Corporation
+    Copyright (c) 2022-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description 
Current implementation of thread registration is only focused on worker threads to be registered in TCM. When external threads are participating in work, they do not register thus TCM won't have enough information on resource usage for better distribution. 
This patch utilizes `task_scheduler_observer` as universal way to support both external and worker threads.

Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
