### PR TITLE
Specialize get_task for the case of no isolation

### DIFF
--- a/include/oneapi/tbb/detail/_template_helpers.h
+++ b/include/oneapi/tbb/detail/_template_helpers.h
@@ -400,12 +400,12 @@ struct type_identity {
 template <typename T>
 using type_identity_t = typename type_identity<T>::type;
 
-template <bool B, typename Callable>
-typename std::enable_if<B, void>::type invoke_if(Callable&& f) {
+template <typename Callable>
+void invoke_if(std::true_type, Callable&& f) {
     std::forward<Callable>(f)();
 }
-template <bool B, typename Callable>
-typename std::enable_if<!B, void>::type invoke_if(Callable&&) {}
+template <typename Callable>
+void invoke_if(std::false_type, Callable&&) {}
 
 } // inline namespace d0
 } // namespace detail

--- a/include/oneapi/tbb/detail/_template_helpers.h
+++ b/include/oneapi/tbb/detail/_template_helpers.h
@@ -400,6 +400,13 @@ struct type_identity {
 template <typename T>
 using type_identity_t = typename type_identity<T>::type;
 
+template <bool B, typename Callable>
+typename std::enable_if<B, void>::type invoke_if(Callable&& f) {
+    std::forward<Callable>(f)();
+}
+template <bool B, typename Callable>
+typename std::enable_if<!B, void>::type invoke_if(Callable&&) {}
+
 } // inline namespace d0
 } // namespace detail
 } // namespace tbb

