### PR TITLE
Fixed conformance_arena_constraints test failure with no NUMA hardware.

### DIFF
--- a/test/conformance/conformance_arena_constraints.cpp
+++ b/test/conformance/conformance_arena_constraints.cpp
@@ -47,8 +47,15 @@ TEST_CASE("Test NUMA topology traversal correctness") {
 
     std::vector<oneapi::tbb::numa_node_id> numa_indexes = oneapi::tbb::info::numa_nodes();
     for (const auto& numa_id: numa_indexes) {
+        // numa_info.index is set to 0 in numa_topology_parsing() if
+        // no NUMA support is present.  No use comparing it with the
+        // numa_id which is -1 when no NUMA support is present, so
+        // handle -1 specially.
         auto pos = std::find_if(numa_nodes_info.begin(), numa_nodes_info.end(),
-            [&](const index_info& numa_info){ return numa_info.index == numa_id; }
+            [&](const index_info& numa_info){
+             printf("numa_info.index %d == numa_id %d\n", numa_info.index, numa_id);
+             return -1 == numa_id || numa_info.index == numa_id;
+           }
         );
 
         REQUIRE_MESSAGE(pos != numa_nodes_info.end(), "Wrong, extra or repeated NUMA node index detected.");


### PR DESCRIPTION
### Description 

On a system without NUMA support, like GNU Hurd, the test would fail like this:

```
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
=============================================================================== test/conformance/conformance_arena_constraints.cpp:44: TEST CASE:  Test NUMA topology traversal correctness

test/conformance/conformance_arena_constraints.cpp:54: FATAL ERROR: REQUIRE( pos != numa_nodes_info.end() ) is NOT correct!
  values: REQUIRE( {?} != {?} )
  logged: Wrong, extra or repeated NUMA node index detected.

=============================================================================== [doctest] test cases:  5 |  4 passed | 1 failed | 0 skipped [doctest] assertions: 27 | 26 passed | 1 failed |
[doctest] Status: FAILURE!
```
With the fix in place, the test succeed.

Fixes #2039

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown