### PR TITLE
Support IPO build for modern Intel compilers with old cmake under Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,28 +249,6 @@ foreach(FILE_WITH_EXTRA_TARGETS ${FILES_WITH_EXTRA_TARGETS})
     include(${FILE_WITH_EXTRA_TARGETS})
 endforeach()
 
-# - Enabling LTO on Android causes the NDK bug.
-#   NDK throws the warning: "argument unused during compilation: '-Wa,--noexecstack'"
-# - For some reason GCC does not instrument code with Thread Sanitizer when lto is enabled and C linker is used.
-if (TBB_ENABLE_IPO AND BUILD_SHARED_LIBS AND NOT ANDROID_PLATFORM AND NOT TBB_SANITIZE MATCHES "thread")
-    # Under Linux, ipo detection for 2024+ versions of Intel compilers is supported starting cmake 3.30.1.
-    # In this case and for older cmake versions without CheckIPOSupported, try to enable IPO unconditionally.
-    if (CMAKE_VERSION VERSION_LESS 3.9 OR (LINUX AND CMAKE_VERSION VERSION_LESS 3.30.1
-        AND CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 2023))
-        set(TBB_IPO_FLAGS TRUE)
-    else()
-        cmake_policy(SET CMP0069 NEW)
-        include(CheckIPOSupported)
-        check_ipo_supported(RESULT TBB_IPO_PROPERTY)
-        if (NOT TBB_IPO_PROPERTY)
-            message(WARNING "IPO disabled: not supported by this compiler.")
-        endif()
-    endif()
-    if (TBB_IPO_PROPERTY OR TBB_IPO_FLAGS)
-        message(STATUS "IPO enabled")
-    endif()
-endif()
-
 if (TBB_FILE_TRIM)
     file(RELATIVE_PATH TBB_RELATIVE_BIN_PATH ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR})
     file(TO_NATIVE_PATH ${CMAKE_SOURCE_DIR} NATIVE_TBB_PROJECT_ROOT_DIR)
@@ -290,6 +268,27 @@ if (EXISTS ${TBB_COMPILER_SETTINGS_FILE})
     include(${TBB_COMPILER_SETTINGS_FILE})
 else()
     message(WARNING "TBB compiler settings not found ${TBB_COMPILER_SETTINGS_FILE}")
+endif()
+
+# - Enabling LTO on Android causes the NDK bug.
+#   NDK throws the warning: "argument unused during compilation: '-Wa,--noexecstack'"
+# - For some reason GCC does not instrument code with Thread Sanitizer when lto is enabled and C linker is used.
+if (TBB_ENABLE_IPO AND BUILD_SHARED_LIBS AND NOT ANDROID_PLATFORM AND NOT TBB_SANITIZE MATCHES "thread")
+    # For older cmake versions without CheckIPOSupported and when ipo detection is broken,
+    # try to enable IPO unconditionally.
+    if (CMAKE_VERSION VERSION_LESS 3.9 OR DEFINED TBB_IPO_DETECTION_BROKEN)
+        set(TBB_IPO_FLAGS TRUE)
+    else()
+        cmake_policy(SET CMP0069 NEW)
+        include(CheckIPOSupported)
+        check_ipo_supported(RESULT TBB_IPO_PROPERTY)
+        if (NOT TBB_IPO_PROPERTY)
+            message(WARNING "IPO disabled: not supported by this compiler.")
+        endif()
+    endif()
+    if (TBB_IPO_PROPERTY OR TBB_IPO_FLAGS)
+        message(STATUS "IPO enabled")
+    endif()
 endif()
 
 if (TBB_FIND_PACKAGE AND TBB_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ endif()
 if (TBB_ENABLE_IPO AND BUILD_SHARED_LIBS AND NOT ANDROID_PLATFORM AND NOT TBB_SANITIZE MATCHES "thread")
     # For older cmake versions without CheckIPOSupported and when ipo detection is broken,
     # try to enable IPO unconditionally.
-    if (CMAKE_VERSION VERSION_LESS 3.9 OR DEFINED TBB_IPO_DETECTION_BROKEN)
+    if (CMAKE_VERSION VERSION_LESS 3.9 OR TBB_IPO_DETECTION_BROKEN)
         set(TBB_IPO_FLAGS TRUE)
     else()
         cmake_policy(SET CMP0069 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,15 +253,18 @@ endforeach()
 #   NDK throws the warning: "argument unused during compilation: '-Wa,--noexecstack'"
 # - For some reason GCC does not instrument code with Thread Sanitizer when lto is enabled and C linker is used.
 if (TBB_ENABLE_IPO AND BUILD_SHARED_LIBS AND NOT ANDROID_PLATFORM AND NOT TBB_SANITIZE MATCHES "thread")
-    if (NOT CMAKE_VERSION VERSION_LESS 3.9)
+    # Under Linux, ipo detection for 2024+ versions of Intel compilers is supported starting cmake 3.30.1.
+    # In this case and for older cmake versions without CheckIPOSupported, try to enable IPO unconditionally.
+    if (CMAKE_VERSION VERSION_LESS 3.9 OR (LINUX AND CMAKE_VERSION VERSION_LESS 3.30.1
+        AND CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 2023))
+        set(TBB_IPO_FLAGS TRUE)
+    else()
         cmake_policy(SET CMP0069 NEW)
         include(CheckIPOSupported)
         check_ipo_supported(RESULT TBB_IPO_PROPERTY)
         if (NOT TBB_IPO_PROPERTY)
             message(WARNING "IPO disabled: not supported by this compiler.")
         endif()
-    else()
-        set(TBB_IPO_FLAGS TRUE)
     endif()
     if (TBB_IPO_PROPERTY OR TBB_IPO_FLAGS)
         message(STATUS "IPO enabled")

--- a/cmake/compilers/IntelLLVM.cmake
+++ b/cmake/compilers/IntelLLVM.cmake
@@ -24,5 +24,9 @@ else()
     #  from statically linked libraries
     set(TBB_LIB_LINK_FLAGS ${TBB_LIB_LINK_FLAGS} -static-intel -Wl,--exclude-libs,ALL)
     set(TBB_OPENMP_FLAG -qopenmp)
+    # Under Linux, ipo detection for 2024+ versions of Intel compilers is supported starting cmake 3.30.1.
+    if (CMAKE_VERSION VERSION_LESS 3.30.1 AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 2023)
+        set(TBB_IPO_DETECTION_BROKEN TRUE)
+    endif()
 endif()
 set(TBB_IPO_LINK_FLAGS ${TBB_IPO_LINK_FLAGS} ${TBB_IPO_COMPILE_FLAGS})

--- a/cmake/compilers/IntelLLVM.cmake
+++ b/cmake/compilers/IntelLLVM.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2020-2024 Intel Corporation
+# Copyright (c) 2026 UXL Foundation Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description 
Previously, CMAKE_CXX_COMPILER_AR was not set for them and IPO detection failed because of that.

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [X] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