--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -551,7 +551,7 @@ inline d1::task* arena::steal_task(unsigned arena_index, FastRandom& frnd, execu
     if (pool == EmptyTaskPool || !(result = victim->steal_task(*this, isolation, k))) {
         return nullptr;
     }
-    result = task_proxy::try_extract_task_from</*stolen=*/true>( result, ed );
+    result = task_proxy::try_extract_task_from( result, ed, /*stolen=*/std::true_type{} );
     if (result) {
         // Update the task owner slot id to identify stealing
         ed.original_slot = k;

--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -546,29 +546,17 @@ inline d1::task* arena::steal_task(unsigned arena_index, FastRandom& frnd, execu
         ++k; // Adjusts random distribution to exclude self
     }
     arena_slot* victim = &my_slots[k];
-    d1::task **pool = victim->task_pool.load(std::memory_order_relaxed);
-    d1::task *t = nullptr;
-    if (pool == EmptyTaskPool || !(t = victim->steal_task(*this, isolation, k))) {
+    d1::task** pool = victim->task_pool.load(std::memory_order_relaxed);
+    d1::task* result = nullptr;
+    if (pool == EmptyTaskPool || !(result = victim->steal_task(*this, isolation, k))) {
         return nullptr;
     }
-    if (task_accessor::is_proxy_task(*t)) {
-        task_proxy &tp = *(task_proxy*)t;
-        d1::slot_id slot = tp.slot;
-        t = tp.extract_task<task_proxy::pool_bit>();
-        if (!t) {
-            // Proxy was empty, so it's our responsibility to free it
-            tp.allocator.delete_object(&tp, ed);
-            return nullptr;
-        }
-        // Note affinity is called for any stolen task (proxy or general)
-        ed.affinity_slot = slot;
-    } else {
-        // Note affinity is called for any stolen task (proxy or general)
-        ed.affinity_slot = d1::any_slot;
+    result = task_proxy::try_extract_task_from</*is_stolen=*/true>( result, ed );
+    if (result) {
+        // Update the task owner slot id to identify stealing
+        ed.original_slot = k;
     }
-    // Update task owner thread id to identify stealing
-    ed.original_slot = k;
-    return t;
+    return result;
 }
 
 template<task_stream_accessor_type accessor>

--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -551,7 +551,7 @@ inline d1::task* arena::steal_task(unsigned arena_index, FastRandom& frnd, execu
     if (pool == EmptyTaskPool || !(result = victim->steal_task(*this, isolation, k))) {
         return nullptr;
     }
-    result = task_proxy::try_extract_task_from</*is_stolen=*/true>( result, ed );
+    result = task_proxy::try_extract_task_from</*stolen=*/true>( result, ed );
     if (result) {
         // Update the task owner slot id to identify stealing
         ed.original_slot = k;

--- a/src/tbb/arena_slot.cpp
+++ b/src/tbb/arena_slot.cpp
@@ -27,10 +27,12 @@ namespace r1 {
 // Arena Slot
 //------------------------------------------------------------------------
 
-d1::task* arena_slot::get_task(execution_data_ext& ed, isolation_type isolation, std::false_type) {
+d1::task* arena_slot::get_task(execution_data_ext& ed, isolation_type isolation, /*use isolation*/ std::false_type) {
+    if ( !is_task_pool_published() )
+        return nullptr;
+
     suppress_unused_warning(isolation);
     __TBB_ASSERT(isolation == no_isolation, nullptr);
-    __TBB_ASSERT(is_task_pool_published(), nullptr);
     bool all_tasks_checked = false;
     // The current task position in the task pool.
     std::size_t T0 = tail.load(std::memory_order_relaxed);
@@ -81,7 +83,10 @@ d1::task* arena_slot::get_task(execution_data_ext& ed, isolation_type isolation,
     return result;
 }
 
-d1::task* arena_slot::get_task(execution_data_ext& ed, isolation_type isolation, std::true_type) {
+d1::task* arena_slot::get_task(execution_data_ext& ed, isolation_type isolation, /*use isolation*/ std::true_type) {
+    if ( !is_task_pool_published() )
+        return nullptr;
+
     bool all_tasks_checked = false;
     bool tasks_skipped = false;
 
@@ -98,7 +103,6 @@ d1::task* arena_slot::get_task(execution_data_ext& ed, isolation_type isolation,
         return nullptr;
     };
 
-    __TBB_ASSERT(is_task_pool_published(), nullptr);
     accessed_by_owner.store(true, std::memory_order_relaxed);
     // The current task position in the task pool.
     std::size_t T0 = tail.load(std::memory_order_relaxed);

--- a/src/tbb/arena_slot.h
+++ b/src/tbb/arena_slot.h
@@ -136,8 +136,10 @@ public:
     //! Get a task from the local pool.
     /** Called only by the pool owner.
         Returns the pointer to the task or nullptr if a suitable task is not found.
-        Resets the pool if it is empty. **/
-    d1::task* get_task(execution_data_ext&, isolation_type);
+        Resets the pool if it is empty.
+        The last parameter is used to differentiate overloads with vs. without task isolation. **/
+    d1::task* get_task(execution_data_ext&, isolation_type, std::false_type);
+    d1::task* get_task(execution_data_ext&, isolation_type, std::true_type);
 
     //! Steal task from slot's ready pool
     d1::task* steal_task(arena&, isolation_type, std::size_t);

--- a/src/tbb/arena_slot.h
+++ b/src/tbb/arena_slot.h
@@ -138,8 +138,8 @@ public:
         Returns the pointer to the task or nullptr if a suitable task is not found.
         Resets the pool if it is empty.
         The last parameter is used to differentiate overloads with vs. without task isolation. **/
-    d1::task* get_task(execution_data_ext&, isolation_type, std::false_type);
-    d1::task* get_task(execution_data_ext&, isolation_type, std::true_type);
+    d1::task* get_task(execution_data_ext&, isolation_type, /*use isolation*/ std::false_type);
+    d1::task* get_task(execution_data_ext&, isolation_type, /*use isolation*/ std::true_type);
 
     //! Steal task from slot's ready pool
     d1::task* steal_task(arena&, isolation_type, std::size_t);

--- a/src/tbb/mailbox.h
+++ b/src/tbb/mailbox.h
@@ -82,11 +82,11 @@ struct task_proxy : public d1::task {
     }
 
     //! Checks if a given task is a proxy, then either extracts the real task or frees the proxy.
-    template<bool stolen = false>
-    static task* try_extract_task_from ( task* t, execution_data_ext& ed ) {
+    template<bool B = false>
+    static task* try_extract_task_from ( task* t, execution_data_ext& ed, std::integral_constant<bool, B> stolen = {} ) {
         __TBB_ASSERT(t && !is_poisoned(t), "Not a valid task pointer");
         if (!task_accessor::is_proxy_task(*t)){
-            invoke_if<stolen>([&ed](){
+            invoke_if( stolen, [&ed](){
                 ed.affinity_slot = d1::any_slot;
             });
             return t;

--- a/src/tbb/mailbox.h
+++ b/src/tbb/mailbox.h
@@ -82,12 +82,13 @@ struct task_proxy : public d1::task {
     }
 
     //! Checks if a given task is a proxy, then either extracts the real task or frees the proxy.
-    template<bool is_stolen = false>
+    template<bool stolen = false>
     static task* try_extract_task_from ( task* t, execution_data_ext& ed ) {
         __TBB_ASSERT(t && !is_poisoned(t), "Not a valid task pointer");
         if (!task_accessor::is_proxy_task(*t)){
-            if constexpr (is_stolen)
+            invoke_if<stolen>([&ed](){
                 ed.affinity_slot = d1::any_slot;
+            });
             return t;
         }
         task_proxy& tp = static_cast<task_proxy&>(*t);

--- a/src/tbb/mailbox.h
+++ b/src/tbb/mailbox.h
@@ -83,7 +83,7 @@ struct task_proxy : public d1::task {
 
     //! Checks if a given task is a proxy, then either extracts the real task or frees the proxy.
     template<bool B = false>
-    static task* try_extract_task_from ( task* t, execution_data_ext& ed, std::integral_constant<bool, B> stolen = {} ) {
+    static task* try_extract_task_from (task* t, execution_data_ext& ed, std::integral_constant<bool, B> stolen = {}) {
         __TBB_ASSERT(t && !is_poisoned(t), "Not a valid task pointer");
         if (!task_accessor::is_proxy_task(*t)){
             invoke_if( stolen, [&ed](){

--- a/src/tbb/scheduler_common.h
+++ b/src/tbb/scheduler_common.h
@@ -595,8 +595,8 @@ public:
                                 context_guard_helper<ITTPossible>& ctxguard,
                                 isolation_type isolation, bool outermost, bool criticality_absence);
 
-    template <bool ITTPossible, typename Waiter>
-    d1::task* local_wait_for_all(d1::task * t, Waiter& waiter);
+    template <bool ITTPossible, bool Isolated, typename Waiter>
+    d1::task* local_wait_for_all(d1::task* t, Waiter& waiter);
 
     task_dispatcher(const task_dispatcher&) = delete;
 

--- a/src/tbb/task_dispatcher.h
+++ b/src/tbb/task_dispatcher.h
@@ -244,7 +244,7 @@ d1::task* task_dispatcher::receive_or_steal_task(
     return t;
 }
 
-template <bool ITTPossible, typename Waiter>
+template <bool ITTPossible, bool Isolated, typename Waiter>
 d1::task* task_dispatcher::local_wait_for_all(d1::task* t, Waiter& waiter ) {
     assert_pointer_valid(m_thread_data);
     __TBB_ASSERT(m_thread_data->my_task_dispatcher == this, nullptr);
@@ -275,8 +275,11 @@ d1::task* task_dispatcher::local_wait_for_all(d1::task* t, Waiter& waiter ) {
     // The context guard to track fp setting and itt tasks.
     context_guard_helper</*report_tasks=*/ITTPossible> context_guard;
 
+    constexpr std::integral_constant<bool, Isolated> use_isolation;
     // Current isolation context
     const isolation_type isolation = dl_guard.old_execute_data_ext.isolation;
+    __TBB_ASSERT((isolation == no_isolation) != Isolated,
+                 "Isolation mismatch; using a wrong instantiation of local_wait_for_all?");
 
     // Critical work inflection point. Once turned false current execution context has taken
     // critical task on the previous stack frame and cannot take more until that critical path is
@@ -363,7 +366,7 @@ d1::task* task_dispatcher::local_wait_for_all(d1::task* t, Waiter& waiter ) {
                     break;
                 }
                 // Retrieve the task from local task pool
-                if (t || (slot.is_task_pool_published() && (t = slot.get_task(ed, isolation)))) {
+                if (t || (slot.is_task_pool_published() && (t = slot.get_task(ed, isolation, use_isolation)))) {
                     __TBB_ASSERT(ed.original_slot == m_thread_data->my_arena_index, nullptr);
                     ed.context = task_accessor::context(*t);
                     ed.isolation = task_accessor::isolation(*t);
@@ -481,11 +484,15 @@ inline d1::task* task_dispatcher::get_mailbox_task(mail_inbox& my_inbox, executi
 
 template <typename Waiter>
 d1::task* task_dispatcher::local_wait_for_all(d1::task* t, Waiter& waiter) {
-    if (governor::is_itt_present()) {
-        return local_wait_for_all</*ITTPossible = */ true>(t, waiter);
-    } else {
-        return local_wait_for_all</*ITTPossible = */ false>(t, waiter);
-    }
+    using instantiation_type = d1::task*(task_dispatcher::*)(d1::task*, Waiter&);
+    static instantiation_type instantiations[] = {
+        &task_dispatcher::local_wait_for_all</*ITTPossible=*/false, /*Isolated=*/false, Waiter>,
+        &task_dispatcher::local_wait_for_all</*ITTPossible=*/false, /*Isolated=*/true,  Waiter>,
+        &task_dispatcher::local_wait_for_all</*ITTPossible=*/true,  /*Isolated=*/false, Waiter>,
+        &task_dispatcher::local_wait_for_all</*ITTPossible=*/true,  /*Isolated=*/true,  Waiter>
+    };
+    const int call_idx = (int(governor::is_itt_present()) << 1) + int(m_execute_data_ext.isolation != no_isolation);
+    return (this->*instantiations[call_idx])(t, waiter);
 }
 
 } // namespace r1

--- a/src/tbb/task_dispatcher.h
+++ b/src/tbb/task_dispatcher.h
@@ -366,7 +366,7 @@ d1::task* task_dispatcher::local_wait_for_all(d1::task* t, Waiter& waiter ) {
                     break;
                 }
                 // Retrieve the task from local task pool
-                if (t || (slot.is_task_pool_published() && (t = slot.get_task(ed, isolation, use_isolation)))) {
+                if (t || (t = slot.get_task(ed, isolation, use_isolation))) {
                     __TBB_ASSERT(ed.original_slot == m_thread_data->my_arena_index, nullptr);
                     ed.context = task_accessor::context(*t);
                     ed.isolation = task_accessor::isolation(*t);


### PR DESCRIPTION
### Description 
After introducing in #1779 a couple of additional operations in `get_task` (which is on the hot path in the task scheduler) that are only useful when the scheduler runs in the task isolation mode, I thought that maybe this function deserves two separate implementations, with and without isolation. This PR elaborates on that idea.

Additionally, it unifies the handling of proxy tasks in `get_task` and `steal_task` into a single routine `task_proxy::try_extract_task_from`.

### Type of change
- Refactoring/optimization

### Tests
- [x] not needed - covered by the existing tests

### Documentation
- [x] not needed

### Breaks backward compatibility?
- [x] No

### Other information
The PR is developed on top of #1779, and so should either be merged afterwards or significantly changed if the base PR is rejected.