### PR TITLE
[NFC] add a few missing template keywords

### DIFF
--- a/include/oneapi/tbb/detail/_flow_graph_node_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_node_impl.h
@@ -31,7 +31,7 @@ public:
     }
 
     const T& front() const {
-        return this->item_buffer<T, A>::front();
+        return this->template item_buffer<T, A>::front();
     }
 
     void pop() {

--- a/include/oneapi/tbb/enumerable_thread_specific.h
+++ b/include/oneapi/tbb/enumerable_thread_specific.h
@@ -879,7 +879,7 @@ public:
     ~enumerable_thread_specific() {
         if(my_construct_callback) my_construct_callback->destroy();
         // Deallocate the hash table before overridden free_array() becomes inaccessible
-        this->ets_base<ETS_key_type>::table_clear();
+        this->template ets_base<ETS_key_type>::table_clear();
     }
 
     //! returns reference to local, discarding exists
@@ -943,7 +943,7 @@ private:
         // concurrent_vector::swap() preserves storage space,
         // so addresses to the vector kept in ETS hash table remain valid.
         swap(my_locals, other.my_locals);
-        this->ets_base<ETS_key_type>::table_swap(other);
+        this->template ets_base<ETS_key_type>::table_swap(other);
     }
 
     template<typename A2, ets_key_usage_type C2>


### PR DESCRIPTION
### Description 

Add a few missing `template` keywords to fix compilation errors and warnings with a very recent clang 19 (probably due to this [LLVM commit](https://github.com/llvm/llvm-project/commit/ce4aada6e2135e29839f672a6599db628b53295d)).

This PR only addresses the three specific ones that failed my compilation; more generally an expression of the form
```c++
this->base<T>::func()
```
for some base class template `base` with a member function `func` (CRTP) should probably be
```c++
this->template base<T>::func()
```

Example compilation error and warning:
```
...

In file included from .../include/tbb/combinable.h:17:
In file included from .../oneapi/tbb/combinable.h:22:
.../oneapi/tbb/enumerable_thread_specific.h:882:39: error: no member named 'table_clear' in the global namespace
  882 |         this->ets_base<ETS_key_type>::table_clear();
      |                                     ~~^
.../oneapi/tbb/enumerable_thread_specific.h:882:15: error: cannot refer to type member 'ets_base' in 'tbb::detail::d1::enumerable_thread_specific<T>' with '->'
  882 |         this->ets_base<ETS_key_type>::table_clear();
      |               ^
.../oneapi/tbb/combinable.h:33:7: note: in instantiation of member function 'tbb::detail::d1::enumerable_thread_specific<T>::~enumerable_thread_specific' requested here
   33 | class combinable {
      |       ^
.../oneapi/tbb/enumerable_thread_specific.h:103:7: note: member 'ets_base' declared here
  103 | class ets_base : detail::no_copy {
      |       ^

...

In file included from .../include/tbb/tbb.h:17:
In file included from .../oneapi/tbb.h:49:
In file included from .../include/oneapi/tbb/flow_graph.h:531:
.../include/oneapi/tbb/detail/_flow_graph_node_impl.h:34:22: warning: use 'template' keyword to treat 'item_buffer' as a dependent template name [-Wmissing-dependent-template-keyword]
   34 |         return this->item_buffer<T, A>::front();
      |                      ^
      |                      template 
...
```

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [x] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
