### PR TITLE
Ensure test_partitioner reliability by waiting between repeats for threads to leave

### DIFF
--- a/test/tbb/test_partitioner.cpp
+++ b/test/tbb/test_partitioner.cpp
@@ -101,6 +101,9 @@ template <typename PerBodyFunc> float test(PerBodyFunc&& body) {
                 tbb::static_partitioner()
             );
         });
+        // To avoid tasks stealing in the beginning of the parallel algorithm, the test waits for
+        // the threads to leave the arena, so that on the next iteration they have tasks assigned
+        // in their mailboxes and, thus, don't need to search for work to do in other task pools.
         observer.wait_leave();
     }
 

--- a/test/tbb/test_partitioner.cpp
+++ b/test/tbb/test_partitioner.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2021-2023 Intel Corporation
+    Copyright (c) 2021-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 #include "tbb/parallel_for.h"
 #include "tbb/task_arena.h"
+#include "tbb/task_scheduler_observer.h"
 #include "tbb/global_control.h"
 #include "oneapi/tbb/mutex.h"
 
@@ -36,10 +37,33 @@
 
 namespace task_affinity_retention {
 
+class leaving_observer : public tbb::task_scheduler_observer {
+    std::atomic<int> my_thread_count{};
+public:
+    leaving_observer(tbb::task_arena& a) : tbb::task_scheduler_observer(a) {
+        observe(true);
+    }
+
+    void on_scheduler_entry(bool) override {
+        ++my_thread_count;
+    }
+
+    void on_scheduler_exit(bool) override {
+        --my_thread_count;
+    }
+
+    void wait_leave() {
+        while (my_thread_count.load() != 0) {
+            std::this_thread::yield();
+        }
+    }
+};
+
 template <typename PerBodyFunc> float test(PerBodyFunc&& body) {
     const std::size_t num_threads = 2 * utils::get_platform_max_threads();
     tbb::global_control concurrency(tbb::global_control::max_allowed_parallelism, num_threads);
     tbb::task_arena big_arena(static_cast<int>(num_threads));
+    leaving_observer observer(big_arena);
 
 #if __TBB_USE_THREAD_SANITIZER
     // Reduce execution time under Thread Sanitizer
@@ -77,8 +101,7 @@ template <typename PerBodyFunc> float test(PerBodyFunc&& body) {
                 tbb::static_partitioner()
             );
         });
-        // TODO:
-        //   - Consider introducing an observer to guarantee the threads left the arena.
+        observer.wait_leave();
     }
 
     std::size_t range_shifts = 0;


### PR DESCRIPTION
### Description 
The `test_partitioner` test was previously relying on worker threads leaving the arena "soon enough" between each `parallel_for`. Now we need to wait, because they block for 1ms before leaving,

Fixes sporadic `test_partitioner` hangs.

- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change
- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests
- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation
- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@omalyshe

### Other information