### PR TITLE
Add a comment explaining why initialize_allocate_handler() is not called in the current library implementation

### DIFF
--- a/src/tbb/allocator.cpp
+++ b/src/tbb/allocator.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -157,6 +157,14 @@ void initialize_cache_aligned_allocator() {
 }
 
 //! Executed on very first call through allocate_handler
+/** Only one of initialize_allocate_handler() and initialize_cache_aligned_allocate_handler()
+    is called, since each one of them also initializes the other.
+
+    In the current implementation of oneTBB library initialization, cache_aligned_allocate() is
+    used, which in turn calls initialize_cache_aligned_allocate_handler(). As mentioned above,
+    that also initializes the regular allocate_handler.
+
+    Therefore, initialize_allocate_handler() is not called in the current library implementation. */
 static void* initialize_allocate_handler(std::size_t size) {
     initialize_cache_aligned_allocator();
     __TBB_ASSERT(allocate_handler != &initialize_allocate_handler, nullptr);


### PR DESCRIPTION
### Description 
- [x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/oneapi-src/oneTBB/blob/master/CONTRIBUTING.md#pull-requests) for details)_

### Type of change
- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests
- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation
- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users

### Other information
