### PR TITLE
Factor out align_up* functions in tbb library.

### DIFF
--- a/include/oneapi/tbb/cache_aligned_allocator.h
+++ b/include/oneapi/tbb/cache_aligned_allocator.h
@@ -126,7 +126,7 @@ private:
         __TBB_ASSERT(base != 0, "Upstream resource returned nullptr.");
 
         // Round up to the next cache line (align the base address)
-        std::uintptr_t result = (base + cache_line_alignment) & ~(cache_line_alignment - 1);
+        std::uintptr_t result = align_up_next(base, cache_line_alignment);
         __TBB_ASSERT((result - base) >= sizeof(std::uintptr_t), "Can`t store a base pointer to the header");
         __TBB_ASSERT(space - (result - base) >= bytes, "Not enough space for the storage");
 

--- a/include/oneapi/tbb/cache_aligned_allocator.h
+++ b/include/oneapi/tbb/cache_aligned_allocator.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/cache_aligned_allocator.h
+++ b/include/oneapi/tbb/cache_aligned_allocator.h
@@ -127,7 +127,7 @@ private:
         __TBB_ASSERT(base != 0, "Upstream resource returned nullptr.");
 
         // Round up to the next cache line (align the base address)
-        std::uintptr_t result = align_up_next(base, cache_line_alignment);
+        std::uintptr_t result = align_to_greater(base, cache_line_alignment);
         __TBB_ASSERT((result - base) >= sizeof(std::uintptr_t), "Can`t store a base pointer to the header");
         __TBB_ASSERT(space - (result - base) >= bytes, "Not enough space for the storage");
 

--- a/include/oneapi/tbb/detail/_utils.h
+++ b/include/oneapi/tbb/detail/_utils.h
@@ -248,7 +248,7 @@ inline T align_up(T arg, std::uintptr_t alignment) {
     return T( ((std::uintptr_t)arg + (alignment - 1)) & ~(alignment - 1) );
 }
 
