### PR TITLE
Remove std::aligned_storage from unordered containers

### DIFF
--- a/include/oneapi/tbb/concurrent_unordered_map.h
+++ b/include/oneapi/tbb/concurrent_unordered_map.h
@@ -24,14 +24,14 @@
 
 namespace tbb {
 namespace detail {
-namespace d1 {
+namespace d2 {
 
 template <typename Key, typename T, typename Hash, typename KeyEqual, typename Allocator, bool AllowMultimapping>
 struct concurrent_unordered_map_traits {
     using value_type = std::pair<const Key, T>;
     using key_type = Key;
     using allocator_type = Allocator;
-    using hash_compare_type = hash_compare<Key, Hash, KeyEqual>;
+    using hash_compare_type = d1::hash_compare<Key, Hash, KeyEqual>;
     static constexpr bool allow_multimapping = AllowMultimapping;
 
     static constexpr const key_type& get_key( const value_type& value ) {
@@ -399,13 +399,13 @@ void swap( concurrent_unordered_multimap<Key, T, Hash, KeyEqual, Allocator>& lhs
     lhs.swap(rhs);
 }
 
-} // namespace d1
+} // namespace d2
 } // namespace detail
 
 inline namespace v1 {
 
-using detail::d1::concurrent_unordered_map;
-using detail::d1::concurrent_unordered_multimap;
+using detail::d2::concurrent_unordered_map;
+using detail::d2::concurrent_unordered_multimap;
 using detail::split;
 
 } // inline namespace v1

--- a/include/oneapi/tbb/concurrent_unordered_map.h
+++ b/include/oneapi/tbb/concurrent_unordered_map.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/concurrent_unordered_set.h
+++ b/include/oneapi/tbb/concurrent_unordered_set.h
@@ -23,14 +23,14 @@
 
 namespace tbb {
 namespace detail {
-namespace d1 {
+namespace d2 {
 
 template <typename Key, typename Hash, typename KeyEqual, typename Allocator, bool AllowMultimapping>
 struct concurrent_unordered_set_traits {
     using key_type = Key;
     using value_type = key_type;
     using allocator_type = Allocator;
-    using hash_compare_type = hash_compare<key_type, Hash, KeyEqual>;
+    using hash_compare_type = d1::hash_compare<key_type, Hash, KeyEqual>;
     static constexpr bool allow_multimapping = AllowMultimapping;
 
     static constexpr const key_type& get_key( const value_type& value ) {
@@ -318,13 +318,13 @@ void swap( concurrent_unordered_multiset<Key, Hash, KeyEqual, Allocator>& lhs,
     lhs.swap(rhs);
 }
 
-} // namespace d1
+} // namespace d2
 } // namespace detail
 
 inline namespace v1 {
 
-using detail::d1::concurrent_unordered_set;
-using detail::d1::concurrent_unordered_multiset;
+using detail::d2::concurrent_unordered_set;
+using detail::d2::concurrent_unordered_multiset;
 using detail::split;
 
 } // inline namespace v1

--- a/include/oneapi/tbb/concurrent_unordered_set.h
+++ b/include/oneapi/tbb/concurrent_unordered_set.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/detail/_concurrent_unordered_base.h
+++ b/include/oneapi/tbb/detail/_concurrent_unordered_base.h
@@ -46,7 +46,7 @@
 
 namespace tbb {
 namespace detail {
-namespace d1 {
+namespace d2 {
 
 template <typename Traits>
 class concurrent_unordered_base;
@@ -171,7 +171,7 @@ public:
     value_node( sokey_type ord_key ) : base_type(ord_key) {}
     ~value_node() {}
     value_type* storage() {
-        return reinterpret_cast<value_type*>(&my_value);
+        return &my_value;
     }
 
     value_type& value() {
@@ -179,8 +179,9 @@ public:
     }
 
 private:
-    using aligned_storage_type = typename std::aligned_storage<sizeof(value_type)>::type;
-    aligned_storage_type my_value;
+    union {
+        value_type my_value;
+    };
 }; // class value_node
 
 template <typename Traits>
@@ -237,7 +238,7 @@ private:
     template <typename T>
     using is_transparent = dependent_bool<has_transparent_key_equal<key_type, hasher, key_equal>, T>;
 public:
-    using node_type = node_handle<key_type, value_type, value_node_type, allocator_type>;
+    using node_type = d1::node_handle<key_type, value_type, value_node_type, allocator_type>;
 
     explicit concurrent_unordered_base( size_type bucket_count, const hasher& hash = hasher(),
                                         const key_equal& equal = key_equal(), const allocator_type& alloc = allocator_type() )
@@ -441,7 +442,7 @@ public:
 
     std::pair<iterator, bool> insert( node_type&& nh ) {
         if (!nh.empty()) {
-            value_node_ptr insert_node = node_handle_accessor::get_node_ptr(nh);
+            value_node_ptr insert_node = d1::node_handle_accessor::get_node_ptr(nh);
             auto init_node = [&insert_node]( sokey_type order_key )->value_node_ptr {
                 insert_node->init(order_key);
                 return insert_node;
@@ -451,7 +452,7 @@ public:
                 // If the insertion succeeded - set node handle to the empty state
                 __TBB_ASSERT(insert_result.remaining_node == nullptr,
                             "internal_insert_node should not return the remaining node if the insertion succeeded");
-                node_handle_accessor::deactivate(nh);
+                d1::node_handle_accessor::deactivate(nh);
             }
             return { iterator(insert_result.node_with_equal_key), insert_result.inserted };
         }
@@ -521,12 +522,12 @@ public:
 
     node_type unsafe_extract( const_iterator pos ) {
         internal_extract(pos.get_node_ptr());
-        return node_handle_accessor::construct<node_type>(pos.get_node_ptr());
+        return d1::node_handle_accessor::construct<node_type>(pos.get_node_ptr());
     }
 
     node_type unsafe_extract( iterator pos ) {
         internal_extract(pos.get_node_ptr());
-        return node_handle_accessor::construct<node_type>(pos.get_node_ptr());
+        return d1::node_handle_accessor::construct<node_type>(pos.get_node_ptr());
     }
 
     node_type unsafe_extract( const key_type& key ) {
@@ -787,11 +788,11 @@ private:
     static constexpr size_type pointers_per_embedded_table = sizeof(size_type) * 8 - 1;
 
     class unordered_segment_table
-        : public segment_table<std::atomic<node_ptr>, allocator_type, unordered_segment_table, pointers_per_embedded_table>
+        : public d1::segment_table<std::atomic<node_ptr>, allocator_type, unordered_segment_table, pointers_per_embedded_table>
     {
         using self_type = unordered_segment_table;
         using atomic_node_ptr = std::atomic<node_ptr>;
-        using base_type = segment_table<std::atomic<node_ptr>, allocator_type, unordered_segment_table, pointers_per_embedded_table>;
+        using base_type = d1::segment_table<std::atomic<node_ptr>, allocator_type, unordered_segment_table, pointers_per_embedded_table>;
         using segment_type = typename base_type::segment_type;
         using base_allocator_type = typename base_type::allocator_type;
 
@@ -1212,7 +1213,7 @@ protected:
 
                     // Node handle with curr cannot be used directly in insert call, because
                     // the destructor of node_type will destroy curr
-                    node_type curr_node = node_handle_accessor::construct<node_type>(curr);
+                    node_type curr_node = d1::node_handle_accessor::construct<node_type>(curr);
 
                     // If the insertion fails - return ownership of the node to the source
                     if (!insert(std::move(curr_node)).second) {
@@ -1230,7 +1231,7 @@ protected:
                         curr->set_next(next_node);
                         source_prev->set_next(curr);
                         source_prev = curr;
-                        node_handle_accessor::deactivate(curr_node);
+                        d1::node_handle_accessor::deactivate(curr_node);
                     } else {
                         source.my_size.fetch_sub(1, std::memory_order_relaxed);
                     }
@@ -1507,7 +1508,7 @@ bool operator!=( const concurrent_unordered_base<Traits>& lhs,
 #pragma warning(pop) // warning 4127 is back
 #endif
 
-} // namespace d1
+} // namespace d2
 } // namespace detail
 } // namespace tbb
 


### PR DESCRIPTION
### Description 
Continuation of #1394.
Replace std::aligned_storage to unnamed union. 
Increase interface version for concurrent unordered containers to avoid possible issues of alignment changes. 


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
