### PR TITLE
Extend blocked_nd_range construction test with necessary checks

### DIFF
--- a/test/conformance/conformance_blocked_nd_range.cpp
+++ b/test/conformance/conformance_blocked_nd_range.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2017-2025 Intel Corporation
+    Copyright (c) 2017-2024 Intel Corporation
     Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
### Description 
Test for blocked_nd_range constructors do not contain any begin/end/grainsize checks for most cases. 
Add necessary checks


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
