### PR TITLE
Don't add -mrtm when building w/ GNU + Emscripten

### DIFF
--- a/cmake/compilers/GNU.cmake
+++ b/cmake/compilers/GNU.cmake
@@ -67,7 +67,7 @@ set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} "-D__TBB_GNU_ASM_VERSIO
 message(STATUS "GNU Assembler version: ${_tbb_gnu_asm_major_version}.${_tbb_gnu_asm_minor_version}  (${_tbb_gnu_asm_version_number})")
 
 # Enable Intel(R) Transactional Synchronization Extensions (-mrtm) and WAITPKG instructions support (-mwaitpkg) on relevant processors
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "(AMD64|amd64|i.86|x86)")
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "(AMD64|amd64|i.86|x86)" AND NOT EMSCRIPTEN)
     set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -mrtm $<$<AND:$<NOT:$<CXX_COMPILER_ID:Intel>>,$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},11.0>>>:-mwaitpkg>)
 endif()
 


### PR DESCRIPTION
Similar to the check done in https://github.com/oneapi-src/oneTBB/blob/d8c53ce141bada427a6eb56fc2fd43d7a210980e/cmake/compilers/Clang.cmake#L57
in GNU.cmake the `-mrtm` flag shouldn't be added when building w/ Emscripten.

I ran into this while trying to compile https://github.com/elalish/manifold w/ pyodide-build (as an out-of-tree package https://pyodide.org/en/stable/development/building-and-testing-packages.html).