### PR TITLE
Fix returning an empty task_handle from task_group task

### DIFF
--- a/include/oneapi/tbb/task_group.h
+++ b/include/oneapi/tbb/task_group.h
@@ -137,7 +137,7 @@ namespace {
         task_handle th = std::forward<F>(f)();
         task_handle_task* task_ptr = task_handle_accessor::release(th);
         // If task has unresolved dependencies, it can't be bypassed
-        if (task_ptr->has_dependencies() && !task_ptr->release_dependency()) {
+        if (task_ptr && task_ptr->has_dependencies() && !task_ptr->release_dependency()) {
             task_ptr = nullptr;
         }
 

--- a/test/tbb/test_task_group.cpp
+++ b/test/tbb/test_task_group.cpp
@@ -1172,6 +1172,16 @@ TEST_CASE("Task handle for scheduler bypass"){
 
     tg.wait();
     CHECK_MESSAGE(run == true, "task handle returned by user lambda (bypassed) should be run");
+
+    // Test returning an empty handle
+    run = false;
+    tg.run([&] {
+        run = true;
+        return tbb::task_handle{};
+    });
+
+    tg.wait();
+    CHECK(run == true);
 }
 
 //! The test for task_handle inside other task waiting with run_and_wait
@@ -1187,6 +1197,13 @@ TEST_CASE("Task handle for scheduler bypass via run_and_wait"){
     });
 
     CHECK_MESSAGE(run == true, "task handle returned by user lambda (bypassed) should be run");
+
+    // Test returning an empty handle
+    run = false;
+    tg.run_and_wait([&] {
+        run = true;
+    });
+    CHECK(run == true);
 }
 #endif //__TBB_PREVIEW_TASK_GROUP_EXTENSIONS
 


### PR DESCRIPTION
### Description 
Task Group Dynamic Dependencies broke the case when an empty `task_handle` is bypassed.
Current documentation do not explicitly allow it, but it is needed to implement constructions like below:

```cpp
class group_task {
    tbb::task_handle operator()() const {
        if (range-too-small) {
            // Do serial work
            return tbb::task_handle{}; // nothing to bypass, but the operator signature forces to return something
        } else {
            // Split work and run in parallel
            tbb::task_handle left = tg.defer(left-subtask);
            tbb::task_handle right = tg.defer(right-subtask);
            
            // Submit the right part
            tg.run(std::move(right);
            
            // Bypass the left part
            return left;
        }
    }
};
```


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
