### PR TITLE
Run CodeQL only when the source code and tests changed

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ on:
     paths:
       - 'src/**'
       - 'include/**'
-      - 'tests/**'
+      - 'test/**'
       - 'python/**'
       - '.github/workflows/codeql.yml'
   schedule:


### PR DESCRIPTION
### Description 
Currently CodeQL scan is run on PRs with any changes even non-related to the source code (e.g. changes in documentation). It negatively affects CI run time.
This will limit the paths to src, include, tests and python. Also the workflow will be run when the change is done in the workflow itself.

Verified on PRs in the fork https://github.com/omalyshe/oneTBB/pulls 

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [X] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
