### PR TITLE
Adjusted test_lightweight to avoid zero threads in test.

### DIFF
--- a/test/common/graph_utils.h
+++ b/test/common/graph_utils.h
@@ -953,7 +953,7 @@ template<typename NodeType>
 void test_lightweight(unsigned N) {
     test_unlimited_lightweight_execution<NodeType>(N);
     test_limited_lightweight_execution<NodeType>(N, tbb::flow::serial);
-    test_limited_lightweight_execution<NodeType>(N, (std::min)(std::thread::hardware_concurrency() / 2, N/2));
+    test_limited_lightweight_execution<NodeType>(N, (std::min)((std::thread::hardware_concurrency()+1) / 2, N/2));
 
     test_limited_lightweight_execution_with_throwing_body<NodeType>(N, tbb::flow::serial);
 }


### PR DESCRIPTION
### Description 

When the hardware only support one core, hardware_concurrency() return 1, which when deviced by 2 using integer division end up as 0, a useless number of threads.  Instead, ensure it end up as 1, while the other return values still end up with a sensible number by changing (i/2) to ((i+1)/2).

This fix is related to #2027.

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown
