### PR TITLE
Fix race on vertex destruction

### DIFF
--- a/include/oneapi/tbb/detail/_task.h
+++ b/include/oneapi/tbb/detail/_task.h
@@ -202,9 +202,10 @@ public:
     }
 
     void release(std::uint32_t delta = 1) override {
+        auto parent = my_parent;
         std::uint64_t ref = m_ref_count.fetch_sub(static_cast<std::uint64_t>(delta)) - static_cast<std::uint64_t>(delta);
         if (ref == 0) {
-            my_parent->release();
+            parent->release();
         }
     }
 


### PR DESCRIPTION
### Description 
There was a race after a reference decrement because the vertex could be destroyed by owner thread since reference counter reached zero.


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
