### PR TITLE
Fix Windows Clang compiler flags in CMake configuration

### DIFF
--- a/cmake/compilers/Clang.cmake
+++ b/cmake/compilers/Clang.cmake
@@ -38,8 +38,14 @@ elseif (MSVC)
     include(${CMAKE_CURRENT_LIST_DIR}/MSVC.cmake)
     return()
 else()
-    set(TBB_LINK_DEF_FILE_FLAG -Wl,--version-script=)
-    set(TBB_DEF_FILE_PREFIX lin${TBB_ARCH})
+    # On Windows, use Windows .def file format, not Linux version-script
+    if(WIN32)
+        set(TBB_LINK_DEF_FILE_FLAG ${CMAKE_LINK_DEF_FILE_FLAG})
+        set(TBB_DEF_FILE_PREFIX win${TBB_ARCH})
+    else()
+        set(TBB_LINK_DEF_FILE_FLAG -Wl,--version-script=)
+        set(TBB_DEF_FILE_PREFIX lin${TBB_ARCH})
+    endif()
     set(TBB_TEST_COMPILE_FLAGS ${TBB_TEST_COMPILE_FLAGS} $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},10.0>>:-ffp-model=precise>)
 endif()
 
@@ -63,14 +69,21 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "(AMD64|amd64|i.86|x86)" AND NOT EMSCRIPTEN)
 endif()
 
 # Clang flags to prevent compiler from optimizing out security checks
-set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -Wformat -Wformat-security -Werror=format-security -fPIC $<$<NOT:$<BOOL:${EMSCRIPTEN}>>:-fstack-protector-strong>)
+# Don't use -fPIC, -fstack-clash-protection, -fcf-protection on Windows (not supported by Clang with MSVC toolchain)
+# Also disable CRT security warnings on Windows (getenv, strncpy, etc. are deprecated but TBB uses them)
+if(WIN32)
+    set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -Wformat -Wformat-security -Werror=format-security -D_CRT_SECURE_NO_WARNINGS $<$<NOT:$<BOOL:${EMSCRIPTEN}>>:-fstack-protector-strong>)
+else()
+    set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -Wformat -Wformat-security -Werror=format-security -fPIC $<$<NOT:$<BOOL:${EMSCRIPTEN}>>:-fstack-protector-strong>)
+endif()
 
-if (NOT APPLE AND NOT ANDROID_PLATFORM AND CMAKE_SYSTEM_PROCESSOR MATCHES "(AMD64|amd64|i.86|x86)")
+if (NOT APPLE AND NOT ANDROID_PLATFORM AND CMAKE_SYSTEM_PROCESSOR MATCHES "(AMD64|amd64|i.86|x86)" AND NOT WIN32)
     set(TBB_LIB_COMPILE_FLAGS ${TBB_LIB_COMPILE_FLAGS} -fstack-clash-protection $<$<NOT:$<BOOL:${EMSCRIPTEN}>>:-fcf-protection=full>)
 endif()
 
-# -z switch is not supported on MacOS
-if (NOT APPLE)
+# -z switch is not supported on MacOS and Windows
+# On Windows, lld-link doesn't support -z options (Linux-specific)
+if (NOT APPLE AND NOT WIN32)
     set(TBB_LIB_LINK_FLAGS ${TBB_LIB_LINK_FLAGS} -Wl,-z,relro,-z,now,-z,noexecstack)
 endif()
 


### PR DESCRIPTION
### Description 

This PR fixes Windows build compatibility issues when using Clang as the compiler on Windows (with the MSVC toolchain). The build system was previously attempting to use Linux-specific compiler and linker flags that are not supported on Windows, causing build failures or warnings. This change adds conditional logic to use platform-appropriate flags based on the target platform.

**Context:**
When Clang is used on Windows (not MSVC compiler, but Clang with MSVC toolchain), it has different capabilities and limitations compared to Clang on Linux. The previous code assumed a Linux-like environment, which caused issues on Windows.

**Key Changes:**

1. **DEF File Format Handling (lines 41-48):**
   - On Windows, use Windows `.def` file format via `CMAKE_LINK_DEF_FILE_FLAG` instead of Linux version-script format
   - Use `win${TBB_ARCH}` prefix for Windows DEF files instead of `lin${TBB_ARCH}`
   - Maintains backward compatibility for non-Windows platforms

2. **Compile Flags (lines 72-78):**
   - Excludes `-fPIC` on Windows (not supported by Clang with MSVC toolchain)
   - Excludes `-fstack-clash-protection` and `-fcf-protection` on Windows (not supported)
   - Adds `-D_CRT_SECURE_NO_WARNINGS` to suppress CRT security warnings for deprecated functions (e.g., `getenv`, `strncpy`) that TBB uses
   - Retains `-fstack-protector-strong` and format security checks on Windows

3. **Library Compile Flags (line 80):**
   - Explicitly excludes Windows from `-fstack-clash-protection` and `-fcf-protection=full` flags
   - These flags are only applied on non-Apple, non-Android, x86/x64 platforms that are not Windows

4. **Linker Flags (lines 84-88):**
   - Excludes Windows from `-z` linker options (relro, now, noexecstack)
   - These options are Linux-specific and not supported by `lld-link` on Windows
   - Updated comments to clarify that `-z` switch is not supported on both macOS and Windows

**Impact:**
- ✅ Windows builds with Clang (MSVC toolchain) now succeed without unsupported flag errors
- ✅ Proper Windows `.def` file format is used instead of Linux version-script
- ✅ CRT security warnings are suppressed for deprecated functions that TBB uses
- ✅ No impact on Linux, macOS, or other platforms (backward compatible)

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information

**Testing:**
- ✅ Verified that the changes maintain existing behavior on Linux and macOS
- ✅ Tested that Windows builds with Clang (MSVC toolchain) now succeed without unsupported flag errors
- ✅ Confirmed that Windows-specific DEF file format is correctly used
- ✅ Verified that all conditional branches work correctly for their respective platforms

**Technical Details:**
- The changes use `WIN32` CMake variable to detect Windows platform (works for both native Windows and cross-compilation)
- Windows-specific flags are only applied when `WIN32` is true, ensuring other platforms are unaffected
- The `-z` linker options are Linux ELF-specific and not supported by `lld-link` on Windows
- `-fPIC` is not needed on Windows as DLLs use a different linking model

