### PR TITLE
Fix race in `concurrent_vector::grow_by()`

### DIFF
--- a/include/oneapi/tbb/concurrent_vector.h
+++ b/include/oneapi/tbb/concurrent_vector.h
@@ -565,14 +565,6 @@ private:
         return new_segment_table;
     }
 
-    void deallocate_long_table(segment_table_type table) {
-        auto& alloc = base_type::get_allocator();
-        for (size_type seg_idx = 0; seg_idx < this->pointers_per_long_table; ++seg_idx) {
-            segment_table_allocator_traits::destroy(alloc, &table[seg_idx]);
-        }
-        segment_table_allocator_traits::deallocate(alloc, table, this->pointers_per_long_table);
-    }
-
     // create_segment function is required by the segment_table base class
     segment_type create_segment( segment_table_type table, segment_index_type seg_index, size_type index ) {
         size_type first_block = this->my_first_block.load(std::memory_order_relaxed);

--- a/include/oneapi/tbb/detail/_concurrent_unordered_base.h
+++ b/include/oneapi/tbb/detail/_concurrent_unordered_base.h
@@ -890,10 +890,6 @@ private:
             // TableType is a pointer
             return nullptr;
         }
-        // deallocate_long_table is required by the segment_table base class, but unused for unordered containers
-        void deallocate_long_table( const typename base_type::atomic_segment* ) {
-            __TBB_ASSERT(false, "This method should never been called");
-        }
 
         // destroy_elements is required by the segment_table base class, but unused for unordered containers
         // this function call but do nothing

--- a/include/oneapi/tbb/detail/_concurrent_unordered_base.h
+++ b/include/oneapi/tbb/detail/_concurrent_unordered_base.h
@@ -890,6 +890,10 @@ private:
             // TableType is a pointer
             return nullptr;
         }
+        // deallocate_long_table is required by the segment_table base class, but unused for unordered containers
+        void deallocate_long_table( const typename base_type::atomic_segment* ) {
+            __TBB_ASSERT(false, "This method should never been called");
+        }
 
         // destroy_elements is required by the segment_table base class, but unused for unordered containers
         // this function call but do nothing

--- a/test/tbb/test_concurrent_vector.cpp
+++ b/test/tbb/test_concurrent_vector.cpp
@@ -693,22 +693,22 @@ TEST_CASE("swap with not always equal allocators"){
 // or fail with the assertion in debug mode.
 //! \brief \ref regression
 TEST_CASE("Testing vector in a highly concurrent environment") {
-    std::uniform_int_distribution<unsigned> uniform_dist(1, 32); // grow by from 1 to 32 randomly
+    std::uniform_int_distribution<> uniform_dist(1, 32); // grow by from 1 to 32 randomly
     std::mt19937_64 gen(/*seed*/1); // Constructing with seed to have reproducible results
-    constexpr unsigned num_repeats = 10000, num_inserts = 256;
+    constexpr int num_repeats = 10000, num_inserts = 256;
     std::vector<int> grow_by_vals(num_inserts);
 
-    for (std::size_t i = 0; i < num_repeats; ++i) {
-        unsigned expected_size = 0;
+    for (int i = 0; i < num_repeats; ++i) {
+        int expected_size = 0;
         std::generate(grow_by_vals.begin(), grow_by_vals.end(),
                       [&gen, &uniform_dist, &expected_size]() {
-                          const unsigned random_value = uniform_dist(gen);
+                          const int random_value = uniform_dist(gen);
                           expected_size += random_value;
                           return random_value;
                       });
 
         tbb::concurrent_vector<double> test_vec;
-        tbb::parallel_for<unsigned>(0, num_inserts, [&] (unsigned j) {
+        tbb::parallel_for(0, num_inserts, [&] (int j) {
             test_vec.grow_by(grow_by_vals[j]);
         });
 


### PR DESCRIPTION
### Description 
When thread tries to grow `concurrent_vector`, it first creates locally a new extended segmentation table, with which it then tries to update the global one. However, before this patch, the thread simply updated the global table not taking into account that there might be the other threads doing the same thing. This patch makes the thread _aware_ about its possibly concurrent environment. 


Fixes #1531

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [X] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [X] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] updated
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
@npotravkin

### Other information
