### PR TITLE
Only look for old Linux kernel versions on Linux.

### DIFF
--- a/test/common/memory_usage.h
+++ b/test/common/memory_usage.h
@@ -74,7 +74,8 @@ namespace utils {
         peakUsage
     };
 
-#if __unix__
+#if __linux__
+
     inline unsigned LinuxKernelVersion()
     {
         unsigned digit1, digit2, digit3;
@@ -125,8 +126,11 @@ namespace utils {
                 break;
             }
         }
-        // VmPeak is available in kernels staring 2.6.15
-        if (stat != peakUsage || LinuxKernelVersion() >= 2006015)
+        // VmPeak is available in Linux kernels staring 2.6.15
+        if (stat != peakUsage
+#if __linux__
+            || LinuxKernelVersion() >= 2006015)
+#endif
             ASSERT(size, "Invalid /proc/self/status format, pattern not found.");
         fclose(fst);
         return size * 1024;


### PR DESCRIPTION
### Description

This do not work well on GNU Hurd, where the kernel version is 0.9.

This get test_malloc_compliance working on GNU Hurd.

This fix is related to #2027.

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ x tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown