### PR TITLE
Add missing default value for this_task_arena::end_parallel_phase

### DIFF
--- a/include/oneapi/tbb/task_arena.h
+++ b/include/oneapi/tbb/task_arena.h
@@ -690,7 +690,7 @@ inline void start_parallel_phase() {
     r1::enter_parallel_phase(nullptr, /*reserved*/0);
 }
 
-inline void end_parallel_phase(bool with_fast_leave) {
+inline void end_parallel_phase(bool with_fast_leave = false) {
     // It is guaranteed by the standard that conversion of boolean to integral type will result in either 0 or 1
     r1::exit_parallel_phase(nullptr, static_cast<std::uintptr_t>(with_fast_leave));
 }

--- a/test/tbb/test_parallel_phase.cpp
+++ b/test/tbb/test_parallel_phase.cpp
@@ -21,6 +21,7 @@
 #define TBB_PREVIEW_PARALLEL_PHASE 1
 
 #include <chrono>
+#include <utility>
 
 #include "common/test.h"
 #include "common/utils.h"
@@ -161,7 +162,7 @@ class start_time_collection_sequenced_phases
     using base = start_time_collection_base<start_time_collection_sequenced_phases>;
     friend base;
 
-    bool with_fast_leave;
+    std::pair<bool, bool> with_fast_leave {false, false};
 
     std::size_t measure_impl() {
         std::size_t median_start_time;
@@ -181,7 +182,10 @@ class start_time_collection_sequenced_phases
                         }
                         barrier.wait();
                     });
-                    arena->end_parallel_phase(with_fast_leave);
+                    if (with_fast_leave.first)
+                        arena->end_parallel_phase(with_fast_leave.second);
+                    else
+                        arena->end_parallel_phase();
                 }
             );
         } else {
@@ -194,7 +198,10 @@ class start_time_collection_sequenced_phases
                         tbb::this_task_arena::enqueue(body);
                     }
                     barrier.wait();
-                    tbb::this_task_arena::end_parallel_phase(with_fast_leave); 
+                    if (with_fast_leave.first)
+                        tbb::this_task_arena::end_parallel_phase(with_fast_leave.second);
+                    else
+                        tbb::this_task_arena::end_parallel_phase();
                 }
             );
         }
@@ -202,12 +209,20 @@ class start_time_collection_sequenced_phases
     }
 
 public:
-    start_time_collection_sequenced_phases(tbb::task_arena& ta, std::size_t ntrials, bool fast_leave = false) :
-        base(ta, ntrials), with_fast_leave(fast_leave)
+    explicit start_time_collection_sequenced_phases(std::size_t ntrials) :
+        base(ntrials)
     {}
 
-    explicit start_time_collection_sequenced_phases(std::size_t ntrials, bool fast_leave = false) :
-        base(ntrials), with_fast_leave(fast_leave)
+    start_time_collection_sequenced_phases(tbb::task_arena& ta, std::size_t ntrials) :
+        base(ta, ntrials)
+    {}
+
+    start_time_collection_sequenced_phases(tbb::task_arena& ta, std::size_t ntrials, bool fast_leave) :
+        base(ta, ntrials), with_fast_leave(/*is_set*/true, fast_leave)
+    {}
+
+    explicit start_time_collection_sequenced_phases(std::size_t ntrials, bool fast_leave) :
+        base(ntrials), with_fast_leave(/*is_set*/true, fast_leave)
     {}
 };
 


### PR DESCRIPTION
### Description 
It appears that the default value for the `with_fast_leave` parameter was accidentally omitted, even though it is mentioned in the [API reference](https://github.com/uxlfoundation/oneTBB/blob/master/doc/main/reference/parallel_phase_for_task_arena.rst?plain=1#L154).

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
