### PR TITLE
Fix build of sycl examples under Windows

### DIFF
--- a/examples/sycl/tbb-async-sycl/CMakeLists.txt
+++ b/examples/sycl/tbb-async-sycl/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2020-2025 Intel Corporation
+# Copyright (c) 2026 UXL Foundation Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/sycl/tbb-resumable-tasks-sycl/CMakeLists.txt
+++ b/examples/sycl/tbb-resumable-tasks-sycl/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2020-2025 Intel Corporation
+# Copyright (c) 2026 UXL Foundation Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/sycl/tbb-task-sycl/CMakeLists.txt
+++ b/examples/sycl/tbb-task-sycl/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2020-2025 Intel Corporation
+# Copyright (c) 2026 UXL Foundation Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description 

Under Windows (Intel(R) oneAPI DPC++/C++ Compiler Version 2025.3.0 Build 20251010 in VS2022 environment), I followed the instruction in examples/sycl/README.md and unable to build sycl examples with such failures.

1. `fsycl` is invalid compiler key. `-fsycl` must be used.
2.  Exceptions is used in 2 of the examples. `/EHsc` or equivalent is required.
3. In current version, linker is called without `-fsycl`. For me, it leads to run-time crash. The flag is added in manner compatible to CMake 3.4.

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [X] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
