### PR TITLE
Remove email from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,5 @@ Use GitHub Issues for feature requests, bug reports, and minor inquiries. For br
 oneAPI Threading Building Blocks is licensed under [Apache License, Version 2.0](LICENSE.txt).
 By its terms, contributions submitted to the project are also done under that license.
 
-## Engineering team contacts
-* [Email us.](mailto:inteltbbdevelopers@intel.com)
-
 ------------------------------------------------------------------------
 \* All names and brands may be claimed as the property of others.


### PR DESCRIPTION
### Description 
All the required communication channels are defined in project [README](https://github.com/oneapi-src/oneTBB?tab=readme-ov-file#how-to-contribute).
Therefore, remove email because all communication should be done in public.


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
