### PR TITLE
Adding CODEOWNERS.txt to identify  lead maintainers.

### DIFF
--- a/CODEOWNERS.txt
+++ b/CODEOWNERS.txt
@@ -4,10 +4,12 @@
 /oneTBB/src/tbb/ @dnmokhov
 /oneTBB/src/tbb/ @JhaShweta1
 /oneTBB/src/tbb/ @sarathnandu
+/oneTBB/src/doc @aepanchi
 /oneTBB/src/tbbbind/ @isaevil
 /oneTBB/src/tbbmalloc/ @lplewa
 /oneTBB/src/tbbmalloc_proxy/ @lplewa
 /oneTBB/cmake/ @isaevil
+/oneTBB/*CMakeLists.txt @isaevil
 /oneTBB/python/ @sarathnandu
 /oneTBB/python/ @isaevil
 

--- a/CODEOWNERS.txt
+++ b/CODEOWNERS.txt
@@ -1,0 +1,14 @@
+# Where component owners are known, add them here.
+
+/oneTBB/src/tbb/ @pavelkumbrasev
+/oneTBB/src/tbb/ @dnmokhov
+/oneTBB/src/tbb/ @JhaShweta1
+/oneTBB/src/tbb/ @sarathnandu
+/oneTBB/src/tbbbind/ @isaevil
+/oneTBB/src/tbbmalloc/ @lplewa
+/oneTBB/src/tbbmalloc_proxy/ @lplewa
+/oneTBB/cmake/ @isaevil
+/oneTBB/python/ @sarathnandu
+/oneTBB/python/ @isaevil
+
+


### PR DESCRIPTION
### Description 
Adding CODEOWNERS.txt to identify  lead maintainers.


Fixes # - _issue number(s) if exists_

- [ ] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
