### PR TITLE
Use CMake 3.12 way to search for Python interpreter when possible

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -51,7 +51,7 @@ add_custom_target(
     ${CMAKE_COMMAND} -E env
         TBB_INCLUDEDIRS="${TBB4PY_INCLUDE_STRING}"
         TBB_LIBDIRS=$<TARGET_FILE_DIR:TBB::tbb>
-    ${P_EXEC} -m pip install
+    ${${P_EXEC}} -m pip install
         --no-build-isolation
         --prefix build
         ./${PYTHON_BUILD_WORK_DIR}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 set(PY_EXECUTABLE "")
 if(CMAKE_VERSION VERSION_LESS 3.12)
   find_package(PythonInterp 3.5 REQUIRED)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -18,7 +18,7 @@ if(CMAKE_VERSION VERSION_LESS 3.12)
   find_package(PythonInterp 3.5 REQUIRED)
   set(PY_EXECUTABLE "${PYTHON_EXECUTABLE}")
 else()
-  find_package(Python3 3.5 REQUIRED)
+  find_package(Python3 3.5 REQUIRED COMPONENTS Interpreter)
   set(PY_EXECUTABLE "${Python3_EXECUTABLE}")
 endif()
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -13,7 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(PythonInterp 3.5 REQUIRED)
+
+set (P_INTERP "Python3")
+set (P_EXEC "Python3_EXECUTABLE")
+if(CMAKE_VERSION VERSION_LESS 3.12)
+    set (P_INTERP "PythonInterp")
+    set (P_EXEC "PYTHON_EXECUTABLE")
+endif()
+find_package(${P_INTERP} 3.5 REQUIRED)
 
 set(PYTHON_BUILD_WORK_DIR python_build)
 
@@ -44,7 +51,7 @@ add_custom_target(
     ${CMAKE_COMMAND} -E env
         TBB_INCLUDEDIRS="${TBB4PY_INCLUDE_STRING}"
         TBB_LIBDIRS=$<TARGET_FILE_DIR:TBB::tbb>
-    ${PYTHON_EXECUTABLE} -m pip install
+    ${P_EXEC} -m pip install
         --no-build-isolation
         --prefix build
         ./${PYTHON_BUILD_WORK_DIR}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -14,13 +14,14 @@
 # limitations under the License.
 
 
-set (P_INTERP "Python3")
-set (P_EXEC "Python3_EXECUTABLE")
+set(PY_EXECUTABLE "")
 if(CMAKE_VERSION VERSION_LESS 3.12)
-    set (P_INTERP "PythonInterp")
-    set (P_EXEC "PYTHON_EXECUTABLE")
+  find_package(PythonInterp 3.5 REQUIRED)
+  set(PY_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 3.5 REQUIRED)
+  set(PY_EXECUTABLE "${Python3_EXECUTABLE}")
 endif()
-find_package(${P_INTERP} 3.5 REQUIRED)
 
 set(PYTHON_BUILD_WORK_DIR python_build)
 
@@ -51,7 +52,7 @@ add_custom_target(
     ${CMAKE_COMMAND} -E env
         TBB_INCLUDEDIRS="${TBB4PY_INCLUDE_STRING}"
         TBB_LIBDIRS=$<TARGET_FILE_DIR:TBB::tbb>
-    ${${P_EXEC}} -m pip install
+    ${PY_EXECUTABLE} -m pip install
         --no-build-isolation
         --prefix build
         ./${PYTHON_BUILD_WORK_DIR}


### PR DESCRIPTION
### Description 
We observed a situation when incorrect Python was used instead of the python from conda environment.
With this change previously failing use cases start passing.

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [X] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
FYI @bnavigator 

### Other information
