### PR TITLE
FreeBSD: Add affinity support to tests

### DIFF
--- a/test/common/utils_concurrency_limit.h
+++ b/test/common/utils_concurrency_limit.h
@@ -335,8 +335,8 @@ private:
 std::vector<int> get_cpuset_indices() {
     std::vector<int> result;
 #if __linux__ || __FreeBSD__
-cpu_set_type mask;
-sched_getaffinity(0, sizeof(cpu_set_type), &mask);
+    cpu_set_type mask;
+    sched_getaffinity(0, sizeof(cpu_set_type), &mask);
     int nproc = sysconf(_SC_NPROCESSORS_ONLN);
     for (int i = 0; i < nproc; ++i) {
         if (CPU_ISSET(i, &mask)) {


### PR DESCRIPTION
Fixes test 63:

63 - test_hw_concurrency (Subprocess aborted)

### Description 

Hi,

Following PR https://github.com/uxlfoundation/oneTBB/pull/1945, here is a patch to fix the last failing test (63) by using sched_getaffinity() on FreeBSD.

Best regards,

Ganael Laplanche