### PR TITLE
Fix maximum concurrency on Windows with NUMA

### DIFF
--- a/examples/migration/recursive_fibonacci/task_emulation_layer.h
+++ b/examples/migration/recursive_fibonacci/task_emulation_layer.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2023 Intel Corporation
+    Copyright (c) 2023-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 namespace task_emulation {
 
 struct task_group_pool {
-    task_group_pool() : pool_size(std::thread::hardware_concurrency()), task_submitters(new tbb::task_group[pool_size]) {}
+    task_group_pool() : pool_size(tbb::this_task_arena::max_concurrency()), task_submitters(new tbb::task_group[pool_size]) {}
 
     ~task_group_pool() {
         for (std::size_t i = 0; i < pool_size; ++i) {


### PR DESCRIPTION
### Description 
On Windows systems with NUMA, `std::thread::hardware_concurrency()` returns 64 instead of the total number of logical processors.

### Type of change
- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed (the `recursive_fibonacci` example now runs fine on Windows NUMA systems)

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
