### PR TITLE
Send ITT task end notifications with less delay (OV branch)

### DIFF
--- a/src/tbb/task_dispatcher.h
+++ b/src/tbb/task_dispatcher.h
@@ -1,5 +1,6 @@
 /*
-    Copyright (c) 2020-2021 Intel Corporation
+    Copyright (c) 2020-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -110,6 +111,7 @@ inline suspend_point_type::suspend_point_type(arena* a, size_t stack_size, task_
 //------------------------------------------------------------------------
 // Task Dispatcher
 //------------------------------------------------------------------------
+
 inline task_dispatcher::task_dispatcher(arena* a) {
     m_execute_data_ext.context = a->my_default_ctx;
     m_execute_data_ext.task_disp = this;
@@ -168,8 +170,8 @@ inline d1::task* task_dispatcher::steal_or_get_critical(
 
 template <bool ITTPossible, typename Waiter>
 d1::task* task_dispatcher::receive_or_steal_task(
-    thread_data& tls, execution_data_ext& ed, Waiter& waiter, isolation_type isolation,
-    bool fifo_allowed, bool critical_allowed)
+    thread_data& tls, execution_data_ext& ed, Waiter& waiter, context_guard_helper<ITTPossible>& ctxguard,
+    isolation_type isolation, bool fifo_allowed, bool critical_allowed)
 {
     __TBB_ASSERT(governor::is_thread_data_set(&tls), NULL);
     // Task to return
@@ -198,6 +200,9 @@ d1::task* task_dispatcher::receive_or_steal_task(
         if (!waiter.continue_execution(slot, t)) {
             __TBB_ASSERT(t == nullptr, nullptr);
             break;
+        }
+        if( ITTPossible ) {
+            ctxguard.maybe_end_itt_task(waiter.pause_count());
         }
         // Start searching
         if (t != nullptr) {
@@ -340,9 +345,9 @@ d1::task* task_dispatcher::local_wait_for_all(d1::task* t, Waiter& waiter ) {
                     continue;
                 }
                 // Retrieve the task from global sources
-                t = receive_or_steal_task<ITTPossible>(
-                    *m_thread_data, ed, waiter, isolation, dl_guard.old_properties.fifo_tasks_allowed,
-                    critical_allowed
+                t = receive_or_steal_task(
+                    *m_thread_data, ed, waiter, context_guard, isolation,
+                    dl_guard.old_properties.fifo_tasks_allowed, critical_allowed
                 );
             } while (t != nullptr); // main dispatch loop
             break; // Exit exception loop;

--- a/src/tbb/waiters.h
+++ b/src/tbb/waiters.h
@@ -1,5 +1,6 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -42,6 +43,10 @@ public:
 
     void reset_wait() {
         my_backoff.reset_wait();
+    }
+
+    int pause_count() {
+        return my_backoff.limited_pause_count();
     }
 
 protected:


### PR DESCRIPTION
### Description 
This change is cherry-picked from the oneTBB main branch, commit 681b96ecad722879ae42193f39d33dbc2630c34b.
The points where TBB worker threads issue ITT "task end" notifications (on the detection of a new task group context and on the leave of the task dispatch loop) may lead to significant delays with those, sometimes way after completion of the algorithm the "tasks" are supposed to indicate. That leads to skewed results in profiling tools that "consume" the ITT calls.

The patch proposes a change to issue the notification earlier, namely after two unsuccessful attempts to find a non-local task (via stealing, etc.).

### Type of change
- [x] bug fix - _change that fixes an issue_

### Tests
- [x] not needed

### Documentation
- [x] not needed

### Breaks backward compatibility?
- [x] No

### Other information
