### PR TITLE
Fixed build on non-English locales

### DIFF
--- a/cmake/compilers/GNU.cmake
+++ b/cmake/compilers/GNU.cmake
@@ -48,7 +48,7 @@ endif()
 # information is written to either stdout or stderr. To not make any
 # assumptions, both are captured.
 execute_process(
-    COMMAND ${CMAKE_CXX_COMPILER} -xc -c /dev/null -Wa,-v -o/dev/null
+    COMMAND ${CMAKE_COMMAND} -E env "LANG=C" ${CMAKE_CXX_COMPILER} -xc -c /dev/null -Wa,-v -o/dev/null
     OUTPUT_VARIABLE ASSEMBLER_VERSION_LINE_OUT
     ERROR_VARIABLE ASSEMBLER_VERSION_LINE_ERR
     OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
### Description 
Fixed build error on non-English locales:

```
-- IPO enabled
CMake Error at cmake/compilers/GNU.cmake:65 (math):
 math cannot parse the expression: "GNU ассемблер, версия
 2.41.0 (x86_64-suse-linux); используется BFD версии (GNU
 Binutils; SUSE Linux Enterprise 15) 2.41.0.20230908-150100.7.46 * 1000 +
 GNU ассемблер, версия 2.41.0 (x86_64-suse-linux);
 используется BFD версии (GNU Binutils; SUSE Linux
 Enterprise 15) 2.41.0.20230908-150100.7.46": syntax error, unexpected
 exp_NUMBER, expecting end of file (42).
Call Stack (most recent call first):
 CMakeLists.txt:231 (include)


-- GNU Assembler version: GNU ассемблер, версия 2.41.0 (x86_64-suse-linux); используется BFD версии (GNU Binutils; SUSE Linux Enterprise 15) 2.41.0.20230908-150100.7.46.GNU ассемблер, версия
2.41.0 (x86_64-suse-linux); используется BFD версии (GNU Binutils; SUSE Linux Enterprise 15) 2.41.0.20230908-150100.7.46  (ERROR)
-- The C compiler identification is GNU 11.3.0
```

Bug was introduced in PR #1347


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
