### PR TITLE
Stop enforcing ITT domains to be active

### DIFF
--- a/src/tbb/profiling.cpp
+++ b/src/tbb/profiling.cpp
@@ -1,5 +1,6 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description 

We should not override the ITT domain flags, keeping enabling or disabling of the domains under the control of a collector/tool.

Fixes #1823.

### Type of change
- [x] bug fix - _change that fixes an issue_

### Tests
- [x] not needed - the change only affects analysis by tools and cannot be tested in a "normal" execution environment

### Documentation
- [x] not needed

### Breaks backward compatibility?
- [x] No

Co-authored by @tovinkere