### PR TITLE
throw() -> noexcept

### DIFF
--- a/include/oneapi/tbb/memory_pool.h
+++ b/include/oneapi/tbb/memory_pool.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -97,10 +97,10 @@ public:
         typedef memory_pool_allocator<U, P> other;
     };
 
-    explicit memory_pool_allocator(pool_type &pool) throw() : my_pool(&pool) {}
-    memory_pool_allocator(const memory_pool_allocator& src) throw() : my_pool(src.my_pool) {}
+    explicit memory_pool_allocator(pool_type &pool) noexcept : my_pool(&pool) {}
+    memory_pool_allocator(const memory_pool_allocator& src) noexcept : my_pool(src.my_pool) {}
     template<typename U>
-    memory_pool_allocator(const memory_pool_allocator<U,P>& src) throw() : my_pool(src.my_pool) {}
+    memory_pool_allocator(const memory_pool_allocator<U,P>& src) noexcept : my_pool(src.my_pool) {}
 
     pointer address(reference x) const { return &x; }
     const_pointer address(const_reference x) const { return &x; }
@@ -117,7 +117,7 @@ public:
         my_pool->free(p);
     }
     //! Largest value for which method allocate might succeed.
-    size_type max_size() const throw() {
+    size_type max_size() const noexcept {
         size_type max = static_cast<size_type>(-1) / sizeof (value_type);
         return (max > 0 ? max : 1);
     }
@@ -149,10 +149,10 @@ public:
         typedef memory_pool_allocator<U, P> other;
     };
 
-    explicit memory_pool_allocator( pool_type &pool) throw() : my_pool(&pool) {}
-    memory_pool_allocator( const memory_pool_allocator& src) throw() : my_pool(src.my_pool) {}
+    explicit memory_pool_allocator( pool_type &pool) noexcept : my_pool(&pool) {}
+    memory_pool_allocator( const memory_pool_allocator& src) noexcept : my_pool(src.my_pool) {}
     template<typename U>
-    memory_pool_allocator(const memory_pool_allocator<U,P>& src) throw() : my_pool(src.my_pool) {}
+    memory_pool_allocator(const memory_pool_allocator<U,P>& src) noexcept : my_pool(src.my_pool) {}
 
 protected:
     pool_type *my_pool;

--- a/src/tbbmalloc_proxy/proxy.cpp
+++ b/src/tbbmalloc_proxy/proxy.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -602,8 +602,8 @@ _expand (by dummy implementation)
 ??_V@YAXPEAX@Z    void * operator new[](unsigned __int64) (intel64)
 ??3@YAXPEAX@Z     operator delete                         (intel64)
 ??_V@YAXPEAX@Z    operator delete[]                       (intel64)
-??2@YAPAXIABUnothrow_t@std@@@Z      void * operator new (size_t sz, const std::nothrow_t&) throw()  (optional)
-??_U@YAPAXIABUnothrow_t@std@@@Z     void * operator new[] (size_t sz, const std::nothrow_t&) throw() (optional)
+??2@YAPAXIABUnothrow_t@std@@@Z      void * operator new (size_t sz, const std::nothrow_t&) noexcept  (optional)
+??_U@YAPAXIABUnothrow_t@std@@@Z     void * operator new[] (size_t sz, const std::nothrow_t&) noexcept (optional)
 
 and these functions have runtime-specific replacement:
 realloc

--- a/test/common/exception_handling.h
+++ b/test/common/exception_handling.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -102,7 +102,7 @@ class test_exception : public std::exception {
 public:
     test_exception ( const char* description ) : my_description(description) {}
 
-    const char* what() const throw() override { return my_description; }
+    const char* what() const noexcept override { return my_description; }
 };
 
 class solitary_test_exception : public test_exception {

--- a/test/conformance/conformance_concurrent_hash_map.cpp
+++ b/test/conformance/conformance_concurrent_hash_map.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@
     that concurrent_hash_map uses only the required interface. */
 class MyException : public std::bad_alloc {
 public:
-    virtual const char *what() const throw() override { return "out of items limit"; }
-    virtual ~MyException() throw() {}
+    virtual const char *what() const noexcept override { return "out of items limit"; }
+    virtual ~MyException() noexcept {}
 };
 
 /** Has tightly controlled interface so that we can verify

--- a/test/conformance/conformance_concurrent_queue.cpp
+++ b/test/conformance/conformance_concurrent_queue.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -777,8 +777,8 @@ void TestConcurrentPushPop() {
 
 class Foo_exception : public std::bad_alloc {
 public:
-    virtual const char *what() const throw() override { return "out of Foo limit"; }
-    virtual ~Foo_exception() throw() {}
+    virtual const char *what() const noexcept override { return "out of Foo limit"; }
+    virtual ~Foo_exception() noexcept {}
 };
 
 #if TBB_USE_EXCEPTIONS

--- a/test/tbb/test_task_group.cpp
+++ b/test/tbb/test_task_group.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -397,7 +397,7 @@ class test_exception : public std::exception
 public:
     test_exception ( const char* descr ) : m_strDescription(descr) {}
 
-    const char* what() const throw() override { return m_strDescription; }
+    const char* what() const noexcept override { return m_strDescription; }
 };
 
 using TestException = test_exception;
@@ -1204,4 +1204,3 @@ TEST_CASE("task_handle cannot be scheduled into other task_group of the same con
 }
 
 #endif // TBB_USE_EXCEPTIONS
-


### PR DESCRIPTION
### Description 
Changes the `throw()` function qualifier to `noexcept`. `throw()` is deprecated/removed as of C++17 and `noexcept` is present from C++11, so this should be an easy switch to improve compatibility with newer standards

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [X] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No (unlikely)
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
