### PR TITLE
Add UXL copyright to DLL properties

### DIFF
--- a/src/tbb/tbb.rc
+++ b/src/tbb/tbb.rc
@@ -55,7 +55,7 @@ BEGIN
             VALUE "CompanyName", "Intel Corporation\0"
             VALUE "FileDescription", "oneAPI Threading Building Blocks (oneTBB) library\0"
             VALUE "FileVersion", TBB_VERSION "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2005-2026 Intel Corporation\0"
+            VALUE "LegalCopyright", "\251 2005-2025 Intel Corporation. \251 2026 UXL Foundation Contributors\0"
             VALUE "LegalTrademarks", "\0"
 #ifndef TBB_USE_DEBUG
             VALUE "OriginalFilename", "tbb12.dll\0"

--- a/src/tbbbind/tbb_bind.rc
+++ b/src/tbbbind/tbb_bind.rc
@@ -55,7 +55,7 @@ BEGIN
             VALUE "CompanyName", "Intel Corporation\0"
             VALUE "FileDescription", "oneAPI Threading Building Blocks (oneTBB) library\0"
             VALUE "FileVersion", TBB_VERSION "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2005-2026 Intel Corporation\0"
+            VALUE "LegalCopyright", "\251 2005-2025 Intel Corporation. \251 2026 UXL Foundation Contributors\0"
             VALUE "LegalTrademarks", "\0"
 #ifndef TBB_USE_DEBUG
             VALUE "OriginalFilename", "tbbbind.dll\0"

--- a/src/tbbmalloc/tbbmalloc.rc
+++ b/src/tbbmalloc/tbbmalloc.rc
@@ -55,7 +55,7 @@ BEGIN
             VALUE "CompanyName", "Intel Corporation\0"
             VALUE "FileDescription", "oneAPI Threading Building Blocks (oneTBB) library\0"
             VALUE "FileVersion", TBB_VERSION "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2005-2026 Intel Corporation\0"
+            VALUE "LegalCopyright", "\251 2005-2025 Intel Corporation. \251 2026 UXL Foundation Contributors\0"
             VALUE "LegalTrademarks", "\0"
 #ifndef TBB_USE_DEBUG
             VALUE "OriginalFilename", "tbbmalloc.dll\0"

--- a/src/tbbmalloc_proxy/tbbmalloc_proxy.rc
+++ b/src/tbbmalloc_proxy/tbbmalloc_proxy.rc
@@ -55,7 +55,7 @@ BEGIN
             VALUE "CompanyName", "Intel Corporation\0"
             VALUE "FileDescription", "oneAPI Threading Building Blocks (oneTBB) library\0"
             VALUE "FileVersion", TBB_VERSION "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2005-2026 Intel Corporation\0"
+            VALUE "LegalCopyright", "\251 2005-2025 Intel Corporation. \251 2026 UXL Foundation Contributors\0"
             VALUE "LegalTrademarks", "\0"
 #ifndef TBB_USE_DEBUG
             VALUE "OriginalFilename", "tbbmalloc_proxy.dll\0"


### PR DESCRIPTION
### Description 
DLL properties are updated with UXL copyright. 
It will look like 
<img width="414" height="515" alt="image" src="https://github.com/user-attachments/assets/5ca3b83c-10ac-4cb6-be6c-4b2425ebf345" />




Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
