### PR TITLE
Fix coverity issue in the alignToBin with return

### DIFF
--- a/src/tbbmalloc/large_objects.h
+++ b/src/tbbmalloc/large_objects.h
@@ -85,7 +85,10 @@ public:
         int sizeExp = (int)BitScanRev(size);
         MALLOC_ASSERT(sizeExp >= 0, "BitScanRev() cannot return -1, as size >= stepfactor > 0");
         MALLOC_ASSERT(sizeExp >= StepFactorExp, "sizeExp >= StepFactorExp, because size >= stepFactor");
+
         int minorStepExp = sizeExp - StepFactorExp;
+
+        if (minorStepExp < 0) return INT_MAX;
 
         return alignUp(size, 1ULL << minorStepExp);
     }
@@ -98,6 +101,8 @@ public:
         MALLOC_ASSERT(sizeExp >= 0, "BitScanRev() cannot return -1, as size >= stepfactor > 0");
         MALLOC_ASSERT(sizeExp >= StepFactorExp, "sizeExp >= StepFactorExp, because size >= stepFactor");
         int minorStepExp = sizeExp - StepFactorExp;
+
+        if (sizeExp < 0 || minorStepExp < 0) return INT_MAX;
 
         size_t majorStepSize = 1ULL << sizeExp;
         int minorIdx = (size - majorStepSize) >> minorStepExp;


### PR DESCRIPTION
### Description 
Original desc: Those values should be always >=0 but coverity do not know it. Assert should fix it.

This PR adds returning INT_MAX.

Fixes #1492

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [x] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
