### PR TITLE
Apply -mwaitpkg only to x86-64

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -50,8 +50,8 @@ cc_library(
     ]),
     copts = ["-w"] + select({
         "@platforms//os:windows": [""],
-        "@platforms//cpu:arm64": [""],
-        "//conditions:default": ["-mwaitpkg"],
+        "@platforms//cpu:x86_64": ["-mwaitpkg"],
+        "//conditions:default": [""],
     }),
     defines =
         select({


### PR DESCRIPTION
### Description 

Fixes building oneTBB on armv7 or other non-aarch64, non-x86-64 artchitectures.

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
