### PR TITLE
Remove dead function from task_handle class

### DIFF
--- a/include/oneapi/tbb/detail/_task_handle.h
+++ b/include/oneapi/tbb/detail/_task_handle.h
@@ -267,10 +267,6 @@ private:
 #endif
 
     task_handle(task_handle_task* t) : m_handle {t}{}
-
-    d1::task* release() {
-       return m_handle.release();
-    }
 };
 
 struct task_handle_accessor {


### PR DESCRIPTION
### Description 
Remove `task_handle::release` function since it is not used after merging the dynamic dependencies PR.

Before merging the dynamic dependencies PR, `task_handle::release` was called by `task_handle_accessor::release`.
Since all other functions in `task_handle_accessor` (`ctx_of` and `get_task_dynamic_state`) calls corresponding function from `task_handle::m_handle` field directly, the logic of `release` was also aligned to use `task_handle::m_handle::release` instead of `task_handle::release` (which is doing the same).


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
