### PR TITLE
Improve robustness of leaked observer warning

### DIFF
--- a/src/tbb/governor.cpp
+++ b/src/tbb/governor.cpp
@@ -90,9 +90,11 @@ void governor::release_resources () {
         runtime_warning("failed to destroy task scheduler TLS: %s", std::strerror(status));
     clear_address_waiter_table();
 
+#if TBB_USE_ASSERT
     if (the_observer_proxy_count != 0) {
             runtime_warning("Leaked %ld observer_proxy objects\n", long(the_observer_proxy_count));
     }
+#endif /* TBB_USE_ASSERT */
 
     system_topology::destroy();
     dynamic_unlink_all();

--- a/src/tbb/governor.cpp
+++ b/src/tbb/governor.cpp
@@ -41,6 +41,10 @@ namespace tbb {
 namespace detail {
 namespace r1 {
 
+#if TBB_USE_ASSERT
+std::atomic<int> the_observer_proxy_count;
+#endif /* TBB_USE_ASSERT */
+
 void clear_address_waiter_table();
 void global_control_acquire();
 void global_control_release();
@@ -85,6 +89,10 @@ void governor::release_resources () {
     if( status )
         runtime_warning("failed to destroy task scheduler TLS: %s", std::strerror(status));
     clear_address_waiter_table();
+
+    if (the_observer_proxy_count != 0) {
+            runtime_warning("Leaked %ld observer_proxy objects\n", long(the_observer_proxy_count));
+    }
 
     system_topology::destroy();
     dynamic_unlink_all();

--- a/src/tbb/main.cpp
+++ b/src/tbb/main.cpp
@@ -72,21 +72,6 @@ void ITT_DoUnsafeOneTimeInitialization();
 static __TBB_InitOnce __TBB_InitOnceHiddenInstance;
 #endif
 
-#if TBB_USE_ASSERT
-std::atomic<int> the_observer_proxy_count;
-
-struct check_observer_proxy_count {
-    ~check_observer_proxy_count() {
-        if (the_observer_proxy_count != 0) {
-            runtime_warning("Leaked %ld observer_proxy objects\n", long(the_observer_proxy_count));
-        }
-    }
-};
-// The proxy count checker shall be defined after __TBB_InitOnceHiddenInstance to check the count
-// after auto termination.
-static check_observer_proxy_count the_check_observer_proxy_count;
-#endif /* TBB_USE_ASSERT */
-
 //------------------------------------------------------------------------
 // __TBB_InitOnce
 //------------------------------------------------------------------------

--- a/src/tbb/main.cpp
+++ b/src/tbb/main.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_task.cpp
+++ b/test/tbb/test_task.cpp
@@ -857,7 +857,7 @@ TEST_CASE("Try to force Leaked proxy observers warning") {
 
     arena.enqueue([] {
         tbb::parallel_for(0, 100000, [] (int) {
-            for (volatile int i = 0; i < 1000; ++i);
+            utils::doDummyWork(1000);
         });
     });
 }

--- a/test/tbb/test_task.cpp
+++ b/test/tbb/test_task.cpp
@@ -30,7 +30,7 @@
 
 #include <atomic>
 #include <thread>
-#include <thread>
+#include <deque>
 
 //! \file test_task.cpp
 //! \brief Test for [internal] functionality
@@ -839,4 +839,25 @@ TEST_CASE("Check correct arena destruction with enqueue") {
         }
         tbb::finalize(handle, std::nothrow_t{});
     }
+}
+
+//! \brief \ref regression
+TEST_CASE("Try to force Leaked proxy observers warning") {
+    int num_threads = std::thread::hardware_concurrency() * 2;
+    tbb::global_control gc(tbb::global_control::max_allowed_parallelism, num_threads);
+    tbb::task_arena arena(num_threads, 0);
+    std::deque<tbb::task_scheduler_observer> observers;
+    for (int i = 0; i < 1000; ++i) {
+        observers.emplace_back(arena);
+    }
+
+    for (auto& observer : observers) {
+        observer.observe(true);
+    }
+
+    arena.enqueue([] {
+        tbb::parallel_for(0, 100000, [] (int) {
+            for (volatile int i = 0; i < 1000; ++i);
+        });
+    });
 }

--- a/test/tbb/test_task.cpp
+++ b/test/tbb/test_task.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description 
The Leaked proxy observers warning could appear during the shutdown process even if there was no memory leak (related structures were destroying concurrently).
This patch improves reliability of the  warning by removing dependency on global variable destructor and moving warning to the `release_resources` (all of the proxies should be destroyed 100%).

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
