### PR TITLE
Fix Specs links

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,7 +29,7 @@ if BUILD_TYPE == 'oneapi' or BUILD_TYPE == 'dita':
     project = u'Intel® oneAPI Threading Building Blocks (oneTBB)'
 else:
     project = u'oneTBB'
-copyright = u'2023, Intel Corporation'
+copyright = u'Intel Corporation'
 author = u'Intel'
 
 # The short X.Y version

--- a/doc/main/reference/custom_mutex_chmap.rst
+++ b/doc/main/reference/custom_mutex_chmap.rst
@@ -50,7 +50,7 @@ Type requirements
 -----------------
 
 The type of the mutex passed as a template argument for ``concurrent_hash_map`` should
-meet the requirements of `ReaderWriterMutex <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/mutual_exclusion/rw_mutex_cls>`_.
+meet the requirements of `ReaderWriterMutex <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/named_requirements/mutexes/rw_mutex>`_.
 It should also provide the following API:
 
 .. cpp:function:: bool ReaderWriterMutex::scoped_lock::is_writer() const;

--- a/doc/main/reference/custom_mutex_chmap.rst
+++ b/doc/main/reference/custom_mutex_chmap.rst
@@ -50,7 +50,7 @@ Type requirements
 -----------------
 
 The type of the mutex passed as a template argument for ``concurrent_hash_map`` should
-meet the requirements of `ReaderWriterMutex <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/named_requirements/mutexes/rw_mutex.html>`_.
+meet the requirements of `ReaderWriterMutex <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/mutual_exclusion/rw_mutex_cls>`_.
 It should also provide the following API:
 
 .. cpp:function:: bool ReaderWriterMutex::scoped_lock::is_writer() const;

--- a/doc/main/reference/parallel_for_each_semantics.rst
+++ b/doc/main/reference/parallel_for_each_semantics.rst
@@ -10,7 +10,7 @@ parallel_for_each Body semantics and requirements
 Description
 ***********
 
-This page clarifies `ParallelForEachBody <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/named_requirements/algorithms/par_for_each_body.html>`_
+This page clarifies `ParallelForEachBody <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/named_requirements/algorithms/par_for_each_body>`_
 named requirements for ``tbb::parallel_for_each`` algorithm specification.
 
 .. code:: cpp

--- a/doc/main/reference/parallel_sort_ranges_extension.rst
+++ b/doc/main/reference/parallel_sort_ranges_extension.rst
@@ -10,7 +10,7 @@ parallel_sort ranges interface extension
 Description
 ***********
 
-|full_name| implementation extends the `oneapi::tbb::parallel_sort specification <https://spec.oneapi.io/versions/latest/elements/oneTBB/source/algorithms/functions/parallel_sort_func.html>`_
+|full_name| implementation extends the `oneapi::tbb::parallel_sort specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/named_requirements/algorithms/par_scan_func>`_
 with overloads that takes the container by forwarding reference.
 
 

--- a/doc/main/reference/parallel_sort_ranges_extension.rst
+++ b/doc/main/reference/parallel_sort_ranges_extension.rst
@@ -10,7 +10,7 @@ parallel_sort ranges interface extension
 Description
 ***********
 
-|full_name| implementation extends the `oneapi::tbb::parallel_sort specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/algorithms/functions/parallel_for_func>`_
+|full_name| implementation extends the `oneapi::tbb::parallel_sort specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/algorithms/functions/parallel_sort_func>`_
 with overloads that takes the container by forwarding reference.
 
 

--- a/doc/main/reference/parallel_sort_ranges_extension.rst
+++ b/doc/main/reference/parallel_sort_ranges_extension.rst
@@ -10,7 +10,7 @@ parallel_sort ranges interface extension
 Description
 ***********
 
-|full_name| implementation extends the `oneapi::tbb::parallel_sort specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/named_requirements/algorithms/par_scan_func>`_
+|full_name| implementation extends the `oneapi::tbb::parallel_sort specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/algorithms/functions/parallel_for_func>`_
 with overloads that takes the container by forwarding reference.
 
 

--- a/doc/main/reference/reference.rst
+++ b/doc/main/reference/reference.rst
@@ -3,13 +3,13 @@
 |short_name| API Reference
 ==========================
 
-For oneTBB API Reference, refer to `oneAPI Specification <https://spec.oneapi.com/>`_. The current supported
+For oneTBB API Reference, refer to `oneAPI Specification <https://github.com/uxlfoundation/oneAPI-spec>`_. The current supported
 version of oneAPI Specification is 1.0.
 
 Specification extensions
 ************************
 
-|full_name| implements the `oneTBB specification <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/nested-index.html>`_.
+|full_name| implements the `oneTBB specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/nested-index>`_.
 This document provides additional details or restrictions where necessary.
 It also describes features that are not included in the oneTBB specification.
 

--- a/doc/main/reference/rvalue_reduce.rst
+++ b/doc/main/reference/rvalue_reduce.rst
@@ -10,8 +10,8 @@ Parallel Reduction for rvalues
 Description
 ***********
 
