### PR TITLE
Remove redundant methods from reference_vertex 

### DIFF
--- a/include/oneapi/tbb/detail/_task.h
+++ b/include/oneapi/tbb/detail/_task.h
@@ -172,7 +172,7 @@ public:
         m_wait.reserve(delta);
     }
 
-    void release(std::uint32_t delta = 1, const d1::execution_data* ed = nullptr) override {
+    void release(std::uint32_t delta, const d1::execution_data*) override {
         m_wait.release(delta);
     }
 
@@ -201,7 +201,7 @@ public:
         }
     }
 
-    void release(std::uint32_t delta = 1, const d1::execution_data* ed = nullptr) override {
+    void release(std::uint32_t delta, const d1::execution_data* ed) override {
         std::uint64_t ref = m_ref_count.fetch_sub(static_cast<std::uint64_t>(delta)) - static_cast<std::uint64_t>(delta);
         if (ref == 0) {
             auto parent = my_parent;

--- a/include/oneapi/tbb/detail/_task.h
+++ b/include/oneapi/tbb/detail/_task.h
@@ -158,7 +158,7 @@ public:
 class wait_tree_vertex_interface {
 public:
     virtual void reserve(std::uint32_t delta = 1) = 0;
-    virtual void release(std::uint32_t delta = 1) = 0;
+    virtual void release(std::uint32_t delta = 1, const d1::execution_data* ed = nullptr) = 0;
 
 protected:
     virtual ~wait_tree_vertex_interface() = default;
@@ -172,7 +172,7 @@ public:
         m_wait.reserve(delta);
     }
 
-    void release(std::uint32_t delta = 1) override {
+    void release(std::uint32_t delta = 1, const d1::execution_data* ed = nullptr) override {
         m_wait.release(delta);
     }
 

--- a/include/oneapi/tbb/detail/_task.h
+++ b/include/oneapi/tbb/detail/_task.h
@@ -158,7 +158,7 @@ public:
 class wait_tree_vertex_interface {
 public:
     virtual void reserve(std::uint32_t delta = 1) = 0;
-    virtual void release(std::uint32_t delta = 1, const d1::execution_data* ed = nullptr) = 0;
+    virtual void release(std::uint32_t delta = 1, d1::execution_data* ed = nullptr) = 0;
 
 protected:
     virtual ~wait_tree_vertex_interface() = default;
@@ -172,7 +172,7 @@ public:
         m_wait.reserve(delta);
     }
 
-    void release(std::uint32_t delta, const d1::execution_data*) override {
+    void release(std::uint32_t delta, d1::execution_data*) override {
         m_wait.release(delta);
     }
 
@@ -201,7 +201,7 @@ public:
         }
     }
 
-    void release(std::uint32_t delta, const d1::execution_data* ed) override {
+    void release(std::uint32_t delta, d1::execution_data* ed) override {
         std::uint64_t ref = m_ref_count.fetch_sub(static_cast<std::uint64_t>(delta)) - static_cast<std::uint64_t>(delta);
         if (ref == 0) {
             auto parent = my_parent;
@@ -216,8 +216,8 @@ public:
     }
 
 protected:
-    virtual void execute_continuation(const d1::execution_data*) {}
-    virtual void destroy(const d1::execution_data*) {}
+    virtual void execute_continuation(d1::execution_data*) {}
+    virtual void destroy(d1::execution_data*) {}
 
 private:
     wait_tree_vertex_interface* my_parent;

--- a/include/oneapi/tbb/detail/_task.h
+++ b/include/oneapi/tbb/detail/_task.h
@@ -172,7 +172,8 @@ public:
         m_wait.reserve(delta);
     }
 
-    void release(std::uint32_t delta, d1::execution_data*) override {
+    void release(std::uint32_t delta = 1, d1::execution_data* ed = nullptr) override {
+        suppress_unused_warning(ed);
         m_wait.release(delta);
     }
 
@@ -201,7 +202,7 @@ public:
         }
     }
 
-    void release(std::uint32_t delta, d1::execution_data* ed) override {
+    void release(std::uint32_t delta = 1 , d1::execution_data* ed = nullptr) override {
         std::uint64_t ref = m_ref_count.fetch_sub(static_cast<std::uint64_t>(delta)) - static_cast<std::uint64_t>(delta);
         if (ref == 0) {
             auto parent = my_parent;

--- a/include/oneapi/tbb/detail/_task.h
+++ b/include/oneapi/tbb/detail/_task.h
@@ -218,7 +218,6 @@ public:
 protected:
     virtual void execute_continuation() {}
     virtual void destroy() {}
-    virtual void destroy(const d1::execution_data&) {}
 
 private:
     wait_tree_vertex_interface* my_parent;

--- a/include/oneapi/tbb/detail/_task.h
+++ b/include/oneapi/tbb/detail/_task.h
@@ -201,12 +201,12 @@ public:
         }
     }
 
-    void release(std::uint32_t delta = 1) override {
+    void release(std::uint32_t delta = 1, const d1::execution_data* ed = nullptr) override {
         std::uint64_t ref = m_ref_count.fetch_sub(static_cast<std::uint64_t>(delta)) - static_cast<std::uint64_t>(delta);
         if (ref == 0) {
             auto parent = my_parent;
-            execute_continuation();
-            destroy();
+            execute_continuation(ed);
+            destroy(ed);
             parent->release();
         }
     }
@@ -216,8 +216,8 @@ public:
     }
 
 protected:
-    virtual void execute_continuation() {}
-    virtual void destroy() {}
+    virtual void execute_continuation(const d1::execution_data*) {}
+    virtual void destroy(const d1::execution_data*) {}
 
 private:
     wait_tree_vertex_interface* my_parent;


### PR DESCRIPTION
### Description 
This methods are empty and are not used by any class.

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
