### PR TITLE
Fix missing brief covers for test_tbb_version.cpp

### DIFF
--- a/test/tbb/test_tbb_version.cpp
+++ b/test/tbb/test_tbb_version.cpp
@@ -14,7 +14,6 @@
     limitations under the License.
 */
 
-//! \file test_tbb_version.cpp
 //! Test for the availability of extensions
 //! \file test_tbb_version.cpp
 //! \brief Test for [configuration.feature_macros] specification


### PR DESCRIPTION
### Description 
In #1839 test/tbb/test_tbb_version.cpp was added. It in brief it misses "covers" part.

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests
- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
