### PR TITLE
Do not link with when symbols are duplicated

### DIFF
--- a/cmake/compilers/IntelLLVM.cmake
+++ b/cmake/compilers/IntelLLVM.cmake
@@ -18,10 +18,10 @@ if (WIN32)
     set(TBB_OPENMP_FLAG /Qopenmp)
     set(TBB_IPO_COMPILE_FLAGS $<$<NOT:$<CONFIG:Debug>>:/Qipo>)
     set(TBB_IPO_LINK_FLAGS $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>)
-    # same symbols are defined in both libmmt.lib and libucrt.lib, fix linking of the tests and the examples
+    # Same symbols are defined in both libmmt.lib and libucrt.lib, fix linking of the tests and the examples
     # by not linking with libmmt.lib for this configuration
-    if(CMAKE_SIZEOF_VOID_P EQUAL 4 AND ("${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "MultiThreaded"
-                                        OR "${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "MultiThreadedDebug"))
+    if (CMAKE_SIZEOF_VOID_P EQUAL 4 AND ("${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "MultiThreaded"
+                                         OR "${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "MultiThreadedDebug"))
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /Qoption,link,/NODEFAULTLIB:libmmt.lib")
     endif()
 else()

--- a/cmake/compilers/IntelLLVM.cmake
+++ b/cmake/compilers/IntelLLVM.cmake
@@ -18,6 +18,12 @@ if (WIN32)
     set(TBB_OPENMP_FLAG /Qopenmp)
     set(TBB_IPO_COMPILE_FLAGS $<$<NOT:$<CONFIG:Debug>>:/Qipo>)
     set(TBB_IPO_LINK_FLAGS $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>)
+    # same symbols are defined in both libmmt.lib and libucrt.lib, fix linking of the tests and the examples
+    # by not linking with libmmt.lib for this configuration
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4 AND ("${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "MultiThreaded"
+                                        OR "${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "MultiThreadedDebug"))
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /Qoption,link,/NODEFAULTLIB:libmmt.lib")
+    endif()
 else()
     include(${CMAKE_CURRENT_LIST_DIR}/Clang.cmake)
     set(TBB_IPO_COMPILE_FLAGS $<$<NOT:$<CONFIG:Debug>>:-ipo>)

--- a/cmake/compilers/IntelLLVM.cmake
+++ b/cmake/compilers/IntelLLVM.cmake
@@ -19,7 +19,7 @@ if (WIN32)
     set(TBB_IPO_COMPILE_FLAGS $<$<NOT:$<CONFIG:Debug>>:/Qipo>)
     set(TBB_IPO_LINK_FLAGS $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>)
     # Same symbols are defined in both libmmt.lib and libucrt.lib, fix linking of the tests and the examples
-    # by not linking with libmmt.lib for this configuration
+    # by not linking with libmmt.lib for this configuration.
     if (CMAKE_SIZEOF_VOID_P EQUAL 4 AND ("${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "MultiThreaded"
                                          OR "${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "MultiThreadedDebug"))
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /Qoption,link,/NODEFAULTLIB:libmmt.lib")

--- a/cmake/compilers/IntelLLVM.cmake
+++ b/cmake/compilers/IntelLLVM.cmake
@@ -23,6 +23,9 @@ if (WIN32)
     if (CMAKE_SIZEOF_VOID_P EQUAL 4 AND ("${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "MultiThreaded"
                                          OR "${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "MultiThreadedDebug"))
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /Qoption,link,/NODEFAULTLIB:libmmt.lib")
+        # _sincos is provided by libmmt, but we have to disable libmmt,
+        # so need to disable _sincos generation as well
+        set(TBB_SINCOS_BROKEN TRUE)
     endif()
 else()
     include(${CMAKE_CURRENT_LIST_DIR}/Clang.cmake)

--- a/examples/parallel_for/tachyon/CMakeLists.txt
+++ b/examples/parallel_for/tachyon/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2020-2025 Intel Corporation
+# Copyright (c) 2026 UXL Foundation Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/parallel_for/tachyon/CMakeLists.txt
+++ b/examples/parallel_for/tachyon/CMakeLists.txt
@@ -66,6 +66,11 @@ target_compile_options(tachyon PRIVATE ${TBB_CXX_STD_FLAG})
 if (MSVC)
   if (CMAKE_CXX_COMPILER_ID STREQUAL IntelLLVM)
     target_compile_options(tachyon PRIVATE -D_CRT_SECURE_NO_WARNINGS)
+    if (TBB_SINCOS_BROKEN)
+      # -fno-builtin-sincos exists, but has no effect: icx-cl still emits sincos,
+      # so we use -fno-builtin to disable all built-in functions.
+      target_compile_options(tachyon PRIVATE -fno-builtin)
+    endif()
   else()
     target_compile_options(tachyon PRIVATE /EHsc)
   endif()


### PR DESCRIPTION
### Description 

For IA-32/Intel compiler/CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded* there is a mass linking failure for tests and examples with

libucrt.lib(frexp.obj) : error LNK2005: _frexp already defined in libmmt.lib(frexp_iface_c99.obj)

This PR removed linking with libmmt.lib for the affected configuration.

### Type of change

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [X] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
