### PR TITLE
Fix module show when using Lmod

### DIFF
--- a/integration/linux/modulefiles/tbb
+++ b/integration/linux/modulefiles/tbb
@@ -50,7 +50,7 @@ module-whatis "Dependencies: none"
 proc ModulesHelp { } {
     global modulefilename
     global modulefilever
-    module whatis "${modulefilename}/${modulefilever}"
+    puts "module whatis ${modulefilename}/${modulefilever}"
 }
 
 ##############################################################################

--- a/integration/linux/modulefiles/tbb32
+++ b/integration/linux/modulefiles/tbb32
@@ -50,7 +50,7 @@ module-whatis "Dependencies: none"
 proc ModulesHelp { } {
     global modulefilename
     global modulefilever
-    module whatis "${modulefilename}/${modulefilever}"
+    puts "module whatis ${modulefilename}/${modulefilever}"
 }
 
 ##############################################################################


### PR DESCRIPTION
### Description 
Fix error that appears when using TBB modulefiles (`module show tbb` command) with Lmod:
```sh
Lmod has detected the following error: Unable to load module because of error when evaluating modulefile: tbb
     /opt/intel/oneapi/tbb/2022.0/etc/modulefiles/tbb/2022.0: [string "whatis([===[Name: Intel(R) oneAPI Threading B..."]:14: unexpected symbol
near ']'
     Please check the modulefile and especially if there is a line number specified in the above message
While processing the following module(s):
```


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