-// if arg is aleady aligned, returns the next aligned value after arg
+// if arg is already aligned, returns the next aligned value after arg
 template<typename T>
 inline T align_up_next(T arg, std::uintptr_t alignment) {
     return T( ((std::uintptr_t)arg + (alignment)) & ~(alignment - 1) );

--- a/include/oneapi/tbb/detail/_utils.h
+++ b/include/oneapi/tbb/detail/_utils.h
@@ -243,6 +243,17 @@ constexpr bool is_aligned(T* pointer, std::uintptr_t alignment) {
     return 0 == (reinterpret_cast<std::uintptr_t>(pointer) & (alignment - 1));
 }
 
+template<typename T>
+inline T align_up(T arg, std::uintptr_t alignment) {
+    return T( ((std::uintptr_t)arg + (alignment - 1)) & ~(alignment - 1) );
+}
+
+// if arg is aleady aligned, returns the next aligned value after arg
+template<typename T>
+inline T align_up_next(T arg, std::uintptr_t alignment) {
+    return T( ((std::uintptr_t)arg + (alignment)) & ~(alignment - 1) );
+}
+
 #if TBB_USE_ASSERT
 __TBB_GLOBAL_VAR void* const poisoned_ptr = reinterpret_cast<void*>(-1);
 

--- a/include/oneapi/tbb/detail/_utils.h
+++ b/include/oneapi/tbb/detail/_utils.h
@@ -245,12 +245,14 @@ constexpr bool is_aligned(T* pointer, std::uintptr_t alignment) {
 
 template<typename T>
 inline T align_up(T arg, std::uintptr_t alignment) {
+    __TBB_ASSERT(alignment != 0 && is_power_of_two(alignment), "Alignment should be a non-zero power of two");
     return T( ((std::uintptr_t)arg + (alignment - 1)) & ~(alignment - 1) );
 }
 
 // if arg is already aligned, returns the next aligned value after arg
 template<typename T>
 inline T align_up_next(T arg, std::uintptr_t alignment) {
+    __TBB_ASSERT(alignment != 0 && is_power_of_two(alignment), "Alignment should be a non-zero power of two");
     return T( ((std::uintptr_t)arg + (alignment)) & ~(alignment - 1) );
 }
 

--- a/include/oneapi/tbb/detail/_utils.h
+++ b/include/oneapi/tbb/detail/_utils.h
@@ -243,15 +243,16 @@ constexpr bool is_aligned(T* pointer, std::uintptr_t alignment) {
     return 0 == (reinterpret_cast<std::uintptr_t>(pointer) & (alignment - 1));
 }
 
+// A function to return the aligned value greater than or equal to arg
 template<typename T>
-inline T align_up(T arg, std::uintptr_t alignment) {
+inline T align_to_greater_or_equal(T arg, std::uintptr_t alignment) {
     __TBB_ASSERT(alignment != 0 && is_power_of_two(alignment), "Alignment should be a non-zero power of two");
     return T( ((std::uintptr_t)arg + (alignment - 1)) & ~(alignment - 1) );
 }
 
-// if arg is already aligned, returns the next aligned value after arg
+// A function to return the next aligned value after arg
 template<typename T>
-inline T align_up_next(T arg, std::uintptr_t alignment) {
+inline T align_to_greater(T arg, std::uintptr_t alignment) {
     __TBB_ASSERT(alignment != 0 && is_power_of_two(alignment), "Alignment should be a non-zero power of two");
     return T( ((std::uintptr_t)arg + (alignment)) & ~(alignment - 1) );
 }

--- a/src/tbb/allocator.cpp
+++ b/src/tbb/allocator.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/allocator.cpp
+++ b/src/tbb/allocator.cpp
@@ -228,7 +228,7 @@ static void* std_cache_aligned_allocate(std::size_t bytes, std::size_t alignment
     if (!base) {
         return nullptr;
     }
-    std::uintptr_t result = (base + nfs_size) & ~(nfs_size - 1);
+    std::uintptr_t result = align_up_next(base, nfs_size);
     // Round up to the next cache line (align the base address)
     __TBB_ASSERT((result - base) >= sizeof(std::uintptr_t), "Cannot store a base pointer to the header");
     __TBB_ASSERT(space - (result - base) >= bytes, "Not enough space for the storage");
@@ -249,7 +249,7 @@ static void std_cache_aligned_deallocate(void* p) {
         __TBB_ASSERT(reinterpret_cast<std::uintptr_t>(p) >= 0x4096, "attempt to free block not obtained from cache_aligned_allocator");
         // Recover where block actually starts
         std::uintptr_t base = (reinterpret_cast<std::uintptr_t*>(p))[-1];
-        __TBB_ASSERT(((base + nfs_size) & ~(nfs_size - 1)) == reinterpret_cast<std::uintptr_t>(p), "Incorrect alignment or not allocated by std_cache_aligned_deallocate?");
+        __TBB_ASSERT(align_up_next(base, nfs_size) == reinterpret_cast<std::uintptr_t>(p), "Incorrect alignment or not allocated by std_cache_aligned_deallocate?");
         std::free(reinterpret_cast<void*>(base));
     }
 #endif

--- a/src/tbb/allocator.cpp
+++ b/src/tbb/allocator.cpp
@@ -229,7 +229,7 @@ static void* std_cache_aligned_allocate(std::size_t bytes, std::size_t alignment
     if (!base) {
         return nullptr;
     }
-    std::uintptr_t result = align_up_next(base, nfs_size);
+    std::uintptr_t result = align_to_greater(base, nfs_size);
     // Round up to the next cache line (align the base address)
     __TBB_ASSERT((result - base) >= sizeof(std::uintptr_t), "Cannot store a base pointer to the header");
     __TBB_ASSERT(space - (result - base) >= bytes, "Not enough space for the storage");
@@ -250,7 +250,7 @@ static void std_cache_aligned_deallocate(void* p) {
         __TBB_ASSERT(reinterpret_cast<std::uintptr_t>(p) >= 0x4096, "attempt to free block not obtained from cache_aligned_allocator");
         // Recover where block actually starts
         std::uintptr_t base = (reinterpret_cast<std::uintptr_t*>(p))[-1];
-        __TBB_ASSERT(align_up_next(base, nfs_size) == reinterpret_cast<std::uintptr_t>(p), "Incorrect alignment or not allocated by std_cache_aligned_deallocate?");
+        __TBB_ASSERT(align_to_greater(base, nfs_size) == reinterpret_cast<std::uintptr_t>(p), "Incorrect alignment or not allocated by std_cache_aligned_deallocate?");
         std::free(reinterpret_cast<void*>(base));
     }
 #endif

--- a/src/tbb/co_context.h
+++ b/src/tbb/co_context.h
@@ -38,7 +38,7 @@
 
 #elif _WIN32 || _WIN64
 #include <windows.h>
-#else
+#else // __TBB_RESUMABLE_TASKS_USE_THREADS
 // ucontext.h API is deprecated since macOS 10.6
 #if __APPLE__
     #if __INTEL_COMPILER
@@ -63,7 +63,7 @@
 // macOS* defines MAP_ANON, which is deprecated in Linux*.
 #define MAP_ANONYMOUS MAP_ANON
 #endif
-#endif // _WIN32 || _WIN64
+#endif // __TBB_RESUMABLE_TASKS_USE_THREADS
 
 namespace tbb {
 namespace detail {
@@ -303,7 +303,7 @@ inline void destroy_coroutine(coroutine_type& c) {
     __TBB_ASSERT(c, nullptr);
     DeleteFiber(c);
 }
-#else // !(_WIN32 || _WIN64)
+#else // !__TBB_RESUMABLE_TASKS_USE_THREADS
 
 inline void create_coroutine(coroutine_type& c, std::size_t stack_size, void* arg) {
     const std::size_t REG_PAGE_SIZE = governor::default_page_size();
@@ -374,7 +374,7 @@ inline void destroy_coroutine(coroutine_type& c) {
     #endif
 #endif
 
-#endif // _WIN32 || _WIN64
+#endif // __TBB_RESUMABLE_TASKS_USE_THREADS
 
 } // namespace r1
 } // namespace detail

--- a/src/tbb/co_context.h
+++ b/src/tbb/co_context.h
@@ -307,7 +307,7 @@ inline void destroy_coroutine(coroutine_type& c) {
 
 inline void create_coroutine(coroutine_type& c, std::size_t stack_size, void* arg) {
     const std::size_t REG_PAGE_SIZE = governor::default_page_size();
-    const std::size_t page_aligned_stack_size = (stack_size + (REG_PAGE_SIZE - 1)) & ~(REG_PAGE_SIZE - 1);
+    const std::size_t page_aligned_stack_size = align_up(stack_size, REG_PAGE_SIZE);
     const std::size_t protected_stack_size = page_aligned_stack_size + 2 * REG_PAGE_SIZE;
 
     // Allocate the stack with protection property

--- a/src/tbb/co_context.h
+++ b/src/tbb/co_context.h
@@ -307,7 +307,7 @@ inline void destroy_coroutine(coroutine_type& c) {
 
 inline void create_coroutine(coroutine_type& c, std::size_t stack_size, void* arg) {
     const std::size_t REG_PAGE_SIZE = governor::default_page_size();
-    const std::size_t page_aligned_stack_size = align_up(stack_size, REG_PAGE_SIZE);
+    const std::size_t page_aligned_stack_size = align_to_greater_or_equal(stack_size, REG_PAGE_SIZE);
     const std::size_t protected_stack_size = page_aligned_stack_size + 2 * REG_PAGE_SIZE;
 
     // Allocate the stack with protection property

--- a/src/tbb/misc.h
+++ b/src/tbb/misc.h
@@ -121,11 +121,6 @@ T max ( const T& val1, const T& val2 ) {
     return val1 < val2 ? val2 : val1;
 }
 
-template<typename T>
-inline T align_up( T arg, uintptr_t alignment ) {
-    return T( ((uintptr_t)arg + (alignment - 1)) & ~(alignment - 1) );
-}
-
 //! Utility helper structure to ease overload resolution
 template<int > struct int_to_type {};
 

--- a/src/tbb/numa_allocation.cpp
+++ b/src/tbb/numa_allocation.cpp
@@ -179,7 +179,7 @@ void *__TBB_EXPORTED_FUNC allocate_interleaved(size_t bytes,
                               PAGE_READWRITE);
 
     // for VirtualAlloc2 it must be a multiple of the page size
-    bytes = align_up(bytes, governor::default_page_size());
+    bytes = align_to_greater_or_equal(bytes, governor::default_page_size());
     char* base_addr =
         reinterpret_cast<char*>(VirtualAlloc2_ptr(/*Process=*/nullptr, /*BaseAddress=*/nullptr, bytes,
                                                   MEM_RESERVE | MEM_RESERVE_PLACEHOLDER, PAGE_NOACCESS,


### PR DESCRIPTION
### Description 
There are 2 kind of alignment up in TBB sources, alignment up to nearest aligned and alignment to next aligned, if an argument is already aligned. Readability is improved, if we name them explicitly. 

### Type of change

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [X] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
