### PR TITLE
Stateful allocator support for concurrent_queue and concurrent_bounde…

### DIFF
--- a/include/oneapi/tbb/concurrent_queue.h
+++ b/include/oneapi/tbb/concurrent_queue.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -237,6 +237,8 @@ public:
 
 private:
     void internal_swap(concurrent_queue& src) {
+        if (!allocator_traits_type::queue_allocator_traits::propagate_on_container)
+            __TBB_ASSERT(my_allocator == src.my_allocator, "Swapping with unequal allocators is not allowed");
         using std::swap;
         swap(my_queue_representation, src.my_queue_representation);
     }

--- a/include/oneapi/tbb/concurrent_queue.h
+++ b/include/oneapi/tbb/concurrent_queue.h
@@ -137,27 +137,27 @@ public:
     }
 
     concurrent_queue& operator=( const concurrent_queue& other ) {
-        if (my_queue_representation == other.my_queue_representation)
-            return *this;
-        clear();
-        tbb::detail::copy_assign_allocators(my_allocator, other.my_allocator);
-        my_queue_representation->assign(*other.my_queue_representation, my_allocator, copy_construct_item);
+        if (this != &other) {
+            clear();
+            tbb::detail::copy_assign_allocators(my_allocator, other.my_allocator);
+            my_queue_representation->assign(*other.my_queue_representation, my_allocator, copy_construct_item);
+        }
         return *this;
     }
 
     concurrent_queue& operator=( concurrent_queue&& other ) {
-        if (my_queue_representation == other.my_queue_representation)
-            return *this;
-        clear();
-        if (queue_allocator_traits::propagate_on_container_move_assignment::value) {
-            tbb::detail::move_assign_allocators(my_allocator, other.my_allocator);
-            internal_swap(other);
-        } else {
-            if (my_allocator == other.my_allocator) {
+        if (this != &other) {
+            clear();
+            if (queue_allocator_traits::propagate_on_container_move_assignment::value) {
+                tbb::detail::move_assign_allocators(my_allocator, other.my_allocator);
                 internal_swap(other);
             } else {
-                my_queue_representation->assign(*other.my_queue_representation, my_allocator, move_construct_item);
-                other.clear();
+                if (my_allocator == other.my_allocator) {
+                    internal_swap(other);
+                } else {
+                    my_queue_representation->assign(*other.my_queue_representation, my_allocator, move_construct_item);
+                    other.clear();
+                }
             }
         }
         return *this;
@@ -415,27 +415,27 @@ public:
     }
 
     concurrent_bounded_queue& operator=( const concurrent_bounded_queue& other ) {
-        if (my_queue_representation == other.my_queue_representation)
-            return *this;
-        clear();
-        tbb::detail::copy_assign_allocators(my_allocator, other.my_allocator);
-        my_queue_representation->assign(*other.my_queue_representation, my_allocator, copy_construct_item);
+        if (this != &other) {
+            clear();
+            tbb::detail::copy_assign_allocators(my_allocator, other.my_allocator);
+            my_queue_representation->assign(*other.my_queue_representation, my_allocator, copy_construct_item);
+        }
         return *this;
     }
 
     concurrent_bounded_queue& operator=( concurrent_bounded_queue&& other ) {
-        if (my_queue_representation == other.my_queue_representation)
-            return *this;
-        clear();
-        if (queue_allocator_traits::propagate_on_container_move_assignment::value) {
-            tbb::detail::move_assign_allocators(my_allocator, other.my_allocator);
-            internal_swap(other);
-        } else {
-            if (my_allocator == other.my_allocator) {
+        if (this != &other) {
+            clear();
+            if (queue_allocator_traits::propagate_on_container_move_assignment::value) {
+                tbb::detail::move_assign_allocators(my_allocator, other.my_allocator);
                 internal_swap(other);
             } else {
-                my_queue_representation->assign(*other.my_queue_representation, my_allocator, move_construct_item);
-                other.clear();
+                if (my_allocator == other.my_allocator) {
+                    internal_swap(other);
+                } else {
+                    my_queue_representation->assign(*other.my_queue_representation, my_allocator, move_construct_item);
+                    other.clear();
+                }
             }
         }
         return *this;

--- a/include/oneapi/tbb/concurrent_queue.h
+++ b/include/oneapi/tbb/concurrent_queue.h
@@ -237,7 +237,7 @@ public:
 
 private:
     void internal_swap(concurrent_queue& src) {
-        if (!allocator_traits_type::queue_allocator_traits::propagate_on_container)
+        if (!queue_allocator_traits::propagate_on_container_swap::value)
             __TBB_ASSERT(my_allocator == src.my_allocator, "Swapping with unequal allocators is not allowed");
         using std::swap;
         swap(my_queue_representation, src.my_queue_representation);

--- a/include/oneapi/tbb/concurrent_queue.h
+++ b/include/oneapi/tbb/concurrent_queue.h
@@ -140,9 +140,7 @@ public:
         if (my_queue_representation == other.my_queue_representation)
             return *this;
         clear();
-        if (queue_allocator_traits::propagate_on_container_move_assignment::value) {
-            my_allocator = other.my_allocator;
-        }
+        tbb::detail::copy_assign_allocators(my_allocator, other.my_allocator);
         my_queue_representation->assign(*other.my_queue_representation, my_allocator, copy_construct_item);
         return *this;
     }
@@ -152,7 +150,7 @@ public:
             return *this;
         clear();
         if (queue_allocator_traits::propagate_on_container_move_assignment::value) {
-            my_allocator = std::move(other.my_allocator);
+            tbb::detail::move_assign_allocators(my_allocator, other.my_allocator);
             internal_swap(other);
         } else {
             if (my_allocator == other.my_allocator) {
@@ -182,12 +180,7 @@ public:
     }
 
     void swap ( concurrent_queue& other ) {
-        if (queue_allocator_traits::propagate_on_container_swap::value) {
-            using std::swap;
-            swap(my_allocator, other.my_allocator);
-        } else {
-            __TBB_ASSERT(my_allocator == other.my_allocator, "unequal allocators");
-        }
+        tbb::detail::swap_allocators(my_allocator, other.my_allocator);
         internal_swap(other);
     }
 
@@ -425,9 +418,7 @@ public:
         if (my_queue_representation == other.my_queue_representation)
             return *this;
         clear();
-        if (queue_allocator_traits::propagate_on_container_move_assignment::value) {
-            my_allocator = other.my_allocator;
-        }
+        tbb::detail::copy_assign_allocators(my_allocator, other.my_allocator);
         my_queue_representation->assign(*other.my_queue_representation, my_allocator, copy_construct_item);
         return *this;
     }
@@ -437,7 +428,7 @@ public:
             return *this;
         clear();
         if (queue_allocator_traits::propagate_on_container_move_assignment::value) {
-            my_allocator = std::move(other.my_allocator);
+            tbb::detail::move_assign_allocators(my_allocator, other.my_allocator);
             internal_swap(other);
         } else {
             if (my_allocator == other.my_allocator) {
@@ -467,12 +458,7 @@ public:
     }
 
     void swap ( concurrent_bounded_queue& other ) {
-        if (queue_allocator_traits::propagate_on_container_swap::value) {
-            using std::swap;
-            swap(my_allocator, other.my_allocator);
-        } else {
-            __TBB_ASSERT(my_allocator == other.my_allocator, "unequal allocators");
-        }
+        tbb::detail::swap_allocators(my_allocator, other.my_allocator);
         internal_swap(other);
     }
 

--- a/include/oneapi/tbb/detail/_allocator_traits.h
+++ b/include/oneapi/tbb/detail/_allocator_traits.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@ void swap_allocators_impl( Allocator& lhs, Allocator& rhs, /*pocs = */ std::true
 template <typename Allocator>
 void swap_allocators_impl( Allocator& lhs, Allocator& rhs, /*pocs = */ std::false_type ) {
     // If the lhs and rhs are not equal, the behavior is undefined
-    __TBB_ASSERT(lhs == rhs, "unequal allocators");
+    __TBB_ASSERT(lhs == rhs, "Swapping with unequal allocators is not allowed");
 }
 
 // Swaps allocators only if propagate_on_container_swap is true

--- a/include/oneapi/tbb/detail/_allocator_traits.h
+++ b/include/oneapi/tbb/detail/_allocator_traits.h
@@ -93,7 +93,11 @@ void swap_allocators_impl( Allocator& lhs, Allocator& rhs, /*pocs = */ std::true
 template <typename Allocator>
 void swap_allocators_impl( Allocator& lhs, Allocator& rhs, /*pocs = */ std::false_type ) {
     // If the lhs and rhs are not equal, the behavior is undefined
-    __TBB_ASSERT(lhs == rhs, "Swapping with unequal allocators is not allowed");
+    if (!allocator_traits<Allocator>::is_always_equal::value) {
+        __TBB_ASSERT(lhs == rhs, "Swapping with unequal allocators is not allowed");
+    }
+    tbb::detail::suppress_unused_warning(lhs);
+    tbb::detail::suppress_unused_warning(rhs);
 }
 
 // Swaps allocators only if propagate_on_container_swap is true

--- a/include/oneapi/tbb/detail/_allocator_traits.h
+++ b/include/oneapi/tbb/detail/_allocator_traits.h
@@ -91,7 +91,10 @@ void swap_allocators_impl( Allocator& lhs, Allocator& rhs, /*pocs = */ std::true
 }
 
 template <typename Allocator>
-void swap_allocators_impl( Allocator&, Allocator&, /*pocs = */ std::false_type ) {}
+void swap_allocators_impl( Allocator& lhs, Allocator& rhs, /*pocs = */ std::false_type ) {
+    // If the lhs and rhs are not equal, the behavior is undefined
+    __TBB_ASSERT(lhs == rhs, "unequal allocators");
+}
 
 // Swaps allocators only if propagate_on_container_swap is true
 template <typename Allocator>

--- a/include/oneapi/tbb/detail/_concurrent_queue_base.h
+++ b/include/oneapi/tbb/detail/_concurrent_queue_base.h
@@ -103,7 +103,7 @@ protected:
     using page_allocator_traits = tbb::detail::allocator_traits<page_allocator_type>;
 
 public:
-    using item_constructor_type = void (*)(value_type* location, const void* src);
+    using item_constructor_type = void (*)(queue_allocator_type&, value_type* location, const void* src);
     micro_queue() = default;
     micro_queue( const micro_queue& ) = delete;
     micro_queue& operator=( const micro_queue& ) = delete;
@@ -254,7 +254,7 @@ public:
         new_page->mask.store(src_page->mask.load(std::memory_order_relaxed), std::memory_order_relaxed);
         for (; begin_in_page!=end_in_page; ++begin_in_page, ++g_index) {
             if (new_page->mask.load(std::memory_order_relaxed) & uintptr_t(1) << begin_in_page) {
-                copy_item(*new_page, begin_in_page, *src_page, begin_in_page, construct_item);
+                copy_item(allocator, *new_page, begin_in_page, *src_page, begin_in_page, construct_item);
             }
         }
         return new_page;
@@ -324,11 +324,11 @@ private:
         ~destroyer() {my_value.~T();}
     }; // class destroyer
 
-    void copy_item( padded_page& dst, size_type dindex, const padded_page& src, size_type sindex,
+    void copy_item( queue_allocator_type& allocator, padded_page& dst, size_type dindex, const padded_page& src, size_type sindex,
         item_constructor_type construct_item )
     {
         auto& src_item = src[sindex];
-        construct_item( &dst[dindex], static_cast<const void*>(&src_item) );
+        construct_item( allocator, &dst[dindex], static_cast<const void*>(&src_item) );
     }
 
     void assign_and_destroy_item( void* dst, padded_page& src, size_type index ) {

--- a/include/oneapi/tbb/detail/_concurrent_queue_base.h
+++ b/include/oneapi/tbb/detail/_concurrent_queue_base.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
…d_queue

### Description 
Add support for [allocator propagation](https://en.cppreference.com/w/cpp/named_req/AllocatorAwareContainer) to concurrent_queue and concurrent_bounded_queue, and use the allocator’s construct function instead of placement new.

### Type of change

- [ ] bug fix - _change that fixes an issue_
- [x] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown
