### PR TITLE
Extend gcc 12-14 workaround in notify_one_relaxed() to 15

### DIFF
--- a/cmake/compilers/GNU.cmake
+++ b/cmake/compilers/GNU.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2020-2025 Intel Corporation
+# Copyright (c) 2026 UXL Foundation Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -85,8 +86,8 @@ if (NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL Intel)
     set(TBB_DSE_FLAG $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},6.0>>:-flifetime-dse=1>)
     set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},8.0>>:-fstack-clash-protection>)
 
-    # Suppress GCC 12.x-14.x warning here that to_wait_node(n)->my_is_in_list might have size 0
-    set(TBB_COMMON_LINK_FLAGS ${TBB_COMMON_LINK_FLAGS} $<$<AND:$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},12.0>>,$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},15.0>>:-Wno-stringop-overflow>)
+    # Suppress GCC 12.x-15.x warning here that to_wait_node(n)->my_is_in_list might have size 0
+    set(TBB_COMMON_LINK_FLAGS ${TBB_COMMON_LINK_FLAGS} $<$<AND:$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},12.0>>,$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},16.0>>:-Wno-stringop-overflow>)
 endif()
 
 # Workaround for heavy tests and too many symbols in debug (rellocation truncated to fit: R_MIPS_CALL16)

--- a/src/tbb/concurrent_monitor.h
+++ b/src/tbb/concurrent_monitor.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2025 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -291,14 +292,14 @@ public:
             if (n != end) {
                 my_waitset.remove(*n);
 
-// GCC 12.x-14.x issues a warning here that to_wait_node(n)->my_is_in_list might have size 0, since n is
+// GCC 12.x-15.x issues a warning here that to_wait_node(n)->my_is_in_list might have size 0, since n is
 // a base_node pointer. (This cannot happen, because only wait_node pointers are added to my_waitset.)
-#if (__TBB_GCC_VERSION >= 120100 && __TBB_GCC_VERSION < 150000 ) && !__clang__ && !__INTEL_COMPILER
+#if (__TBB_GCC_VERSION >= 120100 && __TBB_GCC_VERSION < 160000 ) && !__clang__ && !__INTEL_COMPILER
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
                 to_wait_node(n)->my_is_in_list.store(false, std::memory_order_relaxed);
-#if (__TBB_GCC_VERSION >= 120100 && __TBB_GCC_VERSION < 150000 ) && !__clang__ && !__INTEL_COMPILER
+#if (__TBB_GCC_VERSION >= 120100 && __TBB_GCC_VERSION < 160000 ) && !__clang__ && !__INTEL_COMPILER
 #pragma GCC diagnostic pop
 #endif
             }


### PR DESCRIPTION
### Description 

GCC 15 give this warning turned error during build:

[ 56%] Building CXX object test/CMakeFiles/test_concurrent_monitor.dir/tbb/test_concurrent_monitor.cpp.o In file included from /usr/include/c++/15/atomic:52,
                 from /home/pere/tbb-upsream/test/common/doctest.h:3230,
                 from /home/pere/tbb-upsream/test/common/test.h:32,
                 from /home/pere/tbb-upsream/test/tbb/test_concurrent_monitor.cpp:27:
In member function 'void std::__atomic_base<_IntTp>::store(__int_type, std::memory_order) [with _ITp = bool]',
    inlined from 'void std::atomic<bool>::store(bool, std::memory_order)' at /usr/include/c++/15/atomic:113:20,
    inlined from 'void tbb::detail::r1::concurrent_monitor_base<Context>::notify_one_relaxed() [with Context = unsigned int]' at /home/pere/tbb-upsream/test/tbb/../../src/tbb/concurrent_monitor.h:300:53,
    inlined from 'void tbb::detail::r1::concurrent_monitor_base<Context>::notify_one() [with Context = unsigned int]' at /home/pere/tbb-upsream/test/tbb/../../src/tbb/concurrent_monitor.h:276:27,
    inlined from 'void DOCTEST_ANON_FUNC_41()' at /home/pere/tbb-upsream/test/tbb/test_concurrent_monitor.cpp:88:44:
/usr/include/c++/15/bits/atomic_base.h:477:25: error: 'void __atomic_store_1(volatile void*, unsigned char, int)' writing 1 byte into a region of size 0 overflows the destination [-Werror=stringop-overflow=]
  477 |         __atomic_store_n(&_M_i, __i, int(__m));
      |         ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown
