### PR TITLE
Improve machine_pause on arm64 

### DIFF
--- a/include/oneapi/tbb/detail/_machine.h
+++ b/include/oneapi/tbb/detail/_machine.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ static inline void machine_pause(int32_t delay) {
 #if __TBB_x86_64 || __TBB_x86_32
     while (delay-- > 0) { _mm_pause(); }
 #elif __ARM_ARCH_7A__ || __aarch64__
-    while (delay-- > 0) { __asm__ __volatile__("yield" ::: "memory"); }
+    while (delay-- > 0) { __asm__ __volatile__("isb sy" ::: "memory"); }
 #else /* Generic */
     (void)delay; // suppress without including _template_helpers.h
     yield();


### PR DESCRIPTION
### Description 
On arm64 `isb` (instruction synchronization barrier) is better to use than yield in a spin loop.  The `yield` instruction is a `nop`.  The `isb` instruction puts the processor to sleep for some short time by flushing the pipeline.  `isb` is a good equivalent to the pause instruction on `x86`.

Rust implementation + performance analysis:  [link](https://github.com/rust-lang/rust/commit/c064b6560b7ce0adeb9bbf5d7dcf12b1acb0c807)


Fixes # - _issue number(s) if exists_

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