-|full_name| implementation extends the `ParallelReduceFunc <https://spec.oneapi.io/versions/latest/elements/oneTBB/source/named_requirements/algorithms/par_reduce_func.html>`_ and
-`ParallelReduceReduction <https://spec.oneapi.io/versions/latest/elements/oneTBB/source/named_requirements/algorithms/par_reduce_reduction.html>`_
+|full_name| implementation extends the `ParallelReduceFunc <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/named_requirements/algorithms/par_reduce_func>`_ and
+`ParallelReduceReduction <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/named_requirements/algorithms/par_reduce_reduction>`_
 to optimize operating with ``rvalues`` using functional form of ``tbb::parallel_reduce`` and ``tbb::parallel_deterministic_reduce`` algorithms.
 
 API
@@ -33,8 +33,8 @@ or
 
 .. cpp:function:: Value Func::operator()(const Range& range, const Value& x) const
 
-    Accumulates the result for a subrange, starting with initial value ``x``. The ``Range`` type must meet the `Range requirements <https://spec.oneapi.io/versions/latest/elements/oneTBB/source/named_requirements/algorithms/range.html>_`.
-    The ``Value`` type must be the same as a corresponding template parameter for the `parallel_reduce algorithm <https://spec.oneapi.io/versions/latest/elements/oneTBB/source/algorithms/functions/parallel_reduce_func.html>`_.
+    Accumulates the result for a subrange, starting with initial value ``x``. The ``Range`` type must meet the `Range requirements <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/named_requirements/algorithms/range>_`.
+    The ``Value`` type must be the same as a corresponding template parameter for the `parallel_reduce algorithm <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/algorithms/functions/parallel_reduce_func>`_.
 
     If both ``rvalue`` and ``lvalue`` forms are provided, the ``rvalue`` is preferred.
 
@@ -47,7 +47,7 @@ or
 
 .. cpp:function:: Value Reduction::operator()(const Value& x, const Value& y) const
 
-    Combines the ``x`` and ``y`` results. The ``Value`` type must be the same as a corresponding template parameter for the `parallel_reduce algorithm <https://spec.oneapi.io/versions/latest/elements/oneTBB/source/algorithms/functions/parallel_reduce_func.html>`_.
+    Combines the ``x`` and ``y`` results. The ``Value`` type must be the same as a corresponding template parameter for the `parallel_reduce algorithm <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/algorithms/functions/parallel_reduce_func>`_.
 
     If both ``rvalue`` and ``lvalue`` forms are provided, the ``rvalue`` is preferred.
 
@@ -83,7 +83,7 @@ Example
 
 .. rubric:: See also
 
-* `oneapi::tbb::parallel_reduce specification <https://spec.oneapi.io/versions/latest/elements/oneTBB/source/algorithms/functions/parallel_reduce_func.html>`_
-* `oneapi::tbb::parallel_deterministic_reduce specification <https://spec.oneapi.io/versions/latest/elements/oneTBB/source/algorithms/functions/parallel_deterministic_reduce_func.html>`_
-* `ParallelReduceFunc specification <https://spec.oneapi.io/versions/latest/elements/oneTBB/source/named_requirements/algorithms/par_reduce_func.html>`_
-* `ParallelReduceReduction specification <https://spec.oneapi.io/versions/latest/elements/oneTBB/source/named_requirements/algorithms/par_reduce_reduction.html>`_
+* `oneapi::tbb::parallel_reduce specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/algorithms/functions/parallel_reduce_func>`_
+* `oneapi::tbb::parallel_deterministic_reduce specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/algorithms/functions/parallel_deterministic_reduce_func>`_
+* `ParallelReduceFunc specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/named_requirements/algorithms/par_reduce_func>`_
+* `ParallelReduceReduction specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/named_requirements/algorithms/par_reduce_reduction>`_

--- a/doc/main/reference/task_group_extensions.rst
+++ b/doc/main/reference/task_group_extensions.rst
@@ -13,7 +13,7 @@ task_group extensions
 Description
 ***********
 
-|full_name| implementation extends the `tbb::task_group specification <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/task_scheduler/task_group/task_group_cls.html>`_ with the requirements for a user-provided function object.
+|full_name| implementation extends the `tbb::task_group specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/task_scheduler/task_group/task_group_cls>`_ with the requirements for a user-provided function object.
    
 
 API
@@ -83,7 +83,7 @@ As an optimization hint, ``F`` might return a ``task_handle``, which task object
                
 .. rubric:: See also
 
-* `oneapi::tbb::task_group specification <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/task_scheduler/task_group/task_group_cls.html>`_
-* `oneapi::tbb::task_group_context specification <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/task_scheduler/scheduling_controls/task_group_context_cls.html>`_
-* `oneapi::tbb::task_group_status specification <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/task_scheduler/task_group/task_group_status_enum.html>`_ 
-* `oneapi::tbb::task_handle class <https://oneapi-src.github.io/oneAPI-spec/spec/elements/oneTBB/source/task_scheduler/task_group/task_handle.html>`_
+* `oneapi::tbb::task_group specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/task_scheduler/task_group/task_group_cls>`_
+* `oneapi::tbb::task_group_context specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/task_scheduler/scheduling_controls/task_group_context_cls>`_
+* `oneapi::tbb::task_group_status specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/task_scheduler/task_group/task_group_status_enum>`_ 
+* `oneapi::tbb::task_handle class <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/task_scheduler/task_group/task_handle>`_

