### PR TITLE
Limit cleanup loop in test_tbb_fork to 5 iterations.

### DIFF
--- a/test/tbb/test_tbb_fork.cpp
+++ b/test/tbb/test_tbb_fork.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -310,9 +311,13 @@ int main()
 
                         ASSERT(0, "Hang after fork");
                     }
-                    // clean pending signals (if any occurs since sigwait)
+                    // clean pending signals (if any occurs since
+                    // sigwait).  Should be at most one SIGALRM and
+                    // one SIGCHILD, so 5 iterations should be more
+                    // than enough
                     sigset_t p_mask;
-                    for (;;) {
+                    int loop = 0;
+                    for (; loop < 5; loop++) {
                         sigemptyset(&p_mask);
                         sigpending(&p_mask);
                         if (sigismember(&p_mask, SIGALRM)
@@ -321,7 +326,10 @@ int main()
                                 ASSERT(0, "sigwait failed");
                         } else
                             break;
+                        sleep(1);
                     }
+                    if (5 == loop)
+                        ASSERT(0, "sigpending never emptied");
                 }
             }
 #endif // _WIN32||_WIN64


### PR DESCRIPTION
### Description 

There is no reason why the loop to clean up any pending signals should need more than two iterations to complete any SIGALRM and SIGCHLD remaining.  Break the loop after 5 iterations and abort if it ever take this long, and sleep for one second every iteration to give even slow machines time to process the child.

On GNU Hurd, the loop some times got stuck (around 1/3 of runs during my testing) in a endless stream of SIGCHLD signals.  This code change ensure the test exits with an error instead of getting stuck forever.

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown
