### PR TITLE
Fix a race in task group dynamic dependencies implementation

### DIFF
--- a/include/oneapi/tbb/detail/_task_handle.h
+++ b/include/oneapi/tbb/detail/_task_handle.h
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 2020-2025 Intel Corporation
-    Copyright (c) 2025 UXL Foundation Contributors
+    Copyright (c) 2025-2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/detail/_task_handle.h
+++ b/include/oneapi/tbb/detail/_task_handle.h
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 2020-2025 Intel Corporation
-    Copyright (c) 2025-2026 UXL Foundation Contributors
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/detail/_task_handle.h
+++ b/include/oneapi/tbb/detail/_task_handle.h
@@ -147,6 +147,7 @@ public:
     task_group_status wait_for_completion(d1::task_group_context&);
     task_group_status run_self_and_wait_for_completion(d1::task_group_context&);
     void add_notify_node(notify_list_node* new_notify_node, notify_list_node* current_notify_list_head);
+    void resolve_completion_state_and_add_notify_node(notify_list_node* new_notify_node);
     void add_notify_list(notify_list_node* notify_list);
 
     using notify_list_state_flag = std::uintptr_t;
@@ -411,10 +412,30 @@ inline bool operator!=(std::nullptr_t, task_handle const& th) noexcept {
 }
 
 #if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
+inline void task_dynamic_state::resolve_completion_state_and_add_notify_node(notify_list_node* new_notify_node) {
+    notify_list_node* current_notify_list_head = m_notify_list_head.load(std::memory_order_acquire);
+
+    if (represents_completed_task(current_notify_list_head)) {
+        new_notify_node->notify_on_completion();
+    } else if (represents_canceled_task(current_notify_list_head)) {
+        new_notify_node->notify_on_cancellation();
+    } else if (represents_transferred_completion(current_notify_list_head)) {
+        // Redirect notify_node to the task received the completion
+        task_dynamic_state* new_completion_point = m_new_completion_point.load(std::memory_order_relaxed);
+        __TBB_ASSERT(new_completion_point, "notify list is marked as transferred, but new dynamic state is not set");
+        new_completion_point->resolve_completion_state_and_add_notify_node(new_notify_node);
+    } else {
+        add_notify_node(new_notify_node, current_notify_list_head);
+    }
+}
+
 inline void task_dynamic_state::add_notify_node(notify_list_node* new_notify_node,
                                                 notify_list_node* current_notify_list_head)
 {
     __TBB_ASSERT(new_notify_node != nullptr, nullptr);
+    __TBB_ASSERT(!represents_completed_task(current_notify_list_head) &&
+                 !represents_canceled_task(current_notify_list_head) &&
+                 !represents_transferred_completion(current_notify_list_head), nullptr);
 
     new_notify_node->next_node = current_notify_list_head;
 
@@ -433,7 +454,7 @@ inline void task_dynamic_state::add_notify_node(notify_list_node* new_notify_nod
             // Redirect notify_node to the task received the completion
             task_dynamic_state* new_completion_point = m_new_completion_point.load(std::memory_order_relaxed);
             __TBB_ASSERT(new_completion_point, "notify list is marked as transferred, but new dynamic state is not set");
-            new_completion_point->add_notify_node(new_notify_node, new_completion_point->m_notify_list_head.load(std::memory_order_acquire));
+            new_completion_point->resolve_completion_state_and_add_notify_node(new_notify_node);
             break;
         }
 

--- a/include/oneapi/tbb/detail/_task_handle.h
+++ b/include/oneapi/tbb/detail/_task_handle.h
@@ -419,14 +419,16 @@ inline void task_dynamic_state::add_notify_node(notify_list_node* new_notify_nod
                  !represents_canceled_task(current_notify_list_head) &&
                  !represents_transferred_completion(current_notify_list_head), nullptr);
 
+    new_notify_node->next_node = current_notify_list_head;
+
     // current_state walks through the transfer chain to find the correct list on which to
     // retry the insertion. Rechecking for sentinel values is required for each list in the transfer chain
     task_dynamic_state* current_state = this;
     bool recheck_current_state = false;
 
     while (recheck_current_state ||
-           current_state->m_notify_list_head.compare_exchange_strong(current_notify_list_head, new_notify_node,
-                                                                     std::memory_order_release, std::memory_order_relaxed))
+           !current_state->m_notify_list_head.compare_exchange_strong(current_notify_list_head, new_notify_node,
+                                                                      std::memory_order_release, std::memory_order_relaxed))
     {
         // The recheck was requested because of switching to the next node to the transfer chain
         // Or the CAS failed because of another thread that updated the list head

--- a/include/oneapi/tbb/detail/_task_handle.h
+++ b/include/oneapi/tbb/detail/_task_handle.h
@@ -430,7 +430,7 @@ inline void task_dynamic_state::add_notify_node(notify_list_node* new_notify_nod
            !current_state->m_notify_list_head.compare_exchange_strong(current_notify_list_head, new_notify_node,
                                                                       std::memory_order_release, std::memory_order_relaxed))
     {
-        // The recheck was requested because of switching to the next node to the transfer chain
+        // The recheck was requested because of switching to the next node in the transfer chain
         // Or the CAS failed because of another thread that updated the list head
         // current_notify_list_head has been updated by the CAS call
         recheck_current_state = false;

--- a/include/oneapi/tbb/detail/_task_handle.h
+++ b/include/oneapi/tbb/detail/_task_handle.h
@@ -147,7 +147,6 @@ public:
     task_group_status wait_for_completion(d1::task_group_context&);
     task_group_status run_self_and_wait_for_completion(d1::task_group_context&);
     void add_notify_node(notify_list_node* new_notify_node, notify_list_node* current_notify_list_head);
-    void resolve_completion_state_and_add_notify_node(notify_list_node* new_notify_node);
     void add_notify_list(notify_list_node* notify_list);
 
     using notify_list_state_flag = std::uintptr_t;
@@ -412,23 +411,6 @@ inline bool operator!=(std::nullptr_t, task_handle const& th) noexcept {
 }
 
 #if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
-inline void task_dynamic_state::resolve_completion_state_and_add_notify_node(notify_list_node* new_notify_node) {
-    notify_list_node* current_notify_list_head = m_notify_list_head.load(std::memory_order_acquire);
-
-    if (represents_completed_task(current_notify_list_head)) {
-        new_notify_node->notify_on_completion();
-    } else if (represents_canceled_task(current_notify_list_head)) {
-        new_notify_node->notify_on_cancellation();
-    } else if (represents_transferred_completion(current_notify_list_head)) {
-        // Redirect notify_node to the task received the completion
-        task_dynamic_state* new_completion_point = m_new_completion_point.load(std::memory_order_relaxed);
-        __TBB_ASSERT(new_completion_point, "notify list is marked as transferred, but new dynamic state is not set");
-        new_completion_point->resolve_completion_state_and_add_notify_node(new_notify_node);
-    } else {
-        add_notify_node(new_notify_node, current_notify_list_head);
-    }
-}
-
 inline void task_dynamic_state::add_notify_node(notify_list_node* new_notify_node,
                                                 notify_list_node* current_notify_list_head)
 {
@@ -437,28 +419,50 @@ inline void task_dynamic_state::add_notify_node(notify_list_node* new_notify_nod
                  !represents_canceled_task(current_notify_list_head) &&
                  !represents_transferred_completion(current_notify_list_head), nullptr);
 
+    // Trying to insert new_notify_node into the notify list
+    // calling functions already checked current_notify_list_head for sentinel values
+
     new_notify_node->next_node = current_notify_list_head;
+    if (m_notify_list_head.compare_exchange_strong(current_notify_list_head, new_notify_node)) {
+        return;
+    }
 
-    while (!m_notify_list_head.compare_exchange_strong(current_notify_list_head, new_notify_node)) {
-        // Other thread updated the head of the list
+    // CAS failed, another thread has updated the list head
+    // current_notify_list_head is updated by the CAS call
 
+    // current_state will walk through the transfer chain to find the correct list to
+    // retry the insertion
+    task_dynamic_state* current_state = this;
+
+    while (true) {
         if (represents_completed_task(current_notify_list_head)) {
-            // Current task has completed while we tried to insert the node to the list
+            // Current task has completed while we tried to insert the node into the list
             new_notify_node->notify_on_completion();
             break;
-        } else if (represents_canceled_task(current_notify_list_head)) {
-            // Current task has canceled while we tried to insert the node to the list
+        }
+        if (represents_canceled_task(current_notify_list_head)) {
+            // Current task has canceled while we tried to insert the node into the list
             new_notify_node->notify_on_cancellation();
             break;
-        } else if (represents_transferred_completion(current_notify_list_head)) {
-            // Redirect notify_node to the task received the completion
-            task_dynamic_state* new_completion_point = m_new_completion_point.load(std::memory_order_relaxed);
-            __TBB_ASSERT(new_completion_point, "notify list is marked as transferred, but new dynamic state is not set");
-            new_completion_point->resolve_completion_state_and_add_notify_node(new_notify_node);
-            break;
+        }
+        if (represents_transferred_completion(current_notify_list_head)) {
+            // Switch to the notify list of the recipient of the transferred completion
+            current_state = current_state->m_new_completion_point.load(std::memory_order_relaxed);
+            __TBB_ASSERT(current_state, "notify list is marked as transferred, but new completion point is not set");
+            current_notify_list_head = current_state->m_notify_list_head.load(std::memory_order_acquire);
+
+            // The recipient may be already completed, canceled, or its completion may be transferred,
+            // re-checking will be performed by the next iteration of the while loop
+            continue;
         }
 
+        // current_notify_list_head is a regular list node. Trying to insert the node into the list
         new_notify_node->next_node = current_notify_list_head;
+        if (current_state->m_notify_list_head.compare_exchange_strong(current_notify_list_head, new_notify_node)) {
+            break;
+        }
+        // CAS failed, another thread has updated the list head
+        // current_notify_list_head is updated by the CAS call
     }
 }
 

--- a/include/oneapi/tbb/detail/_task_handle.h
+++ b/include/oneapi/tbb/detail/_task_handle.h
@@ -419,50 +419,50 @@ inline void task_dynamic_state::add_notify_node(notify_list_node* new_notify_nod
                  !represents_canceled_task(current_notify_list_head) &&
                  !represents_transferred_completion(current_notify_list_head), nullptr);
 
-    // Trying to insert new_notify_node into the notify list
-    // calling functions already checked current_notify_list_head for sentinel values
+    // Try to insert new_notify_node into the notify list
+    // Calling functions have already checked current_notify_list_head for sentinel values
 
     new_notify_node->next_node = current_notify_list_head;
     if (m_notify_list_head.compare_exchange_strong(current_notify_list_head, new_notify_node)) {
         return;
     }
 
-    // CAS failed, another thread has updated the list head
-    // current_notify_list_head is updated by the CAS call
+    // CAS failed; another thread has updated the list head
+    // current_notify_list_head has been updated by the CAS call
 
-    // current_state will walk through the transfer chain to find the correct list to
+    // current_state walks through the transfer chain to find the correct list on which to
     // retry the insertion
     task_dynamic_state* current_state = this;
 
     while (true) {
         if (represents_completed_task(current_notify_list_head)) {
-            // Current task has completed while we tried to insert the node into the list
+            // The current task has completed while we were trying to insert the node into the list
             new_notify_node->notify_on_completion();
             break;
         }
         if (represents_canceled_task(current_notify_list_head)) {
-            // Current task has canceled while we tried to insert the node into the list
+            // The current task has been canceled while we were trying to insert the node into the list
             new_notify_node->notify_on_cancellation();
             break;
         }
         if (represents_transferred_completion(current_notify_list_head)) {
             // Switch to the notify list of the recipient of the transferred completion
             current_state = current_state->m_new_completion_point.load(std::memory_order_relaxed);
-            __TBB_ASSERT(current_state, "notify list is marked as transferred, but new completion point is not set");
+            __TBB_ASSERT(current_state, "notify list is marked as transferred, but the new completion point is not set");
             current_notify_list_head = current_state->m_notify_list_head.load(std::memory_order_acquire);
 
-            // The recipient may be already completed, canceled, or its completion may be transferred,
+            // The recipient may already be completed or canceled, or its completion may itself have been transferred
             // re-checking will be performed by the next iteration of the while loop
             continue;
         }
 
-        // current_notify_list_head is a regular list node. Trying to insert the node into the list
+        // current_notify_list_head is a regular list node. Try to insert the node into the list
         new_notify_node->next_node = current_notify_list_head;
         if (current_state->m_notify_list_head.compare_exchange_strong(current_notify_list_head, new_notify_node)) {
             break;
         }
-        // CAS failed, another thread has updated the list head
-        // current_notify_list_head is updated by the CAS call
+        // CAS failed; another thread has updated the list head
+        // current_notify_list_head has been updated by the CAS call
     }
 }
 

--- a/include/oneapi/tbb/detail/_task_handle.h
+++ b/include/oneapi/tbb/detail/_task_handle.h
@@ -420,17 +420,26 @@ inline void task_dynamic_state::add_notify_node(notify_list_node* new_notify_nod
                  !represents_transferred_completion(current_notify_list_head), nullptr);
 
     // current_state walks through the transfer chain to find the correct list on which to
-    // retry the insertion
+    // retry the insertion. Rechecking for sentinel values is required for each list in the transfer chain
     task_dynamic_state* current_state = this;
+    bool recheck_current_state = false;
 
-    while (true) {
+    while (recheck_current_state ||
+           current_state->m_notify_list_head.compare_exchange_strong(current_notify_list_head, new_notify_node,
+                                                                     std::memory_order_release, std::memory_order_relaxed))
+    {
+        // The recheck was requested because of switching to the next node to the transfer chain
+        // Or the CAS failed because of another thread that updated the list head
+        // current_notify_list_head has been updated by the CAS call
+        recheck_current_state = false;
+
         if (represents_completed_task(current_notify_list_head)) {
             // The current task has completed while we were trying to insert the node into the list
             new_notify_node->notify_on_completion();
             break;
         }
         if (represents_canceled_task(current_notify_list_head)) {
-            // The current task has been canceled while we were trying to insert the node into the list
+            // The current task has canceled while we were trying to insert the node into the list
             new_notify_node->notify_on_cancellation();
             break;
         }
@@ -439,21 +448,11 @@ inline void task_dynamic_state::add_notify_node(notify_list_node* new_notify_nod
             current_state = current_state->m_new_completion_point.load(std::memory_order_relaxed);
             __TBB_ASSERT(current_state, "notify list is marked as transferred, but the new completion point is not set");
             current_notify_list_head = current_state->m_notify_list_head.load(std::memory_order_acquire);
-
-            // The recipient may already be completed or canceled, or its completion may itself have been transferred
-            // re-checking will be performed by the next iteration of the while loop
-            continue;
+            recheck_current_state = true;
+        } else {
+            // current_notify_list_head is a regular list node. Try to insert the node into the list on the next iteration
+            new_notify_node->next_node = current_notify_list_head;
         }
-
-        // current_notify_list_head is a regular list node. Try to insert the node into the list
-        new_notify_node->next_node = current_notify_list_head;
-        if (current_state->m_notify_list_head.compare_exchange_strong(current_notify_list_head, new_notify_node,
-                                                                      std::memory_order_release, std::memory_order_relaxed))
-        {
-            break;
-        }
-        // CAS failed; another thread has updated the list head
-        // current_notify_list_head has been updated by the CAS call
     }
 }
 

--- a/include/oneapi/tbb/detail/_task_handle.h
+++ b/include/oneapi/tbb/detail/_task_handle.h
@@ -419,17 +419,6 @@ inline void task_dynamic_state::add_notify_node(notify_list_node* new_notify_nod
                  !represents_canceled_task(current_notify_list_head) &&
                  !represents_transferred_completion(current_notify_list_head), nullptr);
 
-    // Try to insert new_notify_node into the notify list
-    // Calling functions have already checked current_notify_list_head for sentinel values
-
-    new_notify_node->next_node = current_notify_list_head;
-    if (m_notify_list_head.compare_exchange_strong(current_notify_list_head, new_notify_node)) {
-        return;
-    }
-
-    // CAS failed; another thread has updated the list head
-    // current_notify_list_head has been updated by the CAS call
-
     // current_state walks through the transfer chain to find the correct list on which to
     // retry the insertion
     task_dynamic_state* current_state = this;
@@ -458,7 +447,9 @@ inline void task_dynamic_state::add_notify_node(notify_list_node* new_notify_nod
 
         // current_notify_list_head is a regular list node. Try to insert the node into the list
         new_notify_node->next_node = current_notify_list_head;
-        if (current_state->m_notify_list_head.compare_exchange_strong(current_notify_list_head, new_notify_node)) {
+        if (current_state->m_notify_list_head.compare_exchange_strong(current_notify_list_head, new_notify_node,
+                                                                      std::memory_order_release, std::memory_order_relaxed))
+        {
             break;
         }
         // CAS failed; another thread has updated the list head

--- a/include/oneapi/tbb/detail/_task_handle.h
+++ b/include/oneapi/tbb/detail/_task_handle.h
@@ -427,8 +427,10 @@ inline void task_dynamic_state::add_notify_node(notify_list_node* new_notify_nod
     bool recheck_current_state = false;
 
     while (recheck_current_state ||
-           !current_state->m_notify_list_head.compare_exchange_strong(current_notify_list_head, new_notify_node,
-                                                                      std::memory_order_release, std::memory_order_relaxed))
+           !current_state->m_notify_list_head.compare_exchange_strong(current_notify_list_head,
+                                            new_notify_node,
+                                            std::memory_order_release,
+                                            std::memory_order_relaxed))
     {
         // The recheck was requested because of switching to the next node in the transfer chain
         // Or the CAS failed because of another thread that updated the list head

--- a/include/oneapi/tbb/detail/_task_handle.h
+++ b/include/oneapi/tbb/detail/_task_handle.h
@@ -428,9 +428,9 @@ inline void task_dynamic_state::add_notify_node(notify_list_node* new_notify_nod
 
     while (recheck_current_state ||
            !current_state->m_notify_list_head.compare_exchange_strong(current_notify_list_head,
-                                            new_notify_node,
-                                            std::memory_order_release,
-                                            std::memory_order_relaxed))
+                                                                      new_notify_node,
+                                                                      std::memory_order_release,
+                                                                      std::memory_order_relaxed))
     {
         // The recheck was requested because of switching to the next node in the transfer chain
         // Or the CAS failed because of another thread that updated the list head

--- a/test/tbb/test_task_group.cpp
+++ b/test/tbb/test_task_group.cpp
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 2005-2025 Intel Corporation
-    Copyright (c) 2025-2026 UXL Foundation Contributors
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_task_group.cpp
+++ b/test/tbb/test_task_group.cpp
@@ -1,6 +1,6 @@
 /*
     Copyright (c) 2005-2025 Intel Corporation
-    Copyright (c) 2025 UXL Foundation Contributors
+    Copyright (c) 2025-2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -1998,6 +1998,65 @@ void test_adding_successors_after_transfer(submit_function func) {
     CHECK_MESSAGE(new_successor_task_placeholder == finished_task, "new successor task was not finished");
 }
 
+// Regression test for a race in task_dynamic_state::add_notify_node.
+
+// Setup: thread A calls set_task_order(sender, succ). Thread B is
+// executing the sender, which transfers its completion to a recipient that
+// then completes quickly.
+
+// The race: thread A first observes the sender as not-completed and not-yet transferred,
+// allocates a notify node, and tries to CAS it onto the sender's notify
+// list. Meanwhile thread B marks the sender as transferred to recipient and
+// finishes the recipient. Thread A's CAS fails, observes transferred, and
+// must redirect the new node to the recipient.
+
+// The old implementation contained a bug: the redirect path called add_notify_node on
+// the recipient with whatever head it just loaded, never re-classifying it as
+// completed. The successor node was inserted into the notify list of already completed
+// task and therefore, was never notified.
+void test_adding_successors_during_transfer_to_completed_recipient() {
+    const int num_threads = tbb::this_task_arena::max_concurrency();
+    const std::size_t num_iterations = num_threads * 100;
+
+    // Need at least 2 threads to reproduce the race
+    if (num_threads < 2) return;
+    
+    for (std::size_t i = 0; i < num_iterations; ++i) {
+        tbb::task_group tg;
+        std::atomic<int> succ_count{0};
+
+        tbb::task_handle recipient = tg.defer([] {});
+
+        tbb::task_handle sender = tg.defer([&recipient] {
+            tbb::task_group::transfer_this_task_completion_to(recipient);
+            // Bypassing the recipient to minimize the window between the transferring
+            // and the completion of recipient
+            return std::move(recipient);
+        });
+
+        tbb::task_completion_handle sender_ch = sender;
+
+        // Barrier to stop num_threads - 1 threads just before adding the successor
+        // and the submitter thread just before running the sender
+        utils::SpinBarrier barrier(num_threads);
+
+        utils::NativeParallelFor(num_threads, [&](int idx) {
+            if (idx == 0) {
+                barrier.wait();
+                tg.run(std::move(sender));
+            } else {
+                tbb::task_handle succ = tg.defer([&] { ++succ_count; });
+                barrier.wait();
+                tbb::task_group::set_task_order(sender_ch, succ);
+                tg.run(std::move(succ));
+            }
+        });
+
+        tg.wait();
+        CHECK_MESSAGE(succ_count == num_threads - 1, "Lost successors");
+    }
+}
+
 void test_transferring_completion(unsigned num_threads, submit_function func) {
     test_recursive_reduction(func);
     if (num_threads != 1) test_adding_successors_after_transfer(func);
@@ -2121,6 +2180,11 @@ TEST_CASE("test dependencies and cancellation") {
     }
     tbb::task_group_status status = tg.wait();
     CHECK_MESSAGE(status == tbb::task_group_status::canceled, "Incorrect status of cancelled task_group");
+}
+
+//! \brief \ref regression
+TEST_CASE("Test race when successors are added during transfer") {
+    test_adding_successors_during_transfer_to_completed_recipient();
 }
 #endif
 


### PR DESCRIPTION
### Description 
Fix for a tricky race in task group dynamic dependencies.

Consider the following situation:
- Thread A is adding a successor to task T.
- Thread B is executing T which transfers its successors to TT, which executes and completes immediately.

To reproduce the issue, thread A should first detect T as not-completed, not-transferred to bypass initial checks. In this case, it allocates the successor notify node that will be inserted into T's notify list.
After that, thread B transfers T's successors to TT and completes TT (T's notify list is in TRANSFERRED state, TT's - in COMPLETED state).

thread A is then trying to insert new notify node into T's notify list, detects that it is in TRANSFERRED state and redirects the node to TT. The bug is that the state of TT is not checked at this point - the node is just inserted into TT's notify list, which was already processed. Therefore, a successor task will never be executed.

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