--- a/doc/main/reference/type_specified_message_keys.rst
+++ b/doc/main/reference/type_specified_message_keys.rst
@@ -66,4 +66,4 @@ lookup and used in place of the default implementation.
 See Also
 ********
 
-`join_node Specification <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/flow_graph/join_node_cls.html>`_
+`join_node Specification <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/flow_graph/join_node_cls>`_

--- a/doc/main/tbb_userguide/Constraints.rst
+++ b/doc/main/tbb_userguide/Constraints.rst
@@ -4,7 +4,7 @@ Constrained APIs
 ================
 
 Starting from C++20, most of |full_name| APIs are constrained to
-enforce `named requirements <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/named_requirements.html>`_ on
+enforce `named requirements <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/named_requirements>`_ on
 template arguments types.
 
 The violations of these requirements are detected at a compile time during the template instantiation.

--- a/doc/main/tbb_userguide/How_Task_Scheduler_Works.rst
+++ b/doc/main/tbb_userguide/How_Task_Scheduler_Works.rst
@@ -7,7 +7,7 @@ How Task Scheduler Works
 While the task scheduler is not bound to any particular type of parallelism, 
 it was designed to work efficiently for fork-join parallelism with lots of forks.
 This type of parallelism is typical for parallel algorithms such as `oneapi::tbb::parallel_for
-<https://spec.oneapi.io/versions/latest/elements/oneTBB/source/algorithms/functions/parallel_for_func.html>`_.
+<https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/algorithms/functions/parallel_for_func>`_.
 
 Let's consider the mapping of fork-join parallelism on the task scheduler in more detail. 
 

--- a/doc/main/tbb_userguide/Migration_Guide/Task_Scheduler_Init.rst
+++ b/doc/main/tbb_userguide/Migration_Guide/Task_Scheduler_Init.rst
@@ -14,27 +14,27 @@ Querying the default number of threads
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * `oneapi::tbb::info::default_concurrency()
-  <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/info_namespace.html>`_
+  <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/info_namespace>`_
   returns the maximum concurrency that will be created by *default* in implicit or explicit ``task_arena``.
 
 * `oneapi::tbb::this_task_arena::max_concurrency()
-  <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/task_scheduler/task_arena/this_task_arena_ns.html>`_
+  <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/task_scheduler/task_arena/this_task_arena_ns>`_
   returns the maximum number of threads available for the parallel algorithms within the current context
   (or *default* if an implicit arena is not initialized)
 
 * `oneapi::tbb::global_control::active_value(tbb::global_control::max_allowed_parallelism)
-  <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/task_scheduler/scheduling_controls/global_control_cls.html>`_
+  <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/task_scheduler/scheduling_controls/global_control_cls>`_
   returns the current limit of the thread pool (or *default* if oneTBB scheduler is not initialized)
 
 Setting the maximum concurrency
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * `task_arena(/* max_concurrency */)
-  <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/task_scheduler/task_arena/this_task_arena_ns.html>`_
+  <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/task_scheduler/task_arena/this_task_arena_ns>`_
   limits the maximum concurrency of the parallel algorithm running inside ``task_arena``
 
 * `tbb::global_control(tbb::global_control::max_allowed_parallelism, /* max_concurrency */)
-  <https://spec.oneapi.com/versions/latest/elements/oneTBB/source/task_scheduler/scheduling_controls/global_control_cls.html>`_
+  <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/task_scheduler/scheduling_controls/global_control_cls>`_
   limits the total number of oneTBB worker threads
 
 Examples
@@ -116,7 +116,7 @@ The limited parallelism:
 Setting thread stack size
 ---------------------------------------
 Use `oneapi::tbb::global_control(oneapi::tbb::global_control::thread_stack_size, /* stack_size */)
-<https://spec.oneapi.com/versions/latest/elements/oneTBB/source/task_scheduler/scheduling_controls/global_control_cls.html>`_
+<https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/task_scheduler/scheduling_controls/global_control_cls>`_
 to set the stack size for oneTBB worker threads:
 
 .. code:: cpp
@@ -141,7 +141,7 @@ to set the stack size for oneTBB worker threads:
 Terminating oneTBB scheduler
 ---------------------------------------
 
-`task_scheduler_handle <https://oneapi-src.github.io/oneAPI-spec/spec/elements/oneTBB/source/task_scheduler/scheduling_controls/task_scheduler_handle_cls.html>`_
+`task_scheduler_handle <https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onetbb/source/task_scheduler/scheduling_controls/task_scheduler_handle_cls>`_
 allows waiting for oneTBB worker threads completion:
 
 .. code:: cpp


### PR DESCRIPTION
### Description 
Fix broken links to the oneAPI Specs and remobe the year from the copyright variable in the conf.py


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
