### PR TITLE
[tbbmalloc] Make indices unsigned

### DIFF
--- a/src/tbbmalloc/large_objects.cpp
+++ b/src/tbbmalloc/large_objects.cpp
@@ -418,7 +418,8 @@ template<typename Props> void CacheBinFunctor<Props>::operator()(CacheBinOperati
 #if __TBB_MALLOC_WHITEBOX_TEST
             tbbmalloc_whitebox::locPutProcessed+=prep.putListNum;
 #endif
-            toRelease = bin->putList(prep.head, prep.tail, bitMask, idx, prep.putListNum, extMemPool->loc.hugeSizeThreshold);
+            toRelease = bin->putList(prep.head, prep.tail, bitMask, idx, prep.putListNum,
+                                     extMemPool->loc.hugeSizeThreshold);
         }
         needCleanup = extMemPool->loc.isCleanupNeededOnRange(timeRange, startTime);
         currTime = endTime - 1;
@@ -540,7 +541,8 @@ template<typename Props> void LargeObjectCacheImpl<Props>::
 /* ------------------------------ Unsafe methods used with the aggregator ------------------------------ */
 
 template<typename Props> LargeMemoryBlock *LargeObjectCacheImpl<Props>::
-    CacheBin::putList(LargeMemoryBlock *head, LargeMemoryBlock *tail, BinBitMask *bitMask, int idx, int num, size_t hugeSizeThreshold)
+    CacheBin::putList(LargeMemoryBlock *head, LargeMemoryBlock *tail, BinBitMask *bitMask,
+                      unsigned idx, int num, size_t hugeSizeThreshold)
 {
     size_t size = head->unalignedSize;
     usedSize.store(usedSize.load(std::memory_order_relaxed) - num * size, std::memory_order_relaxed);

--- a/src/tbbmalloc/large_objects.cpp
+++ b/src/tbbmalloc/large_objects.cpp
@@ -75,7 +75,7 @@ class CacheBinFunctor {
     typename LargeObjectCacheImpl<Props>::CacheBin *const bin;
     ExtMemoryPool *const extMemPool;
     typename LargeObjectCacheImpl<Props>::BinBitMask *const bitMask;
-    const int idx;
+    const unsigned idx;
 
     LargeMemoryBlock *toRelease;
     bool needCleanup;
@@ -134,7 +134,7 @@ class CacheBinFunctor {
 
 public:
     CacheBinFunctor(typename LargeObjectCacheImpl<Props>::CacheBin *bin, ExtMemoryPool *extMemPool,
-                    typename LargeObjectCacheImpl<Props>::BinBitMask *bitMask, int idx) :
+                    typename LargeObjectCacheImpl<Props>::BinBitMask *bitMask, unsigned idx) :
         bin(bin), extMemPool(extMemPool), bitMask(bitMask), idx(idx), toRelease(nullptr), needCleanup(false), currTime(0) {}
     void operator()(CacheBinOperation* opList);
 
@@ -445,7 +445,8 @@ template<typename Props> void CacheBinFunctor<Props>::operator()(CacheBinOperati
 /* ----------------------------------------------------------------------------------------------------- */
 /* --------------------------- Methods for creating and executing operations --------------------------- */
 template<typename Props> void LargeObjectCacheImpl<Props>::
-    CacheBin::ExecuteOperation(CacheBinOperation *op, ExtMemoryPool *extMemPool, BinBitMask *bitMask, int idx, bool longLifeTime)
+    CacheBin::ExecuteOperation(CacheBinOperation *op, ExtMemoryPool *extMemPool, BinBitMask *bitMask,
+                               unsigned idx, bool longLifeTime)
 {
     CacheBinFunctor<Props> func( this, extMemPool, bitMask, idx );
     aggregator.execute( op, func, longLifeTime );
@@ -470,7 +471,8 @@ template<typename Props> LargeMemoryBlock *LargeObjectCacheImpl<Props>::
 }
 
 template<typename Props> void LargeObjectCacheImpl<Props>::
-    CacheBin::putList(ExtMemoryPool *extMemPool, LargeMemoryBlock *head, BinBitMask *bitMask, int idx)
+    CacheBin::putList(ExtMemoryPool *extMemPool, LargeMemoryBlock *head, BinBitMask *bitMask,
+                      unsigned idx)
 {
     MALLOC_ASSERT(sizeof(LargeMemoryBlock)+sizeof(CacheBinOperation)<=head->unalignedSize, "CacheBinOperation is too large to be placed in LargeMemoryBlock!");
 
@@ -527,7 +529,8 @@ template<typename Props> bool LargeObjectCacheImpl<Props>::
 }
 
 template<typename Props> void LargeObjectCacheImpl<Props>::
-    CacheBin::updateUsedSize(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask, int idx)
+    CacheBin::updateUsedSize(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask,
+                             unsigned idx)
 {
     OpUpdateUsedSize data = {size};
     CacheBinOperation op(data);
@@ -838,7 +841,7 @@ void LargeObjectCache::reset()
 template<typename Props>
 LargeMemoryBlock *LargeObjectCacheImpl<Props>::get(ExtMemoryPool *extMemoryPool, size_t size)
 {
-    int idx = Props::sizeToIdx(size);
+    unsigned idx = Props::sizeToIdx(size);
 
     LargeMemoryBlock *lmb = bin[idx].get(extMemoryPool, size, &bitMask, idx);
 
@@ -852,7 +855,7 @@ LargeMemoryBlock *LargeObjectCacheImpl<Props>::get(ExtMemoryPool *extMemoryPool,
 template<typename Props>
 void LargeObjectCacheImpl<Props>::updateCacheState(ExtMemoryPool *extMemPool, DecreaseOrIncrease op, size_t size)
 {
-    int idx = Props::sizeToIdx(size);
+    unsigned idx = Props::sizeToIdx(size);
     MALLOC_ASSERT(idx < static_cast<int>(numBins), ASSERT_TEXT);
     bin[idx].updateUsedSize(extMemPool, op==decrease? -size : size, &bitMask, idx);
 }
@@ -878,7 +881,7 @@ void LargeObjectCache::reportStat(FILE *f)
 template<typename Props>
 void LargeObjectCacheImpl<Props>::putList(ExtMemoryPool *extMemPool, LargeMemoryBlock *toCache)
 {
-    int toBinIdx = Props::sizeToIdx(toCache->unalignedSize);
+    unsigned toBinIdx = Props::sizeToIdx(toCache->unalignedSize);
 
     MALLOC_ITT_SYNC_RELEASING(bin+toBinIdx);
     bin[toBinIdx].putList(extMemPool, toCache, &bitMask, toBinIdx);
@@ -909,7 +912,7 @@ size_t LargeObjectCache::alignToBin(size_t size) {
 }
 
 // Used for internal purpose
-int LargeObjectCache::sizeToIdx(size_t size)
+unsigned LargeObjectCache::sizeToIdx(size_t size)
 {
     MALLOC_ASSERT(size <= maxHugeSize, ASSERT_TEXT);
     return size < maxLargeSize ?
@@ -928,7 +931,7 @@ void LargeObjectCache::putList(LargeMemoryBlock *list)
             extMemPool->backend.returnLargeObject(curr);
             continue;
         }
-        int currIdx = sizeToIdx(curr->unalignedSize);
+        unsigned currIdx = sizeToIdx(curr->unalignedSize);
 
         // Find all blocks fitting to same bin. Not use more efficient sorting
         // algorithm because list is short (commonly,

--- a/src/tbbmalloc/large_objects.h
+++ b/src/tbbmalloc/large_objects.h
@@ -49,6 +49,7 @@ struct LargeBinStructureProps {
 public:
     static const size_t   MinSize = MIN_SIZE, MaxSize = MAX_SIZE;
     static const size_t   CacheStep = 8 * 1024;
+    static_assert((MaxSize - MinSize) / CacheStep <= UINT_MAX, "The size of NumBins is small.");
     static const unsigned NumBins = (MaxSize - MinSize) / CacheStep;
 
     static size_t alignToBin(size_t size) {
@@ -145,7 +146,7 @@ private:
 
 public:
     // The number of bins to cache large/huge objects.
-    static const uint32_t numBins = Props::NumBins;
+    static const unsigned numBins = Props::NumBins;
 
     typedef BitMaskMax<numBins> BinBitMask;
 
@@ -215,11 +216,11 @@ public:
         /* --------- Unsafe methods used with the aggregator ------- */
         void forgetOutdatedState(uintptr_t currTime);
         LargeMemoryBlock *putList(LargeMemoryBlock *head, LargeMemoryBlock *tail, BinBitMask *bitMask,
-                int idx, int num, size_t hugeObjectThreshold);
+                                  unsigned idx, int num, size_t hugeObjectThreshold);
         LargeMemoryBlock *get();
         LargeMemoryBlock *cleanToThreshold(uintptr_t currTime, BinBitMask *bitMask, int idx);
         LargeMemoryBlock *cleanAll(BinBitMask *bitMask, int idx);
-        void updateUsedSize(size_t size, BinBitMask *bitMask, int idx) {
+        void updateUsedSize(size_t size, BinBitMask *bitMask, unsigned idx) {
             if (!usedSize.load(std::memory_order_relaxed)) bitMask->set(idx, true);
             usedSize.store(usedSize.load(std::memory_order_relaxed) + size, std::memory_order_relaxed);
             if (!usedSize.load(std::memory_order_relaxed) && !first) bitMask->set(idx, false);
@@ -245,7 +246,7 @@ public:
 
     // Huge bins index for fast regular cleanup searching in case of
     // the "huge size threshold" setting defined
-    uintptr_t     hugeSizeThresholdIdx;
+    unsigned hugeSizeThresholdIdx;
 
 private:
     // How many times LOC was "too large"

--- a/src/tbbmalloc/large_objects.h
+++ b/src/tbbmalloc/large_objects.h
@@ -93,8 +93,7 @@ public:
     }
 
     // Sizes between the power of 2 values are approximated to StepFactor.
-    // TODO: Consider returning unsigned for every sizeToIdx
-    static int sizeToIdx(size_t size) {
+    static unsigned sizeToIdx(size_t size) {
         MALLOC_ASSERT(MinSize <= size && size <= MaxSize, ASSERT_TEXT);
 
         int sizeExp = BitScanRev(size); // same as __TBB_Log2
@@ -106,7 +105,7 @@ public:
         unsigned minorIdx = (unsigned)((size - majorStepSize) >> minorStepExp);
         MALLOC_ASSERT(size == majorStepSize + ((size_t)minorIdx << minorStepExp),
                       "Size is not aligned on the bin");
-        return StepFactor * (sizeExp - MinSizeExp) + minorIdx;
+        return (unsigned)(StepFactor * (sizeExp - MinSizeExp) + minorIdx);
     }
 };
 
@@ -180,7 +179,8 @@ public:
 
         typename MallocAggregator<CacheBinOperation>::type aggregator;
 
-        void ExecuteOperation(CacheBinOperation *op, ExtMemoryPool *extMemPool, BinBitMask *bitMask, int idx, bool longLifeTime = true);
+        void ExecuteOperation(CacheBinOperation *op, ExtMemoryPool *extMemPool, BinBitMask *bitMask,
+                              unsigned idx, bool longLifeTime = true);
 
         /* should be placed in zero-initialized memory, ctor not needed. */
         CacheBin();
@@ -191,7 +191,7 @@ public:
         }
 
         /* ---------- Cache accessors ---------- */
-        void putList(ExtMemoryPool *extMemPool, LargeMemoryBlock *head, BinBitMask *bitMask, int idx);
+        void putList(ExtMemoryPool *extMemPool, LargeMemoryBlock *head, BinBitMask *bitMask, unsigned idx);
         LargeMemoryBlock *get(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask, int idx);
 
         /* ---------- Cleanup functions -------- */
@@ -199,7 +199,7 @@ public:
         bool releaseAllToBackend(ExtMemoryPool *extMemPool, BinBitMask *bitMask, int idx);
         /* ------------------------------------- */
 
-        void updateUsedSize(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask, int idx);
+        void updateUsedSize(ExtMemoryPool *extMemPool, size_t size, BinBitMask *bitMask, unsigned idx);
         void decreaseThreshold() {
             intptr_t threshold = ageThreshold.load(std::memory_order_relaxed);
             if (threshold)
@@ -245,7 +245,7 @@ public:
 
     // Huge bins index for fast regular cleanup searching in case of
     // the "huge size threshold" setting defined
-    intptr_t     hugeSizeThresholdIdx;
+    uintptr_t     hugeSizeThresholdIdx;
 
 private:
     // How many times LOC was "too large"
@@ -261,7 +261,7 @@ public:
     static size_t alignToBin(size_t size) {
         return Props::alignToBin(size);
     }
-    static int sizeToIdx(size_t size) {
+    static unsigned sizeToIdx(size_t size) {
         return Props::sizeToIdx(size);
     }
 
@@ -337,7 +337,7 @@ private:
 
     // Returns artificial bin index,
     // it's used only during sorting and never saved
-    static int sizeToIdx(size_t size);
+    static unsigned sizeToIdx(size_t size);
 
     // Our friends
     friend class Backend;


### PR DESCRIPTION
Make `sizeToIdx` to return unsigned values, propagating the change up the stack.