### PR TITLE
Enable TTAS strategy for spin_mutex and queuing_mutex

### DIFF
--- a/include/oneapi/tbb/queuing_mutex.h
+++ b/include/oneapi/tbb/queuing_mutex.h
@@ -1,5 +1,6 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/spin_mutex.h
+++ b/include/oneapi/tbb/spin_mutex.h
@@ -1,5 +1,6 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description 
Current implementation of `tbb::spin_mutex::lock`, `tbb::spin_mutex::try_lock` and `tbb::queuing_mutex::scoped_lock::try_acquire` implements TAS (test-and-set) strategy to acquire the lock. `spin_mutex::lock` atomically exchanges the Boolean flag in the backoff loop until the previous value is `false`, meaning the current thread acquires the lock. 
Under high contention since each thread locks the cache line during exchange that results in invalidations on other threads and leads to poor performance scalability. 

The common strategy to fix this issue is to change the strategy to [TTAS](https://en.wikipedia.org/wiki/Test_and_test-and-set) (test and test-and-set). It adds extra check in the backoff loop. It only tries to exchange the atomic if its value is false (mutex unlocked). This will lock the cache line only if the current iteration has a chance to acquire the lock.

Pre-revamp TBB version [used to implement TTAS](https://github.com/uxlfoundation/oneTBB/blob/81e4471d1191c75e0a78311c584b64b6591da842/include/tbb/tbb_machine.h#L925C1-L931C2) in `spin_mutex::lock` but it was changed during TBB Revamp.

This PR restores the previous behavior. It also changes `spin_mutex::try_lock` and `queuing_mutex::scoped_lock::try_acquire` since it can result in the same performance issue if the user is trying to acquire the lock in the loop while doing something else between the attempts:

```cpp
while (!mutex.try_lock()) {
    do_something_useful();
}
```

The chart below shows the performance improvement of using TTAS in `spin_mutex` on the simple benchmark that is doing 10000 iterations of `parallel_for` with `static_partitioner` each contains the 1ns critical section:

<img width="915" height="443" alt="Screenshot 2025-08-27 191307" src="https://github.com/user-attachments/assets/ee113e12-b389-4272-a20a-2fb3ef3aa866" />



Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
