### PR TITLE
slack notification when PR is labeled RFC

### DIFF
--- a/.github/workflows/slack-pr.yaml
+++ b/.github/workflows/slack-pr.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2021-2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Slack PR Notification
+on:
+  # use pull_request_target to run on PRs from forks and have access to secrets
+  pull_request_target:
+    types: [labeled]
+
+env:
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  channel: "onetbb"
+
+permissions:
+  pull-requests: read
+
+jobs:
+  rfc:
+    name: RFC Notification
+    runs-on: ubuntu-latest
+    # Trigger when labeling a PR with "RFC"
+    if: |
+      github.event.action == 'labeled' &&
+      contains(toJson(github.event.pull_request.labels.*.name), '"RFC"')
+    steps: 
+    - name: Notify Slack
+      uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+      with:
+        channel-id: ${{ env.channel }}
+        slack-message: "${{ github.actor }} posted a RFC: ${{ github.event.pull_request.title }}. URL: ${{ github.event.pull_request.html_url }}"


### PR DESCRIPTION
### Description 

Post notification to onetbb channel in uxlfoundation slack space when a PR is labeled with RFC. To see a sample notification, look at #rc-test channel in uxlfoundation slack workspace. This is same as https://github.com/oneapi-src/oneMKL/pull/481, except the channel name and making the license consistent with ci.yml.

To be functional, the PR must be merged and someone with admin access to the repo must add SLACK_BOT_TOKEN secret. I can provide the token in DM.

Partially addresses UXL open source best practices (don't see TBB in https://github.com/orgs/uxlfoundation/projects/5?)
@vbm23


Fixes # - _issue number(s) if exists_

- [ x] - git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md]

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
