### PR TITLE
Send ITT task end notifications with less delay

### DIFF
--- a/src/tbb/scheduler_common.h
+++ b/src/tbb/scheduler_common.h
@@ -1,5 +1,6 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/task_dispatcher.h
+++ b/src/tbb/task_dispatcher.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2020-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/waiters.h
+++ b/src/tbb/waiters.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description 
The points where TBB worker threads issue ITT "task end" notifications (on the detection of a new task group context and on the leave of the task dispatch loop) may lead to significant delays with those, sometimes way after completion of the algorithm the "tasks" are supposed to indicate. That leads to skewed results in profiling tools that "consume" the ITT calls.

The patch proposes a change to issue the notification earlier, namely after a few unsuccessful attempts to find a non-local task (via stealing, etc.). The threshold is set to 2 empirically; we can try finding a "better" value later.

### Type of change
- [x] bug fix - _change that fixes an issue_

### Tests
- [x] not needed

### Documentation
- [x] not needed

### Breaks backward compatibility?
- [x] No

### Other information
There is also an idea to set the threshold to 0 for algorithms invoked with a static_partitioner, where the expected number of tasks per thread is 1. However the right way to deliver this information to the scheduler is not yet clear; and it might require layout changes in `task_group_context`. Therefore this PR does not implement that idea.