### PR TITLE
[tbbmalloc] Avoid disabling 4267 and 4244 warnings

### DIFF
--- a/src/tbbmalloc/CMakeLists.txt
+++ b/src/tbbmalloc/CMakeLists.txt
@@ -53,7 +53,7 @@ target_include_directories(tbbmalloc
 # TODO: fix warnings
 if (MSVC)
     # signed unsigned mismatch, declaration hides class member
-    set(TBB_WARNING_SUPPRESS ${TBB_WARNING_SUPPRESS} /wd4267 /wd4244 /wd4245 /wd4458)
+    set(TBB_WARNING_SUPPRESS ${TBB_WARNING_SUPPRESS} /wd4245 /wd4458)
 endif()
 
 target_compile_options(tbbmalloc

--- a/src/tbbmalloc/Customize.h
+++ b/src/tbbmalloc/Customize.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbbmalloc/Customize.h
+++ b/src/tbbmalloc/Customize.h
@@ -47,8 +47,9 @@
 #define MALLOC_ITT_RELEASE_RESOURCES()  ((void)0)
 #endif
 
-inline intptr_t BitScanRev(uintptr_t x) {
-    return x == 0 ? -1 : static_cast<intptr_t>(tbb::detail::log2(x));
+// TODO: Consider conforming to _BitScanReverse interface, an MSVC intrinsic
+inline int BitScanRev(uintptr_t x) {
+    return x == 0 ? -1 : static_cast<int>(tbb::detail::log2(x));
 }
 
 template<typename T>

--- a/src/tbbmalloc/backend.cpp
+++ b/src/tbbmalloc/backend.cpp
@@ -374,7 +374,7 @@ FreeBlock *CoalRequestQ::getAll()
 inline void CoalRequestQ::blockWasProcessed()
 {
     bkndSync->binsModified();
-    int prev = inFlyBlocks.fetch_sub(1);
+    intptr_t prev = inFlyBlocks.fetch_sub(1);
     tbb::detail::suppress_unused_warning(prev);
     MALLOC_ASSERT(prev > 0, ASSERT_TEXT);
 }

--- a/src/tbbmalloc/backend.h
+++ b/src/tbbmalloc/backend.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbbmalloc/backend.h
+++ b/src/tbbmalloc/backend.h
@@ -326,7 +326,8 @@ private:
         else if (size < minBinnedSize)
             return NO_BIN;
 
-        int bin = (size - minBinnedSize)/freeBinsStep;
+        size_t val = (size - minBinnedSize)/freeBinsStep;
+        int bin = (int)val;
 
         MALLOC_ASSERT(bin < HUGE_BIN, "Invalid size.");
         return bin;

--- a/src/tbbmalloc/backref.cpp
+++ b/src/tbbmalloc/backref.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbbmalloc/backref.cpp
+++ b/src/tbbmalloc/backref.cpp
@@ -40,8 +40,9 @@ struct BackRefBlock : public BlockI {
 
     BackRefBlock(const BackRefBlock *blockToUse, intptr_t num) :
         nextForUse(nullptr), bumpPtr((FreeObject*)((uintptr_t)blockToUse + slabSize - sizeof(void*))),
-        freeList(nullptr), nextRawMemBlock(nullptr), allocatedCount(0), myNum(num),
-        addedToForUse(false) {
+        freeList(nullptr), nextRawMemBlock(nullptr), allocatedCount(0),
+        myNum((BackRefIdx::main_t)num), addedToForUse(false)
+    {
         memset(static_cast<void*>(&blockMutex), 0, sizeof(MallocMutex));
 
         MALLOC_ASSERT(!(num >> CHAR_BIT*sizeof(BackRefIdx::main_t)),
@@ -181,14 +182,15 @@ bool BackRefMain::requestNewSpace()
 
     MallocMutex::scoped_lock lock(mainMutex); // ... and share under lock
 
-    const size_t numOfUnusedIdxs = BackRefMain::dataSz - lastUsed - 1;
+    const intptr_t numOfUnusedIdxs = BackRefMain::dataSz - lastUsed - 1;
     if (numOfUnusedIdxs <= 0) { // no space in main under lock, roll back
         backend->putBackRefSpace(newBl, blockSpaceSize, isRawMemUsed);
         return false;
     }
     // It's possible that only part of newBl is used, due to lack of indices in main.
     // This is OK as such underutilization is possible only once for backreferneces table.
-    int blocksToUse = min(numOfUnusedIdxs, blockSpaceSize / BackRefBlock::bytes);
+    unsigned blocksToUse =
+        (unsigned)(min((uintptr_t)numOfUnusedIdxs, blockSpaceSize / BackRefBlock::bytes));
 
     // use the first block in the batch to maintain the list of "raw" memory
     // to be released at shutdown
@@ -196,7 +198,9 @@ bool BackRefMain::requestNewSpace()
         newBl->nextRawMemBlock = backRefMain.load(std::memory_order_relaxed)->allRawMemBlocks;
         backRefMain.load(std::memory_order_relaxed)->allRawMemBlocks = newBl;
     }
-    for (BackRefBlock *bl = newBl; blocksToUse>0; bl = (BackRefBlock*)((uintptr_t)bl + BackRefBlock::bytes), blocksToUse--) {
+    for (BackRefBlock *bl = newBl; blocksToUse != 0;
+         bl = (BackRefBlock*)((uintptr_t)bl + BackRefBlock::bytes), blocksToUse--)
+    {
         initEmptyBackRefBlock(bl);
         if (active.load(std::memory_order_relaxed)->allocatedCount.load(std::memory_order_relaxed) == BR_MAX_CNT) {
             active.store(bl, std::memory_order_release); // active leaf is not needed in listForUse

--- a/src/tbbmalloc/backref.cpp
+++ b/src/tbbmalloc/backref.cpp
@@ -189,6 +189,12 @@ bool BackRefMain::requestNewSpace()
     }
     // It's possible that only part of newBl is used, due to lack of indices in main.
     // This is OK as such underutilization is possible only once for backreferneces table.
+
+    // Since numOfUnusedIdxs remains greater than zero after subtraction above, its value should be
+    // less than INT_MAX.
+    MALLOC_ASSERT(numOfUnusedIdxs <= INT_MAX, ASSERT_TEXT);
+
+    // Therefore, the minimum below will be at most as large as the value of numOfUnusedIdxs
     unsigned blocksToUse =
         (unsigned)(min((uintptr_t)numOfUnusedIdxs, blockSpaceSize / BackRefBlock::bytes));
 

--- a/src/tbbmalloc/frontend.cpp
+++ b/src/tbbmalloc/frontend.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2025 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbbmalloc/frontend.cpp
+++ b/src/tbbmalloc/frontend.cpp
@@ -2311,15 +2311,17 @@ void *MemoryPool::getFromLLOCache(TLSData* tls, size_t size, size_t alignment)
             alignDown((uintptr_t)lmb+lmb->unalignedSize - size, alignment);
         // Has some room to shuffle object between cache lines?
         // Note that alignedRight and alignedArea are aligned at alignment.
-        MALLOC_ASSERT(alignedRight - (uintptr_t)alignedArea <= UINT_MAX, ASSERT_TEXT);
-        unsigned ptrDelta = (unsigned)(alignedRight - (uintptr_t)alignedArea);
+        uintptr_t ptrDelta = alignedRight - (uintptr_t)alignedArea;
         if (ptrDelta && tls) { // !tls is cold path
             // for the hot path of alignment==estimatedCacheLineSize,
             // allow compilers to use shift for division
             // (since estimatedCacheLineSize is a power-of-2 constant)
-            unsigned numOfPossibleOffsets = alignment == estimatedCacheLineSize?
-                                            ptrDelta / estimatedCacheLineSize :
-                                            (unsigned)(ptrDelta / alignment);
+            MALLOC_ASSERT((alignment == estimatedCacheLineSize?
+                           ptrDelta / estimatedCacheLineSize : ptrDelta / alignment) <= UINT_MAX,
+                          ASSERT_TEXT);
+            unsigned numOfPossibleOffsets =
+                (unsigned)(alignment == estimatedCacheLineSize?
+                           (ptrDelta / estimatedCacheLineSize) : (ptrDelta / alignment));
             unsigned myCacheIdx = ++tls->currCacheIdx;
             unsigned offset = myCacheIdx % numOfPossibleOffsets;
 

--- a/src/tbbmalloc/frontend.cpp
+++ b/src/tbbmalloc/frontend.cpp
@@ -2316,14 +2316,11 @@ void *MemoryPool::getFromLLOCache(TLSData* tls, size_t size, size_t alignment)
             // for the hot path of alignment==estimatedCacheLineSize,
             // allow compilers to use shift for division
             // (since estimatedCacheLineSize is a power-of-2 constant)
-            MALLOC_ASSERT((alignment == estimatedCacheLineSize?
-                           ptrDelta / estimatedCacheLineSize : ptrDelta / alignment) <= UINT_MAX,
-                          ASSERT_TEXT);
-            unsigned numOfPossibleOffsets =
-                (unsigned)(alignment == estimatedCacheLineSize?
-                           (ptrDelta / estimatedCacheLineSize) : (ptrDelta / alignment));
+            uintptr_t numOfPossibleOffsets = alignment == estimatedCacheLineSize?
+                ptrDelta / estimatedCacheLineSize : ptrDelta / alignment;
+
             unsigned myCacheIdx = ++tls->currCacheIdx;
-            unsigned offset = myCacheIdx % numOfPossibleOffsets;
+            uintptr_t offset = myCacheIdx % numOfPossibleOffsets;
 
             // Move object to a cache line with an offset that is different from
             // previous allocation. This supposedly allows us to use cache

--- a/src/tbbmalloc/frontend.cpp
+++ b/src/tbbmalloc/frontend.cpp
@@ -2572,12 +2572,16 @@ static void *internalPoolMalloc(MemoryPool* memPool, size_t size)
 
     if (!tls) return nullptr;
 
+    // size has lesser value than minLargeObjectSize, so casting is harmless.
+    static_assert(minLargeObjectSize <= UINT_MAX, "The cast below is incorrect");
+    const unsigned uSize = (unsigned)size;
+
     tls->markUsed();
     /*
      * Get an element in thread-local array corresponding to the given size;
      * It keeps ptr to the active block for allocations of this size
      */
-    bin = tls->getAllocationBin((unsigned)size);
+    bin = tls->getAllocationBin(uSize);
     if ( !bin ) return nullptr;
 
     /* Get a block to try to allocate in. */
@@ -2598,25 +2602,25 @@ static void *internalPoolMalloc(MemoryPool* memPool, size_t size)
             return result;
         /* Else something strange happened, need to retry from the beginning; */
         TRACEF(( "[ScalableMalloc trace] Something is wrong: no objects in public free list; reentering.\n" ));
-        return internalPoolMalloc(memPool, (unsigned)size);
+        return internalPoolMalloc(memPool, uSize);
     }
 
     /*
      * no suitable own blocks, try to get a partial block that some other thread has discarded.
      */
-    mallocBlock = memPool->extMemPool.orphanedBlocks.get(tls, (unsigned)size);
+    mallocBlock = memPool->extMemPool.orphanedBlocks.get(tls, uSize);
     while (mallocBlock) {
         bin->pushTLSBin(mallocBlock);
         bin->setActiveBlock(mallocBlock); // TODO: move under the below condition?
         if( FreeObject *result = mallocBlock->allocate() )
             return result;
-        mallocBlock = memPool->extMemPool.orphanedBlocks.get(tls, (unsigned)size);
+        mallocBlock = memPool->extMemPool.orphanedBlocks.get(tls, uSize);
     }
 
     /*
      * else try to get a new empty block
      */
-    mallocBlock = memPool->getEmptyBlock((unsigned)size);
+    mallocBlock = memPool->getEmptyBlock(uSize);
     if (mallocBlock) {
         bin->pushTLSBin(mallocBlock);
         bin->setActiveBlock(mallocBlock);

--- a/src/tbbmalloc/frontend.cpp
+++ b/src/tbbmalloc/frontend.cpp
@@ -2467,17 +2467,19 @@ inline bool Block::isProperlyPlaced(const void *object) const
 #endif
 
 /* Finds the real object inside the block */
-FreeObject *Block::findAllocatedObject(const void *address) const
+FreeObject *Block::findAllocatedObject(const void *address_ptr) const
 {
+    const uintptr_t address = (uintptr_t)address_ptr;
     // calculate offset from the end of the block space
-    const uintptr_t tmp_offset = (uintptr_t)this + slabSize - (uintptr_t)address;
-    MALLOC_ASSERT(tmp_offset <= USHRT_MAX, ASSERT_TEXT);
+    const uintptr_t tmp_offset = (uintptr_t)this + slabSize - address;
+    MALLOC_ASSERT(tmp_offset <= slabSize - sizeof(Block),
+                  "Address is within the small object allocation block");
+    MALLOC_ASSERT(slabSize <= USHRT_MAX, "Below cast is harmless");
     uint16_t offset = (uint16_t)tmp_offset;
-    MALLOC_ASSERT( offset<=slabSize-sizeof(Block), ASSERT_TEXT );
     // find offset difference from a multiple of allocation size
     offset %= objectSize;
     // and move the address down to where the real object starts.
-    return (FreeObject*)((uintptr_t)address - (offset? objectSize-offset: 0));
+    return (FreeObject*)(address - (offset? objectSize-offset: 0));
 }
 
 /*

--- a/src/tbbmalloc/frontend.cpp
+++ b/src/tbbmalloc/frontend.cpp
@@ -2474,7 +2474,7 @@ FreeObject *Block::findAllocatedObject(const void *address_ptr) const
     const uintptr_t tmp_offset = (uintptr_t)this + slabSize - address;
     MALLOC_ASSERT(tmp_offset <= slabSize - sizeof(Block),
                   "Address is within the small object allocation block");
-    MALLOC_ASSERT(slabSize <= USHRT_MAX, "Below cast is harmless");
+    static_assert(slabSize <= USHRT_MAX, "Below cast is harmless");
     uint16_t offset = (uint16_t)tmp_offset;
     // find offset difference from a multiple of allocation size
     offset %= objectSize;

--- a/src/tbbmalloc/frontend.cpp
+++ b/src/tbbmalloc/frontend.cpp
@@ -284,7 +284,7 @@ public:
     inline TLSData *getTLS(bool create);
     void clearTLS() { extMemPool.tlsPointerKey.setThreadMallocTLS(nullptr); }
 
-    Block *getEmptyBlock(size_t size);
+    Block *getEmptyBlock(unsigned size);
     void returnEmptyBlock(Block *block, bool poolTheBlock);
 
     // get/put large object to/from local large object cache
@@ -344,7 +344,7 @@ protected:
     friend class LifoList;
     friend void *BootStrapBlocks::allocate(MemoryPool *, size_t);
     friend bool OrphanedBlocks::cleanup(Backend*);
-    friend Block *MemoryPool::getEmptyBlock(size_t);
+    friend Block *MemoryPool::getEmptyBlock(unsigned);
 };
 
 // Use inheritance to guarantee that a user data start on next cache line.
@@ -417,7 +417,7 @@ public:
         suppress_unused_warning(object);
 #endif
     }
-    void initEmptyBlock(TLSData *tls, size_t size);
+    void initEmptyBlock(TLSData *tls, unsigned size);
     size_t findObjectSize(void *object) const;
     MemoryPool *getMemPool() const { return poolPtr; } // do not use on the hot path!
 
@@ -472,7 +472,7 @@ public:
     void addPublicFreeListBlock(Block* block);
 
     void outofTLSBin(Block* block);
-    void verifyTLSBin(size_t size) const;
+    void verifyTLSBin(unsigned size) const;
     void pushTLSBin(Block* block);
 
 #if MALLOC_DEBUG
@@ -595,7 +595,7 @@ private:
 public:
     TLSData(MemoryPool *mPool, Backend *bknd) : memPool(mPool), freeSlabBlocks(bknd), currCacheIdx(0) {}
     MemoryPool *getMemPool() const { return memPool; }
-    Bin* getAllocationBin(size_t size);
+    Bin* getAllocationBin(unsigned size);
     void release();
     bool externalCleanup(bool cleanOnlyUnused, bool cleanBins) {
         if (!unused.load(std::memory_order_relaxed) && cleanOnlyUnused) return false;
@@ -886,7 +886,7 @@ void *BootStrapBlocks::allocate(MemoryPool *memPool, size_t size)
             bootStrapObjectList = bootStrapObjectList->next;
         } else {
             if (!bootStrapBlock) {
-                bootStrapBlock = memPool->getEmptyBlock(size);
+                bootStrapBlock = memPool->getEmptyBlock((unsigned)size);
                 if (!bootStrapBlock) return nullptr;
             }
             result = bootStrapBlock->bumpPtr;
@@ -999,13 +999,13 @@ TLSData* MemoryPool::getTLS(bool create)
 /*
  * Return the bin for the given size.
  */
-inline Bin* TLSData::getAllocationBin(size_t size)
+inline Bin* TLSData::getAllocationBin(unsigned size)
 {
     return bin + getIndex(size);
 }
 
 /* Return an empty uninitialized block in a non-blocking fashion. */
-Block *MemoryPool::getEmptyBlock(size_t size)
+Block *MemoryPool::getEmptyBlock(unsigned size)
 {
     TLSData* tls = getTLS(/*create=*/false);
     // try to use per-thread cache, if TLS available
@@ -1169,9 +1169,9 @@ void MemoryPool::onThreadShutdown(TLSData *tlsData)
 }
 
 #if MALLOC_DEBUG
-void Bin::verifyTLSBin (size_t size) const
+void Bin::verifyTLSBin (unsigned size) const
 {
-/* The debug version verifies the TLSBin as needed */
+    /* The debug version verifies the TLSBin as needed */
     uint32_t objSize = getObjectSize(size);
 
     if (activeBlk) {
@@ -1200,7 +1200,7 @@ void Bin::verifyTLSBin (size_t size) const
     }
 }
 #else /* MALLOC_DEBUG */
-inline void Bin::verifyTLSBin (size_t) const { }
+inline void Bin::verifyTLSBin (unsigned) const { }
 #endif /* MALLOC_DEBUG */
 
 /*
@@ -1574,7 +1574,7 @@ void Block::cleanBlockHeader()
     publicFreeList.store(nullptr, std::memory_order_relaxed);
 }
 
-void Block::initEmptyBlock(TLSData *tls, size_t size)
+void Block::initEmptyBlock(TLSData *tls, unsigned size)
 {
     // Having getIndex and getObjectSize called next to each other
     // allows better compiler optimization as they basically share the code.
@@ -1583,7 +1583,7 @@ void Block::initEmptyBlock(TLSData *tls, size_t size)
 
     cleanBlockHeader();
     MALLOC_ASSERT(objSz <= USHRT_MAX, "objSz must not be less 2^16-1");
-    objectSize = objSz;
+    objectSize = (uint16_t)objSz;
     markOwned(tls);
     // bump pointer should be prepared for first allocation - thus mode it down to objectSize
     bumpPtr = (FreeObject *)((uintptr_t)this + slabSize - objectSize);
@@ -2311,14 +2311,15 @@ void *MemoryPool::getFromLLOCache(TLSData* tls, size_t size, size_t alignment)
             alignDown((uintptr_t)lmb+lmb->unalignedSize - size, alignment);
         // Has some room to shuffle object between cache lines?
         // Note that alignedRight and alignedArea are aligned at alignment.
-        unsigned ptrDelta = alignedRight - (uintptr_t)alignedArea;
+        MALLOC_ASSERT(alignedRight - (uintptr_t)alignedArea <= UINT_MAX, ASSERT_TEXT);
+        unsigned ptrDelta = (unsigned)(alignedRight - (uintptr_t)alignedArea);
         if (ptrDelta && tls) { // !tls is cold path
             // for the hot path of alignment==estimatedCacheLineSize,
             // allow compilers to use shift for division
             // (since estimatedCacheLineSize is a power-of-2 constant)
             unsigned numOfPossibleOffsets = alignment == estimatedCacheLineSize?
-                  ptrDelta / estimatedCacheLineSize :
-                  ptrDelta / alignment;
+                                            ptrDelta / estimatedCacheLineSize :
+                                            (unsigned)(ptrDelta / alignment);
             unsigned myCacheIdx = ++tls->currCacheIdx;
             unsigned offset = myCacheIdx % numOfPossibleOffsets;
 
@@ -2469,7 +2470,9 @@ inline bool Block::isProperlyPlaced(const void *object) const
 FreeObject *Block::findAllocatedObject(const void *address) const
 {
     // calculate offset from the end of the block space
-    uint16_t offset = (uintptr_t)this + slabSize - (uintptr_t)address;
+    const uintptr_t tmp_offset = (uintptr_t)this + slabSize - (uintptr_t)address;
+    MALLOC_ASSERT(tmp_offset <= USHRT_MAX, ASSERT_TEXT);
+    uint16_t offset = (uint16_t)tmp_offset;
     MALLOC_ASSERT( offset<=slabSize-sizeof(Block), ASSERT_TEXT );
     // find offset difference from a multiple of allocation size
     offset %= objectSize;
@@ -2575,7 +2578,7 @@ static void *internalPoolMalloc(MemoryPool* memPool, size_t size)
      * Get an element in thread-local array corresponding to the given size;
      * It keeps ptr to the active block for allocations of this size
      */
-    bin = tls->getAllocationBin(size);
+    bin = tls->getAllocationBin((unsigned)size);
     if ( !bin ) return nullptr;
 
     /* Get a block to try to allocate in. */
@@ -2596,25 +2599,25 @@ static void *internalPoolMalloc(MemoryPool* memPool, size_t size)
             return result;
         /* Else something strange happened, need to retry from the beginning; */
         TRACEF(( "[ScalableMalloc trace] Something is wrong: no objects in public free list; reentering.\n" ));
-        return internalPoolMalloc(memPool, size);
+        return internalPoolMalloc(memPool, (unsigned)size);
     }
 
     /*
      * no suitable own blocks, try to get a partial block that some other thread has discarded.
      */
-    mallocBlock = memPool->extMemPool.orphanedBlocks.get(tls, size);
+    mallocBlock = memPool->extMemPool.orphanedBlocks.get(tls, (unsigned)size);
     while (mallocBlock) {
         bin->pushTLSBin(mallocBlock);
         bin->setActiveBlock(mallocBlock); // TODO: move under the below condition?
         if( FreeObject *result = mallocBlock->allocate() )
             return result;
-        mallocBlock = memPool->extMemPool.orphanedBlocks.get(tls, size);
+        mallocBlock = memPool->extMemPool.orphanedBlocks.get(tls, (unsigned)size);
     }
 
     /*
      * else try to get a new empty block
      */
-    mallocBlock = memPool->getEmptyBlock(size);
+    mallocBlock = memPool->getEmptyBlock((unsigned)size);
     if (mallocBlock) {
         bin->pushTLSBin(mallocBlock);
         bin->setActiveBlock(mallocBlock);

--- a/src/tbbmalloc/large_objects.cpp
+++ b/src/tbbmalloc/large_objects.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbbmalloc/large_objects.cpp
+++ b/src/tbbmalloc/large_objects.cpp
@@ -708,9 +708,10 @@ bool LargeObjectCacheImpl<Props>::regularCleanup(ExtMemoryPool *extMemPool, uint
 
     // Threshold settings is below this cache or starts from zero index
     if (hugeSizeThresholdIdx == 0) return false;
+    MALLOC_ASSERT(hugeSizeThresholdIdx > 0, "Invalid size threshold index");
 
     // Starting searching for bin that is less than huge size threshold (can be cleaned-up)
-    int startSearchIdx = hugeSizeThresholdIdx - 1;
+    unsigned startSearchIdx = (unsigned)(hugeSizeThresholdIdx - 1);
 
     for (int i = bitMask.getMaxTrue(startSearchIdx); i >= 0; i = bitMask.getMaxTrue(i-1)) {
         bin[i].updateBinsSummary(&binsSummary);

--- a/src/tbbmalloc/large_objects.cpp
+++ b/src/tbbmalloc/large_objects.cpp
@@ -718,7 +718,7 @@ bool LargeObjectCacheImpl<Props>::regularCleanup(ExtMemoryPool *extMemPool, uint
     MALLOC_ASSERT(hugeSizeThresholdIdx > 0, "Invalid size threshold index");
 
     // Starting searching for bin that is less than huge size threshold (can be cleaned-up)
-    unsigned startSearchIdx = (unsigned)(hugeSizeThresholdIdx - 1);
+    int startSearchIdx = (int)(hugeSizeThresholdIdx - 1);
 
     for (int i = bitMask.getMaxTrue(startSearchIdx); i >= 0; i = bitMask.getMaxTrue(i-1)) {
         bin[i].updateBinsSummary(&binsSummary);

--- a/src/tbbmalloc/large_objects.cpp
+++ b/src/tbbmalloc/large_objects.cpp
@@ -75,7 +75,7 @@ class CacheBinFunctor {
     typename LargeObjectCacheImpl<Props>::CacheBin *const bin;
     ExtMemoryPool *const extMemPool;
     typename LargeObjectCacheImpl<Props>::BinBitMask *const bitMask;
-    const int idx;
+    const unsigned idx;
 
     LargeMemoryBlock *toRelease;
     bool needCleanup;
@@ -134,7 +134,7 @@ class CacheBinFunctor {
 
 public:
     CacheBinFunctor(typename LargeObjectCacheImpl<Props>::CacheBin *bin, ExtMemoryPool *extMemPool,
-                    typename LargeObjectCacheImpl<Props>::BinBitMask *bitMask, int idx) :
+                    typename LargeObjectCacheImpl<Props>::BinBitMask *bitMask, unsigned idx) :
         bin(bin), extMemPool(extMemPool), bitMask(bitMask), idx(idx), toRelease(nullptr), needCleanup(false), currTime(0) {}
     void operator()(CacheBinOperation* opList);
 
@@ -418,7 +418,8 @@ template<typename Props> void CacheBinFunctor<Props>::operator()(CacheBinOperati
 #if __TBB_MALLOC_WHITEBOX_TEST
             tbbmalloc_whitebox::locPutProcessed+=prep.putListNum;
 #endif
-            toRelease = bin->putList(prep.head, prep.tail, bitMask, idx, prep.putListNum, extMemPool->loc.hugeSizeThreshold);
+            toRelease = bin->putList(prep.head, prep.tail, bitMask, idx, prep.putListNum,
+                                     extMemPool->loc.hugeSizeThreshold);
         }
         needCleanup = extMemPool->loc.isCleanupNeededOnRange(timeRange, startTime);
         currTime = endTime - 1;
@@ -445,7 +446,8 @@ template<typename Props> void CacheBinFunctor<Props>::operator()(CacheBinOperati
 /* ----------------------------------------------------------------------------------------------------- */
 /* --------------------------- Methods for creating and executing operations --------------------------- */
 template<typename Props> void LargeObjectCacheImpl<Props>::
-    CacheBin::ExecuteOperation(CacheBinOperation *op, ExtMemoryPool *extMemPool, BinBitMask *bitMask, int idx, bool longLifeTime)
+    CacheBin::ExecuteOperation(CacheBinOperation *op, ExtMemoryPool *extMemPool, BinBitMask *bitMask,
+                               unsigned idx, bool longLifeTime)
 {
     CacheBinFunctor<Props> func( this, extMemPool, bitMask, idx );
     aggregator.execute( op, func, longLifeTime );
@@ -470,7 +472,8 @@ template<typename Props> LargeMemoryBlock *LargeObjectCacheImpl<Props>::
 }
 
 template<typename Props> void LargeObjectCacheImpl<Props>::
-    CacheBin::putList(ExtMemoryPool *extMemPool, LargeMemoryBlock *head, BinBitMask *bitMask, int idx)
+    CacheBin::putList(ExtMemoryPool *extMemPool, LargeMemoryBlock *head, BinBitMask *bitMask,
+                      unsigned idx)
 {
     MALLOC_ASSERT(sizeof(LargeMemoryBlock)+sizeof(CacheBinOperation)<=head->unalignedSize, "CacheBinOperation is too large to be placed in LargeMemoryBlock!");
 
@@ -527,7 +530,8 @@ template<typename Props> bool LargeObjectCacheImpl<Props>::
 }
 
 template<typename Props> void LargeObjectCacheImpl<Props>::
-    CacheBin::updateUsedSize(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask, int idx)
+    CacheBin::updateUsedSize(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask,
+                             unsigned idx)
 {
     OpUpdateUsedSize data = {size};
     CacheBinOperation op(data);
@@ -537,7 +541,8 @@ template<typename Props> void LargeObjectCacheImpl<Props>::
 /* ------------------------------ Unsafe methods used with the aggregator ------------------------------ */
 
 template<typename Props> LargeMemoryBlock *LargeObjectCacheImpl<Props>::
-    CacheBin::putList(LargeMemoryBlock *head, LargeMemoryBlock *tail, BinBitMask *bitMask, int idx, int num, size_t hugeSizeThreshold)
+    CacheBin::putList(LargeMemoryBlock *head, LargeMemoryBlock *tail, BinBitMask *bitMask,
+                      unsigned idx, int num, size_t hugeSizeThreshold)
 {
     size_t size = head->unalignedSize;
     usedSize.store(usedSize.load(std::memory_order_relaxed) - num * size, std::memory_order_relaxed);
@@ -838,7 +843,7 @@ void LargeObjectCache::reset()
 template<typename Props>
 LargeMemoryBlock *LargeObjectCacheImpl<Props>::get(ExtMemoryPool *extMemoryPool, size_t size)
 {
-    int idx = Props::sizeToIdx(size);
+    unsigned idx = Props::sizeToIdx(size);
 
     LargeMemoryBlock *lmb = bin[idx].get(extMemoryPool, size, &bitMask, idx);
 
@@ -852,7 +857,7 @@ LargeMemoryBlock *LargeObjectCacheImpl<Props>::get(ExtMemoryPool *extMemoryPool,
 template<typename Props>
 void LargeObjectCacheImpl<Props>::updateCacheState(ExtMemoryPool *extMemPool, DecreaseOrIncrease op, size_t size)
 {
-    int idx = Props::sizeToIdx(size);
+    unsigned idx = Props::sizeToIdx(size);
     MALLOC_ASSERT(idx < static_cast<int>(numBins), ASSERT_TEXT);
     bin[idx].updateUsedSize(extMemPool, op==decrease? -size : size, &bitMask, idx);
 }
@@ -878,7 +883,7 @@ void LargeObjectCache::reportStat(FILE *f)
 template<typename Props>
 void LargeObjectCacheImpl<Props>::putList(ExtMemoryPool *extMemPool, LargeMemoryBlock *toCache)
 {
-    int toBinIdx = Props::sizeToIdx(toCache->unalignedSize);
+    unsigned toBinIdx = Props::sizeToIdx(toCache->unalignedSize);
 
     MALLOC_ITT_SYNC_RELEASING(bin+toBinIdx);
     bin[toBinIdx].putList(extMemPool, toCache, &bitMask, toBinIdx);
@@ -909,7 +914,7 @@ size_t LargeObjectCache::alignToBin(size_t size) {
 }
 
 // Used for internal purpose
-int LargeObjectCache::sizeToIdx(size_t size)
+unsigned LargeObjectCache::sizeToIdx(size_t size)
 {
     MALLOC_ASSERT(size <= maxHugeSize, ASSERT_TEXT);
     return size < maxLargeSize ?
@@ -928,7 +933,7 @@ void LargeObjectCache::putList(LargeMemoryBlock *list)
             extMemPool->backend.returnLargeObject(curr);
             continue;
         }
-        int currIdx = sizeToIdx(curr->unalignedSize);
+        unsigned currIdx = sizeToIdx(curr->unalignedSize);
 
         // Find all blocks fitting to same bin. Not use more efficient sorting
         // algorithm because list is short (commonly,

--- a/src/tbbmalloc/large_objects.cpp
+++ b/src/tbbmalloc/large_objects.cpp
@@ -756,7 +756,7 @@ template<typename Props>
 bool LargeObjectCacheImpl<Props>::cleanAll(ExtMemoryPool *extMemPool)
 {
     bool released = false;
-    for (int i = numBins-1; i >= 0; i--) {
+    for (unsigned i = 0; i < numBins; ++i) {
         released |= bin[i].releaseAllToBackend(extMemPool, &bitMask, i);
     }
     return released;
@@ -765,7 +765,7 @@ bool LargeObjectCacheImpl<Props>::cleanAll(ExtMemoryPool *extMemPool)
 template<typename Props>
 void LargeObjectCacheImpl<Props>::reset() {
     tooLargeLOC.store(0, std::memory_order_relaxed);
-    for (int i = numBins-1; i >= 0; i--)
+    for (unsigned i = 0; i < numBins; ++i)
         bin[i].init();
     bitMask.reset();
 }
@@ -775,7 +775,7 @@ template<typename Props>
 size_t LargeObjectCacheImpl<Props>::getLOCSize() const
 {
     size_t size = 0;
-    for (int i = numBins-1; i >= 0; i--)
+    for (unsigned i = 0; i < numBins; ++i)
         size += bin[i].getSize();
     return size;
 }
@@ -789,7 +789,7 @@ template<typename Props>
 size_t LargeObjectCacheImpl<Props>::getUsedSize() const
 {
     size_t size = 0;
-    for (int i = numBins-1; i >= 0; i--)
+    for (unsigned i = 0; i < numBins; ++i)
         size += bin[i].getUsedSize();
     return size;
 }
@@ -869,7 +869,7 @@ template<typename Props>
 void LargeObjectCacheImpl<Props>::reportStat(FILE *f)
 {
     size_t cachedSize = 0;
-    for (int i=0; i<numBins; i++)
+    for (unsigned i=0; i<numBins; ++i)
         cachedSize += bin[i].reportStat(i, f);
     fprintf(f, "total LOC size %lu MB\n", cachedSize/1024/1024);
 }

--- a/src/tbbmalloc/large_objects.cpp
+++ b/src/tbbmalloc/large_objects.cpp
@@ -462,7 +462,7 @@ template<typename Props> void LargeObjectCacheImpl<Props>::
 }
 
 template<typename Props> LargeMemoryBlock *LargeObjectCacheImpl<Props>::
-    CacheBin::get(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask, int idx)
+    CacheBin::get(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask, unsigned idx)
 {
     LargeMemoryBlock *lmb=nullptr;
     OpGet data = {&lmb, size, static_cast<uintptr_t>(0)};
@@ -483,7 +483,8 @@ template<typename Props> void LargeObjectCacheImpl<Props>::
 }
 
 template<typename Props> bool LargeObjectCacheImpl<Props>::
-    CacheBin::cleanToThreshold(ExtMemoryPool *extMemPool, BinBitMask *bitMask, uintptr_t currTime, int idx)
+    CacheBin::cleanToThreshold(ExtMemoryPool *extMemPool, BinBitMask *bitMask, uintptr_t currTime,
+                               unsigned idx)
 {
     LargeMemoryBlock *toRelease = nullptr;
 
@@ -507,7 +508,7 @@ template<typename Props> bool LargeObjectCacheImpl<Props>::
 }
 
 template<typename Props> bool LargeObjectCacheImpl<Props>::
-    CacheBin::releaseAllToBackend(ExtMemoryPool *extMemPool, BinBitMask *bitMask, int idx)
+    CacheBin::releaseAllToBackend(ExtMemoryPool *extMemPool, BinBitMask *bitMask, unsigned idx)
 {
     LargeMemoryBlock *toRelease = nullptr;
 
@@ -629,7 +630,7 @@ template<typename Props> void LargeObjectCacheImpl<Props>::
 }
 
 template<typename Props> LargeMemoryBlock *LargeObjectCacheImpl<Props>::
-    CacheBin::cleanToThreshold(uintptr_t currTime, BinBitMask *bitMask, int idx)
+    CacheBin::cleanToThreshold(uintptr_t currTime, BinBitMask *bitMask, unsigned idx)
 {
     /* oldest may be more recent then age, that's why cast to signed type
     was used. age overflow is also processed correctly. */
@@ -671,7 +672,7 @@ template<typename Props> LargeMemoryBlock *LargeObjectCacheImpl<Props>::
 }
 
 template<typename Props> LargeMemoryBlock *LargeObjectCacheImpl<Props>::
-    CacheBin::cleanAll(BinBitMask *bitMask, int idx)
+    CacheBin::cleanAll(BinBitMask *bitMask, unsigned idx)
 {
     if (!last.load(std::memory_order_relaxed)) return nullptr;
 
@@ -855,10 +856,11 @@ LargeMemoryBlock *LargeObjectCacheImpl<Props>::get(ExtMemoryPool *extMemoryPool,
 }
 
 template<typename Props>
-void LargeObjectCacheImpl<Props>::updateCacheState(ExtMemoryPool *extMemPool, DecreaseOrIncrease op, size_t size)
+void LargeObjectCacheImpl<Props>::updateCacheState(ExtMemoryPool *extMemPool, DecreaseOrIncrease op,
+                                                   size_t size)
 {
     unsigned idx = Props::sizeToIdx(size);
-    MALLOC_ASSERT(idx < static_cast<int>(numBins), ASSERT_TEXT);
+    MALLOC_ASSERT(idx < numBins, ASSERT_TEXT);
     bin[idx].updateUsedSize(extMemPool, op==decrease? -size : size, &bitMask, idx);
 }
 

--- a/src/tbbmalloc/large_objects.h
+++ b/src/tbbmalloc/large_objects.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbbmalloc/large_objects.h
+++ b/src/tbbmalloc/large_objects.h
@@ -193,11 +193,12 @@ public:
 
         /* ---------- Cache accessors ---------- */
         void putList(ExtMemoryPool *extMemPool, LargeMemoryBlock *head, BinBitMask *bitMask, unsigned idx);
-        LargeMemoryBlock *get(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask, int idx);
+        LargeMemoryBlock *get(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask, unsigned idx);
 
         /* ---------- Cleanup functions -------- */
-        bool cleanToThreshold(ExtMemoryPool *extMemPool, BinBitMask *bitMask, uintptr_t currTime, int idx);
-        bool releaseAllToBackend(ExtMemoryPool *extMemPool, BinBitMask *bitMask, int idx);
+        bool cleanToThreshold(ExtMemoryPool *extMemPool, BinBitMask *bitMask, uintptr_t currTime,
+                              unsigned idx);
+        bool releaseAllToBackend(ExtMemoryPool *extMemPool, BinBitMask *bitMask, unsigned idx);
         /* ------------------------------------- */
 
         void updateUsedSize(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask, unsigned idx);
@@ -218,8 +219,8 @@ public:
         LargeMemoryBlock *putList(LargeMemoryBlock *head, LargeMemoryBlock *tail, BinBitMask *bitMask,
                                   unsigned idx, int num, size_t hugeObjectThreshold);
         LargeMemoryBlock *get();
-        LargeMemoryBlock *cleanToThreshold(uintptr_t currTime, BinBitMask *bitMask, int idx);
-        LargeMemoryBlock *cleanAll(BinBitMask *bitMask, int idx);
+        LargeMemoryBlock *cleanToThreshold(uintptr_t currTime, BinBitMask *bitMask, unsigned idx);
+        LargeMemoryBlock *cleanAll(BinBitMask *bitMask, unsigned idx);
         void updateUsedSize(size_t size, BinBitMask *bitMask, unsigned idx) {
             if (!usedSize.load(std::memory_order_relaxed)) bitMask->set(idx, true);
             usedSize.store(usedSize.load(std::memory_order_relaxed) + size, std::memory_order_relaxed);

--- a/src/tbbmalloc/large_objects.h
+++ b/src/tbbmalloc/large_objects.h
@@ -49,6 +49,7 @@ struct LargeBinStructureProps {
 public:
     static const size_t   MinSize = MIN_SIZE, MaxSize = MAX_SIZE;
     static const size_t   CacheStep = 8 * 1024;
+    static_assert((MaxSize - MinSize) / CacheStep <= UINT_MAX, "The size of NumBins is small.");
     static const unsigned NumBins = (MaxSize - MinSize) / CacheStep;
 
     static size_t alignToBin(size_t size) {
@@ -93,8 +94,7 @@ public:
     }
 
     // Sizes between the power of 2 values are approximated to StepFactor.
-    // TODO: Consider returning unsigned for every sizeToIdx
-    static int sizeToIdx(size_t size) {
+    static unsigned sizeToIdx(size_t size) {
         MALLOC_ASSERT(MinSize <= size && size <= MaxSize, ASSERT_TEXT);
 
         int sizeExp = BitScanRev(size); // same as __TBB_Log2
@@ -106,7 +106,7 @@ public:
         unsigned minorIdx = (unsigned)((size - majorStepSize) >> minorStepExp);
         MALLOC_ASSERT(size == majorStepSize + ((size_t)minorIdx << minorStepExp),
                       "Size is not aligned on the bin");
-        return StepFactor * (sizeExp - MinSizeExp) + minorIdx;
+        return (unsigned)(StepFactor * (sizeExp - MinSizeExp) + minorIdx);
     }
 };
 
@@ -146,7 +146,7 @@ private:
 
 public:
     // The number of bins to cache large/huge objects.
-    static const uint32_t numBins = Props::NumBins;
+    static const unsigned numBins = Props::NumBins;
 
     typedef BitMaskMax<numBins> BinBitMask;
 
@@ -180,7 +180,8 @@ public:
 
         typename MallocAggregator<CacheBinOperation>::type aggregator;
 
-        void ExecuteOperation(CacheBinOperation *op, ExtMemoryPool *extMemPool, BinBitMask *bitMask, int idx, bool longLifeTime = true);
+        void ExecuteOperation(CacheBinOperation *op, ExtMemoryPool *extMemPool, BinBitMask *bitMask,
+                              unsigned idx, bool longLifeTime = true);
 
         /* should be placed in zero-initialized memory, ctor not needed. */
         CacheBin();
@@ -191,7 +192,7 @@ public:
         }
 
         /* ---------- Cache accessors ---------- */
-        void putList(ExtMemoryPool *extMemPool, LargeMemoryBlock *head, BinBitMask *bitMask, int idx);
+        void putList(ExtMemoryPool *extMemPool, LargeMemoryBlock *head, BinBitMask *bitMask, unsigned idx);
         LargeMemoryBlock *get(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask, int idx);
 
         /* ---------- Cleanup functions -------- */
@@ -199,7 +200,7 @@ public:
         bool releaseAllToBackend(ExtMemoryPool *extMemPool, BinBitMask *bitMask, int idx);
         /* ------------------------------------- */
 
-        void updateUsedSize(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask, int idx);
+        void updateUsedSize(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask, unsigned idx);
         void decreaseThreshold() {
             intptr_t threshold = ageThreshold.load(std::memory_order_relaxed);
             if (threshold)
@@ -215,11 +216,11 @@ public:
         /* --------- Unsafe methods used with the aggregator ------- */
         void forgetOutdatedState(uintptr_t currTime);
         LargeMemoryBlock *putList(LargeMemoryBlock *head, LargeMemoryBlock *tail, BinBitMask *bitMask,
-                int idx, int num, size_t hugeObjectThreshold);
+                                  unsigned idx, int num, size_t hugeObjectThreshold);
         LargeMemoryBlock *get();
         LargeMemoryBlock *cleanToThreshold(uintptr_t currTime, BinBitMask *bitMask, int idx);
         LargeMemoryBlock *cleanAll(BinBitMask *bitMask, int idx);
-        void updateUsedSize(size_t size, BinBitMask *bitMask, int idx) {
+        void updateUsedSize(size_t size, BinBitMask *bitMask, unsigned idx) {
             if (!usedSize.load(std::memory_order_relaxed)) bitMask->set(idx, true);
             usedSize.store(usedSize.load(std::memory_order_relaxed) + size, std::memory_order_relaxed);
             if (!usedSize.load(std::memory_order_relaxed) && !first) bitMask->set(idx, false);
@@ -245,7 +246,7 @@ public:
 
     // Huge bins index for fast regular cleanup searching in case of
     // the "huge size threshold" setting defined
-    intptr_t     hugeSizeThresholdIdx;
+    unsigned hugeSizeThresholdIdx;
 
 private:
     // How many times LOC was "too large"
@@ -261,7 +262,7 @@ public:
     static size_t alignToBin(size_t size) {
         return Props::alignToBin(size);
     }
-    static int sizeToIdx(size_t size) {
+    static unsigned sizeToIdx(size_t size) {
         return Props::sizeToIdx(size);
     }
 
@@ -337,7 +338,7 @@ private:
 
     // Returns artificial bin index,
     // it's used only during sorting and never saved
-    static int sizeToIdx(size_t size);
+    static unsigned sizeToIdx(size_t size);
 
     // Our friends
     friend class Backend;

--- a/src/tbbmalloc/large_objects.h
+++ b/src/tbbmalloc/large_objects.h
@@ -49,7 +49,8 @@ struct LargeBinStructureProps {
 public:
     static const size_t   MinSize = MIN_SIZE, MaxSize = MAX_SIZE;
     static const size_t   CacheStep = 8 * 1024;
-    static_assert((MaxSize - MinSize) / CacheStep <= UINT_MAX, "The size of NumBins is small.");
+    static_assert((MaxSize - MinSize) / CacheStep <= UINT_MAX,
+                  "The type for NumBins is small to represent the desired value.");
     static const unsigned NumBins = (MaxSize - MinSize) / CacheStep;
 
     static size_t alignToBin(size_t size) {

--- a/src/tbbmalloc/large_objects.h
+++ b/src/tbbmalloc/large_objects.h
@@ -54,10 +54,11 @@ public:
         return alignUp(size, CacheStep);
     }
 
-    static int sizeToIdx(size_t size) {
+    static unsigned sizeToIdx(size_t size) {
+        MALLOC_ASSERT(MaxSize <= UINT_MAX, ASSERT_TEXT);
         MALLOC_ASSERT(MinSize <= size && size < MaxSize, ASSERT_TEXT);
         MALLOC_ASSERT(size % CacheStep == 0, ASSERT_TEXT);
-        return (size - MinSize) / CacheStep;
+        return (unsigned)((size - MinSize) / CacheStep);
     }
 };
 
@@ -82,7 +83,7 @@ public:
     static size_t alignToBin(size_t size) {
         MALLOC_ASSERT(size >= StepFactor, "Size must not be less than the StepFactor");
 
-        int sizeExp = (int)BitScanRev(size);
+        int sizeExp = BitScanRev(size);
         MALLOC_ASSERT(sizeExp >= 0, "BitScanRev() cannot return -1, as size >= stepfactor > 0");
         MALLOC_ASSERT(sizeExp >= StepFactorExp, "sizeExp >= StepFactorExp, because size >= stepFactor");
         int minorStepExp = sizeExp - StepFactorExp;
@@ -91,18 +92,19 @@ public:
     }
 
     // Sizes between the power of 2 values are approximated to StepFactor.
+    // TODO: Consider returning unsigned for every sizeToIdx
     static int sizeToIdx(size_t size) {
         MALLOC_ASSERT(MinSize <= size && size <= MaxSize, ASSERT_TEXT);
 
-        int sizeExp = (int)BitScanRev(size); // same as __TBB_Log2
+        int sizeExp = BitScanRev(size); // same as __TBB_Log2
         MALLOC_ASSERT(sizeExp >= 0, "BitScanRev() cannot return -1, as size >= stepfactor > 0");
         MALLOC_ASSERT(sizeExp >= StepFactorExp, "sizeExp >= StepFactorExp, because size >= stepFactor");
-        int minorStepExp = sizeExp - StepFactorExp;
+        unsigned minorStepExp = sizeExp - StepFactorExp;
 
         size_t majorStepSize = 1ULL << sizeExp;
-        int minorIdx = (size - majorStepSize) >> minorStepExp;
+        unsigned minorIdx = (unsigned)((size - majorStepSize) >> minorStepExp);
         MALLOC_ASSERT(size == majorStepSize + ((size_t)minorIdx << minorStepExp),
-            "Size is not aligned on the bin");
+                      "Size is not aligned on the bin");
         return StepFactor * (sizeExp - MinSizeExp) + minorIdx;
     }
 };

--- a/src/tbbmalloc/large_objects.h
+++ b/src/tbbmalloc/large_objects.h
@@ -55,7 +55,7 @@ public:
     }
 
     static unsigned sizeToIdx(size_t size) {
-        MALLOC_ASSERT(MaxSize <= UINT_MAX, ASSERT_TEXT);
+        static_assert(MaxSize <= UINT_MAX, "The cast below can be incorrect");
         MALLOC_ASSERT(MinSize <= size && size < MaxSize, ASSERT_TEXT);
         MALLOC_ASSERT(size % CacheStep == 0, ASSERT_TEXT);
         return (unsigned)((size - MinSize) / CacheStep);

--- a/src/tbbmalloc/large_objects.h
+++ b/src/tbbmalloc/large_objects.h
@@ -49,9 +49,9 @@ struct LargeBinStructureProps {
 public:
     static const size_t   MinSize = MIN_SIZE, MaxSize = MAX_SIZE;
     static const size_t   CacheStep = 8 * 1024;
-    static_assert((MaxSize - MinSize) / CacheStep <= UINT_MAX,
-                  "The type for NumBins is small to represent the desired value.");
     static const unsigned NumBins = (MaxSize - MinSize) / CacheStep;
+    static_assert((MaxSize - MinSize) / CacheStep <= (std::numeric_limits<decltype(NumBins)>::max)(),
+                  "The size of NumBins is enough to represent the desired value.");
 
     static size_t alignToBin(size_t size) {
         return alignUp(size, CacheStep);

--- a/src/tbbmalloc/tbbmalloc_internal.h
+++ b/src/tbbmalloc/tbbmalloc_internal.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbbmalloc/tbbmalloc_internal.h
+++ b/src/tbbmalloc/tbbmalloc_internal.h
@@ -198,7 +198,9 @@ protected:
             mask[i].fetch_and(~(1ULL << pos));
         }
     }
-    int getMinTrue(unsigned startIdx) const {
+    int getMinTrue(int startIndex) const {
+        MALLOC_ASSERT(startIndex >= 0, ASSERT_TEXT);
+        const unsigned startIdx = (unsigned)startIndex;
         unsigned idx = startIdx / WORD_LEN;
         int pos;
 
@@ -226,7 +228,7 @@ template<unsigned NUM>
 class BitMaskMin : public BitMaskBasic<NUM> {
 public:
     void set(size_t idx, bool val) { BitMaskBasic<NUM>::set(idx, val); }
-    int getMinTrue(unsigned startIdx) const {
+    int getMinTrue(int startIdx) const {
         return BitMaskBasic<NUM>::getMinTrue(startIdx);
     }
 };
@@ -239,8 +241,8 @@ public:
 
         BitMaskBasic<NUM>::set(NUM - 1 - idx, val);
     }
-    int getMaxTrue(unsigned startIdx) const {
-        MALLOC_ASSERT(NUM >= startIdx + 1, ASSERT_TEXT);
+    int getMaxTrue(int startIdx) const {
+        MALLOC_ASSERT((int)NUM >= startIdx + 1, ASSERT_TEXT);
 
         int p = BitMaskBasic<NUM>::getMinTrue(NUM-startIdx-1);
         return -1==p? -1 : (int)NUM - 1 - p;

--- a/src/tbbmalloc/tbbmalloc_internal.h
+++ b/src/tbbmalloc/tbbmalloc_internal.h
@@ -51,6 +51,7 @@
 #if MALLOC_CHECK_RECURSION
 #include <new>        /* for placement new */
 #endif
+#include <limits>               // for std::numeric_limits
 #include "oneapi/tbb/scalable_allocator.h"
 #include "tbbmalloc_internal_api.h"
 

--- a/src/tbbmalloc/tbbmalloc_internal.h
+++ b/src/tbbmalloc/tbbmalloc_internal.h
@@ -204,10 +204,12 @@ protected:
         if (startIdx % WORD_LEN) {
             // only interested in part of a word, clear bits before startIdx
             pos = WORD_LEN - startIdx % WORD_LEN;
-            uintptr_t actualMask = mask[idx].load(std::memory_order_relaxed) & (((uintptr_t)1<<pos) - 1);
+            uintptr_t actualMask =
+                mask[idx].load(std::memory_order_relaxed) & (((uintptr_t) 1 << pos) - 1);
             idx++;
-            if (-1 != (pos = BitScanRev(actualMask)))
-                return idx*WORD_LEN - pos - 1;
+            pos = BitScanRev(actualMask);
+            if (-1 != pos)
+                return idx * WORD_LEN - pos - 1;
         }
 
         while (idx<SZ)

--- a/src/tbbmalloc/tbbmalloc_internal.h
+++ b/src/tbbmalloc/tbbmalloc_internal.h
@@ -211,13 +211,17 @@ protected:
                 mask[idx].load(std::memory_order_relaxed) & (((uintptr_t) 1 << pos) - 1);
             idx++;
             pos = BitScanRev(actualMask);
-            if (-1 != pos)
+            if (-1 != pos) {
+                MALLOC_ASSERT(idx * WORD_LEN - pos - 1 <= INT_MAX, ASSERT_TEXT);
                 return idx * WORD_LEN - pos - 1;
+            }
         }
 
         while (idx<SZ)
-            if (-1 != (pos = BitScanRev(mask[idx++].load(std::memory_order_relaxed))))
-                return idx*WORD_LEN - pos - 1;
+            if (-1 != (pos = BitScanRev(mask[idx++].load(std::memory_order_relaxed)))) {
+                MALLOC_ASSERT(idx * WORD_LEN - pos - 1 <= INT_MAX, ASSERT_TEXT);
+                return idx * WORD_LEN - pos - 1;
+            }
         return -1;
     }
 public:

--- a/src/tbbmalloc/tbbmalloc_internal.h
+++ b/src/tbbmalloc/tbbmalloc_internal.h
@@ -503,7 +503,7 @@ private:
 
         // Initialize object variables
         if (hugePageSize > -1) {
-            pageSize = hugePageSize * 1024; // was read in KB from meminfo
+            pageSize = (size_t)hugePageSize * 1024; // was read in KB from meminfo
         } else {
             pageSize = 0;
         }


### PR DESCRIPTION
4267 - 'var' : conversion from 'size_t' to 'type', possible loss of data.
4244 - 'argument' : conversion from 'type1' to 'type2', possible loss of data.
