### PR TITLE
Fix memory leak for static_partitioner

### DIFF
--- a/include/oneapi/tbb/partitioner.h
+++ b/include/oneapi/tbb/partitioner.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_task.cpp
+++ b/test/tbb/test_task.cpp
@@ -20,6 +20,7 @@
 #include "common/spin_barrier.h"
 #include "common/utils_concurrency_limit.h"
 #include "common/cpu_usertime.h"
+#include "common/memory_usage.h"
 
 #include "tbb/task.h"
 #include "tbb/task_group.h"
@@ -839,4 +840,29 @@ TEST_CASE("Check correct arena destruction with enqueue") {
         }
         tbb::finalize(handle, std::nothrow_t{});
     }
+}
+
+//! \brief \ref regression
+TEST_CASE("Check that memory does not leak with static_partitioner + global_control") {
+    tbb::global_control gbl_ctrl{ tbb::global_control::max_allowed_parallelism, std::size_t(tbb::this_task_arena::max_concurrency() / 2) };
+
+    size_t current_memory_usage = 0, previous_memory_usage = 0, stability_counter = 0;
+    bool no_memory_leak = false;
+    std::size_t num_iterations = 100;
+    for (std::size_t i = 0; i < num_iterations; ++i) {
+        for (std::size_t j = 0; j < 100; ++j) {
+            tbb::parallel_for(0, 1000, [] (int) {}, tbb::static_partitioner{});
+        }
+
+        current_memory_usage = utils::GetMemoryUsage();
+        stability_counter = current_memory_usage==previous_memory_usage ? stability_counter + 1 : 0;
+        // If the amount of used memory has not changed during 5% of executions,
+        // then we can assume that the check was successful
+        if (stability_counter > num_iterations / 20) {
+            no_memory_leak = true;
+            break;
+        }
+        previous_memory_usage = current_memory_usage;
+    }
+    REQUIRE_MESSAGE(no_memory_leak, "Seems we get memory leak here.");
 }

--- a/test/tbb/test_task.cpp
+++ b/test/tbb/test_task.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description 
`global_control` we limit concurrency that all the internal arenas can share between each other. Therefore, each particular arena doesn't not know its actual concurrency limit but only one you explicitly set during construction or for `default arena` (one that will be used for simple `parallel_for` call for example) the concurrency will be a whole machine.
When you start `parallel_for` with `static_partitioner` it will create as many internal `proxy tasks` as `normal tasks` (`proxy tasks` are used to assign tasks to specific threads). `Proxy tasks` have a property they should be executed twice. When execute is called for the `proxy task` for the first time it will return actual task that it propagated. When execute is called for the second time `proxy task` can be deleted.
In test case each time we call `parallel_for` with `static_partitioner` it will create `hardware_concurrency` proxy tasks but because `global_control` is present the concurrency of the default arena will not be fully satisfied and some of the proxy tasks will be called only once so they never be destroyed.

This fix will not help if `global_control` is set concurrently with parallel algorithm execution. Perhaps, this scenario is less probable.

Fixes # - _issue number(s) if exists_ 
#1403 

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@lennoxho

### Other information
