### PR TITLE
Allocate memory directly from NUMA nodes to support interleaving

### DIFF
--- a/src/tbb/numa_allocation.cpp
+++ b/src/tbb/numa_allocation.cpp
@@ -29,8 +29,16 @@
 
 // TBB build must be done without numaif.h, but we need signature of move_pages()
 // for dynamic loading, so declare it here.
-extern "C" long move_pages(int pid, unsigned long count,
-                           void **pages, const int *nodes, int *status, int flags);
+extern "C" {
+long move_pages(int pid, unsigned long count,
+                void **pages, const int *nodes, int *status, int flags);
+struct bitmask *numa_bitmask_alloc(unsigned int);
+void numa_bitmask_free(struct bitmask *);
+int numa_bitmask_isbitset(const struct bitmask *, unsigned int);
+struct bitmask *numa_bitmask_setbit(struct bitmask *, unsigned int);
+void numa_interleave_memory(void *mem, size_t size, struct bitmask *mask);
+
+} // extern "C"
 
 #elif !(_WIN32 || _WIN64)
 
@@ -46,13 +54,28 @@ namespace r1 {
 
 #if __TBB_WEAK_SYMBOLS_PRESENT
 #pragma weak move_pages
+#pragma weak numa_bitmask_alloc
+#pragma weak numa_bitmask_free
+#pragma weak numa_bitmask_isbitset
+#pragma weak numa_bitmask_setbit
+#pragma weak numa_interleave_memory
 #endif
 
 static long (*move_pages_ptr)(int pid, unsigned long count,
              void **pages, const int *nodes, int *status, int flags);
+static struct bitmask *(*numa_bitmask_alloc_ptr)(unsigned int);
+static void (*numa_bitmask_free_ptr)(struct bitmask *);
+static int (*numa_bitmask_isbitset_ptr)(const struct bitmask *, unsigned int);
+static struct bitmask *(*numa_bitmask_setbit_ptr)(struct bitmask *, unsigned int);
+static void (*numa_interleave_memory_ptr)(void *mem, size_t size, struct bitmask *mask);
 
 static const dynamic_link_descriptor LibnumaLinkTable[] = {
-    DLD(move_pages, move_pages_ptr)
+    DLD(move_pages, move_pages_ptr),
+    DLD(numa_bitmask_alloc, numa_bitmask_alloc_ptr),
+    DLD(numa_bitmask_free, numa_bitmask_free_ptr),
+    DLD(numa_bitmask_isbitset, numa_bitmask_isbitset_ptr),
+    DLD(numa_bitmask_setbit, numa_bitmask_setbit_ptr),
+    DLD(numa_interleave_memory, numa_interleave_memory_ptr)
 };
 #elif _WIN32 || _WIN64
 static PVOID (*VirtualAlloc2_ptr)(HANDLE Process,
@@ -125,21 +148,46 @@ void *__TBB_EXPORTED_FUNC allocate_interleaved(size_t bytes,
     if (base_addr == MAP_FAILED)
         return nullptr;
 
+    // no NUMA nodes or move_pages() not available, just return the memory as is
+    if (numa_node_count() == 1 || !move_pages_ptr)
+        return base_addr;
+
     auto unmap = [bytes](void *ptr) {
         munmap(ptr, bytes);
     };
     std::unique_ptr<void, decltype(unmap)> data_holder(base_addr, unmap);
 
-    // no NUMA nodes or move_pages() not available, just return the memory as is
-    if (numa_node_count() == 1 || !move_pages_ptr)
-        return data_holder.release();
+    // for chunk size equal to page size and all nodes being different we can place memory right to
+    // the appropriate NUMA nodes with a single system call, otherwise we need to touch each page
+    // from current thread and only then move them
+    if (bytes_per_chunk == governor::default_page_size()) {
+        auto bitmask_free = [](struct bitmask *m) {
+            numa_bitmask_free_ptr(m);
+        };
+        std::unique_ptr<struct bitmask, decltype(bitmask_free)>
+            bitmask_holder(numa_bitmask_alloc_ptr(numa_node_count()), bitmask_free);
+
+        size_t i = 0;
+        for (; i < nodes_count; ++i) {
+            // numa_interleave_memory doesn't support repeated nodes, fallback to move_pages()
+            if (numa_bitmask_isbitset_ptr(bitmask_holder.get(), nodes[i]))
+                break;
+            numa_bitmask_setbit_ptr(bitmask_holder.get(), nodes[i]);
+        }
+        if (i == nodes_count) {
+            numa_interleave_memory_ptr(base_addr, bytes, bitmask_holder.get());
+
+            return data_holder.release();
+        }
+    }
+    // process non-standard chunk size or repeated nodes
 
     // touch each page, otherwise move_pages() will fail with EFAULT
     for (size_t i = 0; i < bytes; i += governor::default_page_size())
         base_addr[i] = 0;
 
     size_t count_pages = (bytes + governor::default_page_size() - 1) / governor::default_page_size();
-    std::unique_ptr<void*[]> pages(new void*[count_pages]);
+    std::unique_ptr<void *[]> pages(new void *[count_pages]);
     std::unique_ptr<int[]> nodes_per_page(new int[count_pages]);
     std::unique_ptr<int[]> status(new int[count_pages]);
 

--- a/src/tbb/numa_allocation.cpp
+++ b/src/tbb/numa_allocation.cpp
@@ -25,6 +25,7 @@
 
 #if __linux__
 
+#include <algorithm> // for std::any_of
 #include <sys/mman.h>
 
 // TBB build must be done without numaif.h, but we need signature of move_pages()
@@ -160,7 +161,7 @@ void *__TBB_EXPORTED_FUNC allocate_interleaved(size_t bytes,
     // for chunk size equal to page size and all nodes being different we can place memory right to
     // the appropriate NUMA nodes with a single system call, otherwise we need to touch each page
     // from current thread and only then move them
-    if (bytes_per_chunk == governor::default_page_size()) {
+    if (bytes_per_chunk == governor::default_page_size() && nodes_count <= numa_node_count()) {
         auto bitmask_free = [](struct bitmask *m) {
             numa_bitmask_free_ptr(m);
         };
@@ -204,10 +205,8 @@ void *__TBB_EXPORTED_FUNC allocate_interleaved(size_t bytes,
     if (ret < 0)
         return nullptr;
 
-    for (size_t i = 0; i < count_pages; ++i)
-        if (status[i] < 0)
-            return nullptr;
-    return data_holder.release();
+    return std::any_of(status.get(), status.get() + count_pages, [](int s) { return s < 0; }) ?
+        nullptr : data_holder.release();
 }
 
 #elif _WIN32 || _WIN64
@@ -281,7 +280,7 @@ void __TBB_EXPORTED_FUNC deallocate_interleaved(void *ptr, size_t bytes) {
 #if __linux__
     munmap(ptr, bytes);
 #elif _WIN32 || _WIN64
-    (void)bytes;
+    suppress_unused_warning(bytes);
     VirtualFree(ptr, /*dwSize=*/0, MEM_RELEASE);
 #endif
 }
@@ -296,8 +295,7 @@ void *__TBB_EXPORTED_FUNC allocate_interleaved(size_t bytes,
         calloc(bytes, 1) : nullptr;
 }
 
-void __TBB_EXPORTED_FUNC deallocate_interleaved(void *ptr, size_t bytes) {
-    (void)bytes;
+void __TBB_EXPORTED_FUNC deallocate_interleaved(void *ptr, size_t /*bytes*/) {
     free(ptr);
 }
 

--- a/src/tbb/numa_allocation.cpp
+++ b/src/tbb/numa_allocation.cpp
@@ -136,6 +136,15 @@ static const int *common_init(size_t bytes, const tbb::detail::d1::numa_node_id 
     return nodes;
 }
 
+static bool is_numa_funcs_found() {
+#if __linux__
+    return move_pages_ptr && numa_bitmask_alloc_ptr && numa_bitmask_free_ptr &&
+           numa_bitmask_isbitset_ptr && numa_bitmask_setbit_ptr && numa_interleave_memory_ptr;
+#elif _WIN32 || _WIN64
+    return VirtualAlloc2_ptr;
+ #endif
+}
+
 #if __linux__
 void *__TBB_EXPORTED_FUNC allocate_interleaved(size_t bytes,
                         const tbb::detail::d1::numa_node_id *nodes_ids, size_t nodes_count,
@@ -150,7 +159,7 @@ void *__TBB_EXPORTED_FUNC allocate_interleaved(size_t bytes,
         return nullptr;
 
     // no NUMA nodes or move_pages() not available, just return the memory as is
-    if (numa_node_count() == 1 || !move_pages_ptr)
+    if (numa_node_count() == 1 || !is_numa_funcs_found())
         return base_addr;
 
     auto unmap = [bytes](void *ptr) {
@@ -219,7 +228,7 @@ void *__TBB_EXPORTED_FUNC allocate_interleaved(size_t bytes,
         return nullptr;
 
     // no NUMA nodes or no VirtualAlloc2, just return the memory as is
-    if (numa_node_count() == 1 || !VirtualAlloc2_ptr)
+    if (numa_node_count() == 1 || !is_numa_funcs_found())
         // do not use VirtualAlloc(), because it compiled incorrectly by MSVC 2017 with
         // -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebug -DTBB_WINDOWS_DRIVER=ON
         return VirtualAllocEx(GetCurrentProcess(), /*BaseAddress=*/nullptr, bytes, MEM_RESERVE | MEM_COMMIT,

--- a/src/tbb/numa_allocation.cpp
+++ b/src/tbb/numa_allocation.cpp
@@ -28,7 +28,7 @@
 #include <algorithm> // for std::any_of
 #include <sys/mman.h>
 
-// TBB build must be done without numaif.h, but we need signature of move_pages()
+// TBB build must be done without numaif.h, but we need signatures of those functions
 // for dynamic loading, so declare it here.
 extern "C" {
 long move_pages(int pid, unsigned long count,

--- a/src/tbb/numa_allocation.cpp
+++ b/src/tbb/numa_allocation.cpp
@@ -167,10 +167,12 @@ void *__TBB_EXPORTED_FUNC allocate_interleaved(size_t bytes,
     };
     std::unique_ptr<void, decltype(unmap)> data_holder(base_addr, unmap);
 
-    // for chunk size equal to page size and all nodes being different we can place memory right to
+    // For chunk size equal to page size and all nodes being different we can place memory right to
     // the appropriate NUMA nodes with a single system call, otherwise we need to touch each page
-    // from current thread and only then move them
-    if (bytes_per_chunk == governor::default_page_size() && nodes_count <= numa_node_count()) {
+    // from current thread and only then move them.
+    // Another case is allocation from a single NUMA node, in this case bytes_per_chunk is irrelevant.
+    if ((bytes_per_chunk == governor::default_page_size() && nodes_count <= numa_node_count())
+         || nodes_count == 1) {
         auto bitmask_free = [](struct bitmask *m) {
             numa_bitmask_free_ptr(m);
         };

--- a/test/tbb/test_numa_allocation.cpp
+++ b/test/tbb/test_numa_allocation.cpp
@@ -35,6 +35,21 @@
 static long (*move_pages_ptr)(int pid, unsigned long count,
                               void **pages, const int *nodes,
                               int *status, int flags) = nullptr;
+
+#include <sstream>
+
+std::string NodesToString(const std::vector<tbb::numa_node_id>& nodes) {
+    std::ostringstream os;
+    os << '[';
+    for (std::size_t i = 0; i < nodes.size(); ++i) {
+        if (i != 0) {
+            os << ", ";
+        }
+        os << nodes[i];
+    }
+    os << ']';
+    return os.str();
+}
 #endif
 
 size_t DefaultSystemPageSize() {
@@ -98,16 +113,49 @@ TEST_CASE("invalid parameters") {
                     "nodes_count must be greater than 0 if nodes_ids is not nullptr");
 }
 
-void VerifySizeAndNodes(bool use_find_node, size_t bytes, const std::vector<tbb::numa_node_id>& nodes,
-                        size_t bytes_per_chunk)
-{
-    char* ptr = (char*)tbb::allocate_numa_interleaved(bytes, nodes, bytes_per_chunk);
+void VerifySizeAndNodes(char *ptr, size_t bytes, const std::vector<tbb::numa_node_id>& nodes,
+                        size_t bytes_per_chunk, bool check_ownership) {
+    static const size_t page_size = DefaultSystemPageSize();
+
     REQUIRE(ptr != nullptr);
     REQUIRE_EQ(utils::NonZero(ptr, bytes), 0);
-    if (use_find_node)
-        for (size_t i = 0; i < bytes; i += bytes_per_chunk) {
-            NUMA_EQ(find_numa_node(ptr + i), nodes[i / bytes_per_chunk % nodes.size()]);
+    if (!check_ownership)
+        return;
+#if __linux__
+    // for such granularity, interleaving can be done not in exact order of nodes
+    if (bytes_per_chunk == page_size) {
+        // touch each page, otherwise move_pages() will fail with EFAULT
+        // and so detecting NUMA node will be impossible
+        for (size_t i = 0; i < bytes; i += page_size)
+            ptr[i] = 0;
+
+        int start_node = find_numa_node(ptr);
+        auto it = std::find_if(nodes.begin(), nodes.end(),
+                               [start_node](tbb::numa_node_id node)
+                               { return node == start_node; });
+        if (it == nodes.end()) {
+
+            const std::string nodes_str = NodesToString(nodes);
+            REQUIRE_MESSAGE(false, "Unexpected NUMA node " << start_node
+                            << " for the first page, expected one of: " << nodes_str);
+            return;
         }
+
+        for (size_t offset = 0, page_index = it - nodes.begin(); offset < bytes;
+             offset += page_size, ++page_index)
+            NUMA_EQ(find_numa_node(ptr + offset), nodes[page_index % nodes.size()]);
+    }
+    else
+#endif // __linux__
+        for (size_t i = 0; i < bytes; i += bytes_per_chunk)
+            NUMA_EQ(find_numa_node(ptr + i), nodes[i / bytes_per_chunk % nodes.size()]);
+}
+
+void AllocateAndVerify(bool use_find_node, size_t bytes, const std::vector<tbb::numa_node_id>& nodes,
+                       size_t bytes_per_chunk)
+{
+    char* ptr = (char*)tbb::allocate_numa_interleaved(bytes, nodes, bytes_per_chunk);
+    VerifySizeAndNodes(ptr, bytes, nodes, bytes_per_chunk, use_find_node);
     tbb::deallocate_numa_interleaved(ptr, bytes);
 }
 
@@ -137,53 +185,50 @@ TEST_CASE("test basics") {
 
     for (size_t obj_size = 8; obj_size <= 1024 * 1024LLU; obj_size *= 2)
     {
-        std::vector<tbb::numa_node_id> numa_nodes = tbb::info::numa_nodes();
-        // during ownership checking we treat no-NUMA as single-NUMA with node index 0,
-        // but numa_nodes() return -1 in this case
-        if (numa_nodes.size() == 1)
-            numa_nodes[0] = 0;
-
         {
-            char *ptr = (char *)tbb::allocate_numa_interleaved(obj_size);
-            REQUIRE(ptr != nullptr);
-            REQUIRE_EQ(utils::NonZero(ptr, obj_size), 0);
-            if (lib)
-                for (size_t i = 0; i < obj_size; i += page_size) {
-                    NUMA_EQ(find_numa_node(ptr + i), numa_nodes[i / page_size % numa_nodes.size()]);
-                }
-            tbb::deallocate_numa_interleaved(ptr, obj_size);
+           std::vector<tbb::numa_node_id> numa_nodes = tbb::info::numa_nodes();
+            // during ownership checking we treat no-NUMA as single-NUMA with node index 0,
+            // but numa_nodes() return -1 in this case
+            if (numa_nodes.size() == 1)
+                numa_nodes[0] = 0;
+
+            {
+                char *ptr = (char *)tbb::allocate_numa_interleaved(obj_size);
+                VerifySizeAndNodes(ptr, obj_size, numa_nodes, page_size, lib);
+                tbb::deallocate_numa_interleaved(ptr, obj_size);
+            }
+
+            for (size_t bytes_per_chunk : std::vector<size_t>{page_size, 3 * page_size, 41 * page_size})
+            {
+                char *ptr = (char *)tbb::allocate_numa_interleaved(obj_size, bytes_per_chunk);
+                VerifySizeAndNodes(ptr, obj_size, numa_nodes, bytes_per_chunk, lib);
+                tbb::deallocate_numa_interleaved(ptr, obj_size);
+            }
         }
 
-        for (size_t bytes_per_chunk : std::vector<size_t>{page_size, 3 * page_size, 41 * page_size})
+        for (size_t bytes_per_chunk : std::vector<size_t>{page_size, 3 * page_size})
         {
-            char *ptr = (char *)tbb::allocate_numa_interleaved(obj_size, bytes_per_chunk);
-            REQUIRE(ptr != nullptr);
-            REQUIRE_EQ(utils::NonZero(ptr, obj_size), 0);
-            if (lib)
-                for (size_t i = 0; i < obj_size; i += bytes_per_chunk) {
-                    NUMA_EQ(find_numa_node(ptr + i), numa_nodes[i / bytes_per_chunk % numa_nodes.size()]);
-                }
-            tbb::deallocate_numa_interleaved(ptr, obj_size);
+            std::vector<tbb::numa_node_id> numa_nodes = tbb::info::numa_nodes();
+
+            // explicit nodes and bytes_per_chunk
+            AllocateAndVerify(lib, obj_size, numa_nodes, bytes_per_chunk);
+
+            // reverse numa_nodes and check that interleaving works as expected
+            std::reverse(numa_nodes.begin(), numa_nodes.end());
+            AllocateAndVerify(lib, obj_size, numa_nodes, bytes_per_chunk);
+
+            // remove half of the nodes and check that interleaving works as expected
+            numa_nodes.erase(numa_nodes.begin(), numa_nodes.begin() + numa_nodes.size() / 2);
+            AllocateAndVerify(lib, obj_size, numa_nodes, bytes_per_chunk);
+
+            // check that duplicated nodes are supported
+            std::vector<tbb::numa_node_id> numa_nodes_1 = tbb::info::numa_nodes();
+            // we treat no-NUMA as single-NUMA with node index 0, but numa_nodes() return -1 in this case
+            if (numa_nodes_1.size() == 1)
+                numa_nodes_1[0] = 0;
+            numa_nodes.insert(numa_nodes.end(), numa_nodes_1.begin(), numa_nodes_1.end());
+            AllocateAndVerify(lib, obj_size, numa_nodes, bytes_per_chunk);
         }
-
-        // explicit nodes and bytes_per_chunk
-        VerifySizeAndNodes(lib, obj_size, numa_nodes, 3 * page_size);
-
-        // reverse numa_nodes and check that interleaving works as expected
-        std::reverse(numa_nodes.begin(), numa_nodes.end());
-        VerifySizeAndNodes(lib, obj_size, numa_nodes, 3 * page_size);
-
-        // remove half of the nodes and check that interleaving works as expected
-        numa_nodes.erase(numa_nodes.begin(), numa_nodes.begin() + numa_nodes.size() / 2);
-        VerifySizeAndNodes(lib, obj_size, numa_nodes, 7 * page_size);
-
-        // duplicated nodes are supported
-        std::vector<tbb::numa_node_id> numa_nodes_1 = tbb::info::numa_nodes();
-        // we treat no-NUMA as single-NUMA with node index 0, but numa_nodes() return -1 in this case
-        if (numa_nodes_1.size() == 1)
-            numa_nodes_1[0] = 0;
-        numa_nodes.insert(numa_nodes.end(), numa_nodes_1.begin(), numa_nodes_1.end());
-        VerifySizeAndNodes(lib, obj_size, numa_nodes, 3 * page_size);
     }
     // explicitly check that allocation with tbb::info::numa_nodes() works
     {

--- a/test/tbb/test_numa_allocation.cpp
+++ b/test/tbb/test_numa_allocation.cpp
@@ -115,13 +115,13 @@ TEST_CASE("invalid parameters") {
 
 void VerifySizeAndNodes(char *ptr, size_t bytes, const std::vector<tbb::numa_node_id>& nodes,
                         size_t bytes_per_chunk, bool check_ownership) {
-    static const size_t page_size = DefaultSystemPageSize();
-
     REQUIRE(ptr != nullptr);
     REQUIRE_EQ(utils::NonZero(ptr, bytes), 0);
     if (!check_ownership)
         return;
 #if __linux__
+    static const size_t page_size = DefaultSystemPageSize();
+
     // for such granularity, interleaving can be done not in exact order of nodes
     if (bytes_per_chunk == page_size) {
         std::vector<tbb::numa_node_id> sorted_nodes(nodes);
@@ -147,13 +147,7 @@ void VerifySizeAndNodes(char *ptr, size_t bytes, const std::vector<tbb::numa_nod
 
             for (size_t offset = 0, page_index = it - sorted_nodes.begin(); offset < bytes;
                  offset += page_size, ++page_index) {
-#if 1
-                if (find_numa_node(ptr + offset) != sorted_nodes[page_index % sorted_nodes.size()]) {
-                    abort();
-                }
-#else
                 NUMA_EQ(find_numa_node(ptr + offset), sorted_nodes[page_index % sorted_nodes.size()]);
-#endif
             }
         }
     }

--- a/test/tbb/test_numa_allocation.cpp
+++ b/test/tbb/test_numa_allocation.cpp
@@ -149,12 +149,12 @@ void VerifySizeAndNodes(char *ptr, size_t bytes, const std::vector<tbb::numa_nod
                  offset += page_size, ++page_index) {
                 NUMA_EQ(find_numa_node(ptr + offset), sorted_nodes[page_index % sorted_nodes.size()]);
             }
+            return;
         }
     }
-    else
 #endif // __linux__
-        for (size_t i = 0; i < bytes; i += bytes_per_chunk)
-            NUMA_EQ(find_numa_node(ptr + i), nodes[i / bytes_per_chunk % nodes.size()]);
+    for (size_t i = 0; i < bytes; i += bytes_per_chunk)
+        NUMA_EQ(find_numa_node(ptr + i), nodes[i / bytes_per_chunk % nodes.size()]);
 }
 
 void AllocateAndVerify(bool use_find_node, size_t bytes, const std::vector<tbb::numa_node_id>& nodes,

--- a/test/tbb/test_numa_allocation.cpp
+++ b/test/tbb/test_numa_allocation.cpp
@@ -124,26 +124,38 @@ void VerifySizeAndNodes(char *ptr, size_t bytes, const std::vector<tbb::numa_nod
 #if __linux__
     // for such granularity, interleaving can be done not in exact order of nodes
     if (bytes_per_chunk == page_size) {
-        // touch each page, otherwise move_pages() will fail with EFAULT
-        // and so detecting NUMA node will be impossible
-        for (size_t i = 0; i < bytes; i += page_size)
-            ptr[i] = 0;
+        std::vector<tbb::numa_node_id> sorted_nodes(nodes);
+        std::sort(sorted_nodes.begin(), sorted_nodes.end());
+        auto adj = std::adjacent_find(sorted_nodes.begin(), sorted_nodes.end());
+        // numa_interleave_memory() can be used only for non-repeated nodes case
+        if (adj == sorted_nodes.end()) {
+            // touch each page, otherwise move_pages() will fail with EFAULT
+            // and so detecting NUMA node will be impossible
+            for (size_t i = 0; i < bytes; i += page_size)
+                ptr[i] = 0;
 
-        int start_node = find_numa_node(ptr);
-        auto it = std::find_if(nodes.begin(), nodes.end(),
-                               [start_node](tbb::numa_node_id node)
-                               { return node == start_node; });
-        if (it == nodes.end()) {
+            int start_node = find_numa_node(ptr);
+            auto it = std::find_if(sorted_nodes.begin(), sorted_nodes.end(),
+                                   [start_node](tbb::numa_node_id node)
+                                   { return node == start_node; });
+            if (it == sorted_nodes.end()) {
+                const std::string nodes_str = NodesToString(sorted_nodes);
+                REQUIRE_MESSAGE(false, "Unexpected NUMA node " << start_node
+                                << " for the first page, expected one of: " << nodes_str);
+                return;
+            }
 
-            const std::string nodes_str = NodesToString(nodes);
-            REQUIRE_MESSAGE(false, "Unexpected NUMA node " << start_node
-                            << " for the first page, expected one of: " << nodes_str);
-            return;
+            for (size_t offset = 0, page_index = it - sorted_nodes.begin(); offset < bytes;
+                 offset += page_size, ++page_index) {
+#if 1
+                if (find_numa_node(ptr + offset) != sorted_nodes[page_index % sorted_nodes.size()]) {
+                    abort();
+                }
+#else
+                NUMA_EQ(find_numa_node(ptr + offset), sorted_nodes[page_index % sorted_nodes.size()]);
+#endif
+            }
         }
-
-        for (size_t offset = 0, page_index = it - nodes.begin(); offset < bytes;
-             offset += page_size, ++page_index)
-            NUMA_EQ(find_numa_node(ptr + offset), nodes[page_index % nodes.size()]);
     }
     else
 #endif // __linux__

--- a/test/tbb/test_numa_allocation.cpp
+++ b/test/tbb/test_numa_allocation.cpp
@@ -85,7 +85,7 @@ int find_numa_node(void* addr) {
     // Extract the NUMA Node from the bitfield (0-63)
     return (int)pv.VirtualAttributes.Node;
 #else
-    (void)addr;
+    utils::suppress_unused_warning(addr);
     return 0;
 #endif
 }
@@ -185,19 +185,16 @@ TEST_CASE("test basics") {
 #else
     bool lib = false;
 #endif
-#else // on Windows we use VirtualAllocEx and QueryWorkingSetEx, so always can check NUMA node
-    bool lib = true;
+#else
+    // On Windows we use VirtualAllocEx and QueryWorkingSetEx, so always can find NUMA node,
+    // but do it only if there are more than 1 NUMA node.
+    bool lib = tbb::info::numa_nodes().size() > 1;
 #endif
 
     for (size_t obj_size = 8; obj_size <= 1024 * 1024LLU; obj_size *= 2)
     {
         {
-           std::vector<tbb::numa_node_id> numa_nodes = tbb::info::numa_nodes();
-            // during ownership checking we treat no-NUMA as single-NUMA with node index 0,
-            // but numa_nodes() return -1 in this case
-            if (numa_nodes.size() == 1)
-                numa_nodes[0] = 0;
-
+            std::vector<tbb::numa_node_id> numa_nodes = tbb::info::numa_nodes();
             {
                 char *ptr = (char *)tbb::allocate_numa_interleaved(obj_size);
                 VerifySizeAndNodes(ptr, obj_size, numa_nodes, page_size, lib);

--- a/test/tbb/test_numa_allocation.cpp
+++ b/test/tbb/test_numa_allocation.cpp
@@ -152,6 +152,11 @@ void VerifySizeAndNodes(char *ptr, size_t bytes, const std::vector<tbb::numa_nod
             return;
         }
     }
+    // for single-node allocation, it's possible an optimization when memory is not touched inside
+    // allocate_numa_interleaved(), so touch each page to make move_pages() work correctly
+    if (nodes.size() == 1)
+        for (size_t i = 0; i < bytes; i += page_size)
+            ptr[i] = 0;
 #endif // __linux__
     for (size_t i = 0; i < bytes; i += bytes_per_chunk)
         NUMA_EQ(find_numa_node(ptr + i), nodes[i / bytes_per_chunk % nodes.size()]);
@@ -231,6 +236,9 @@ TEST_CASE("test basics") {
                 numa_nodes_1[0] = 0;
             numa_nodes.insert(numa_nodes.end(), numa_nodes_1.begin(), numa_nodes_1.end());
             AllocateAndVerify(lib, obj_size, numa_nodes, bytes_per_chunk);
+
+            // check that single-node interleaving works
+            AllocateAndVerify(lib, obj_size, {numa_nodes[0]}, bytes_per_chunk);
         }
     }
     // explicitly check that allocation with tbb::info::numa_nodes() works

--- a/test/tbb/test_numa_allocation.cpp
+++ b/test/tbb/test_numa_allocation.cpp
@@ -126,10 +126,14 @@ void VerifySizeAndNodes(char *ptr, size_t bytes, const std::vector<tbb::numa_nod
     REQUIRE_EQ(utils::NonZero(ptr, bytes), 0);
     if (!check_ownership)
         return;
+    const std::vector<tbb::numa_node_id> *nodes_to_check = &nodes;
+    size_t page_index = 0;
 #if __linux__
-    // for such granularity, interleaving can be done not in exact order of nodes
-    if (bytes_per_chunk == page_size) {
-        std::vector<tbb::numa_node_id> sorted_nodes(nodes);
+    std::vector<tbb::numa_node_id> sorted_nodes;
+    // For such granularity, interleaving can be done not in exact order of nodes.
+    // 1-node case is correctly processed by generic code path below, so exclude it.
+    if (bytes_per_chunk == page_size && nodes.size() > 1) {
+        sorted_nodes = nodes;
         std::sort(sorted_nodes.begin(), sorted_nodes.end());
         auto adj = std::adjacent_find(sorted_nodes.begin(), sorted_nodes.end());
         // numa_interleave_memory() can be used only for non-repeated nodes case
@@ -149,20 +153,17 @@ void VerifySizeAndNodes(char *ptr, size_t bytes, const std::vector<tbb::numa_nod
                 return;
             }
 
-            for (size_t offset = 0, page_index = it - sorted_nodes.begin(); offset < bytes;
-                 offset += page_size, ++page_index) {
-                NUMA_EQ(find_numa_node(ptr + offset), sorted_nodes[page_index % sorted_nodes.size()]);
-            }
-            return;
+            nodes_to_check = &sorted_nodes;
+            page_index = it - sorted_nodes.begin();
         }
     }
-    // for single-node allocation, it's possible an optimization when memory is not touched inside
+    // for single-node allocation, an optimization is possible where memory is not touched inside
     // allocate_numa_interleaved(), so touch each page to make move_pages() work correctly
     if (nodes.size() == 1)
         TouchEachPage(ptr, bytes);
 #endif // __linux__
-    for (size_t i = 0; i < bytes; i += bytes_per_chunk)
-        NUMA_EQ(find_numa_node(ptr + i), nodes[i / bytes_per_chunk % nodes.size()]);
+    for (size_t offset = 0; offset < bytes; offset += bytes_per_chunk, ++page_index)
+        NUMA_EQ(find_numa_node(ptr + offset), (*nodes_to_check)[page_index % nodes_to_check->size()]);
 }
 
 void AllocateAndVerify(bool use_find_node, size_t bytes, const std::vector<tbb::numa_node_id>& nodes,

--- a/test/tbb/test_numa_allocation.cpp
+++ b/test/tbb/test_numa_allocation.cpp
@@ -115,7 +115,7 @@ TEST_CASE("invalid parameters") {
 
 void VerifySizeAndNodes(char *ptr, size_t bytes, const std::vector<tbb::numa_node_id>& nodes,
                         size_t bytes_per_chunk, bool check_ownership) {
-    REQUIRE(ptr != nullptr);
+    REQUIRE_MESSAGE(ptr != nullptr, "Failed to allocate NUMA interleaved memory for size " << bytes);
     REQUIRE_EQ(utils::NonZero(ptr, bytes), 0);
     if (!check_ownership)
         return;
@@ -238,7 +238,7 @@ TEST_CASE("test basics") {
         size_t obj_size = 1024 * 1024LLU;
         std::vector<tbb::numa_node_id> numa_nodes = tbb::info::numa_nodes();
         char *ptr = (char *)tbb::allocate_numa_interleaved(obj_size, numa_nodes);
-        REQUIRE(ptr != nullptr);
+        REQUIRE_MESSAGE(ptr != nullptr, "Failed to allocate NUMA interleaved memory for size " << obj_size);
         REQUIRE_EQ(utils::NonZero(ptr, obj_size), 0);
         tbb::deallocate_numa_interleaved(ptr, obj_size);
     }

--- a/test/tbb/test_numa_allocation.cpp
+++ b/test/tbb/test_numa_allocation.cpp
@@ -31,6 +31,18 @@
 #include <unistd.h> // for sysconf(_SC_PAGESIZE)
 #endif
 
+size_t DefaultSystemPageSize() {
+#if _WIN32 || _WIN64
+    SYSTEM_INFO si;
+    GetSystemInfo(&si);
+    return si.dwPageSize;
+#else
+    return sysconf(_SC_PAGESIZE);
+#endif
+}
+
+static const size_t page_size = DefaultSystemPageSize();
+
 #if __linux__
 static long (*move_pages_ptr)(int pid, unsigned long count,
                               void **pages, const int *nodes,
@@ -38,7 +50,7 @@ static long (*move_pages_ptr)(int pid, unsigned long count,
 
 #include <sstream>
 
-std::string NodesToString(const std::vector<tbb::numa_node_id>& nodes) {
+static std::string NodesToString(const std::vector<tbb::numa_node_id>& nodes) {
     std::ostringstream os;
     os << '[';
     for (std::size_t i = 0; i < nodes.size(); ++i) {
@@ -50,17 +62,12 @@ std::string NodesToString(const std::vector<tbb::numa_node_id>& nodes) {
     os << ']';
     return os.str();
 }
-#endif
 
-size_t DefaultSystemPageSize() {
-#if _WIN32 || _WIN64
-    SYSTEM_INFO si;
-    GetSystemInfo(&si);
-    return si.dwPageSize;
-#else
-    return sysconf(_SC_PAGESIZE);
-#endif
+static void TouchEachPage(char* base_addr, size_t bytes) {
+    for (size_t i = 0; i < bytes; i += page_size)
+        base_addr[i] = 0;
 }
+#endif
 
 int find_numa_node(void* addr) {
 #if __linux__
@@ -120,8 +127,6 @@ void VerifySizeAndNodes(char *ptr, size_t bytes, const std::vector<tbb::numa_nod
     if (!check_ownership)
         return;
 #if __linux__
-    static const size_t page_size = DefaultSystemPageSize();
-
     // for such granularity, interleaving can be done not in exact order of nodes
     if (bytes_per_chunk == page_size) {
         std::vector<tbb::numa_node_id> sorted_nodes(nodes);
@@ -131,8 +136,7 @@ void VerifySizeAndNodes(char *ptr, size_t bytes, const std::vector<tbb::numa_nod
         if (adj == sorted_nodes.end()) {
             // touch each page, otherwise move_pages() will fail with EFAULT
             // and so detecting NUMA node will be impossible
-            for (size_t i = 0; i < bytes; i += page_size)
-                ptr[i] = 0;
+            TouchEachPage(ptr, bytes);
 
             int start_node = find_numa_node(ptr);
             auto it = std::find_if(sorted_nodes.begin(), sorted_nodes.end(),
@@ -155,8 +159,7 @@ void VerifySizeAndNodes(char *ptr, size_t bytes, const std::vector<tbb::numa_nod
     // for single-node allocation, it's possible an optimization when memory is not touched inside
     // allocate_numa_interleaved(), so touch each page to make move_pages() work correctly
     if (nodes.size() == 1)
-        for (size_t i = 0; i < bytes; i += page_size)
-            ptr[i] = 0;
+        TouchEachPage(ptr, bytes);
 #endif // __linux__
     for (size_t i = 0; i < bytes; i += bytes_per_chunk)
         NUMA_EQ(find_numa_node(ptr + i), nodes[i / bytes_per_chunk % nodes.size()]);
@@ -175,7 +178,6 @@ TEST_CASE("test basics") {
     CHECK_MESSAGE(TBB_HAS_NUMA_ALLOCATION == 202605,
                   "Incorrect feature test macro for NUMA allocation");
 
-    size_t page_size = DefaultSystemPageSize();
 #if __linux__
 #if __TBB_DYNAMIC_LOAD_ENABLED
     utils::LIBRARY_HANDLE lib = nullptr;


### PR DESCRIPTION
### Description 
When interleaved memory allocated with default interleaving step, it's possible to allocate it directly from required nodes, not migrate after 1st touch.

### Type of change
- [ ] bug fix - _change that fixes an issue_
- [X] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [X] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
