### PR TITLE
Add a forward declaration to avoid a compilation error in GCC ≤ 7

### DIFF
--- a/include/oneapi/tbb/flow_graph.h
+++ b/include/oneapi/tbb/flow_graph.h
@@ -138,6 +138,7 @@ template< typename T > class receiver;
 class continue_receiver;
 
 template< typename T, typename U > class limiter_node;  // needed for resetting decrementer
+template< typename T > class overwrite_node; // needed for the forward friend declaration to work in GCC < 8
 
 template<typename T, typename M> class successor_cache;
 template<typename T, typename M> class broadcast_cache;


### PR DESCRIPTION
### Description 
Fixes
```
include/oneapi/tbb/flow_graph.h: In instantiation of 'bool tbb::detail::d2::overwrite_node<T>::register_successor(tbb::detail::d2::overwrite_node<T>::successor_type&) [with T = tbb::detail::d2::continue_msg; tbb::detail::d2::overwrite_node<T>::successor_type = tbb::detail::d2::receiver<tbb::detail::d2::continue_msg>]':
test/tbb/test_overwrite_node.cpp:435:1:   required from here
include/tbb/oneapi/tbb/flow_graph.h:3322:13: error: 'bool tbb::detail::d2::receiver<T>::is_continue_receiver() [with T = tbb::detail::d2::continue_msg]' is protected within this context
             if (s.is_continue_receiver()) {
             ^~
```

### Type of change
- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests
- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation
- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown