### PR TITLE
Load libnuma.so.1 under Linux, as libnuma.so goes from *-dev package

### DIFF
--- a/src/tbb/numa_allocation.cpp
+++ b/src/tbb/numa_allocation.cpp
@@ -87,9 +87,9 @@ static std::atomic<do_once_state> interleaved_initialization_state;
 
 void interleaved_initialization_impl() {
 #if __linux__
-const char* numa_lib_name = "libnuma.so.1";
+    const char* numa_lib_name = "libnuma.so.1";
 #elif _WIN32 || _WIN64
-const char* numa_lib_name = "kernelbase.dll";
+    const char* numa_lib_name = "kernelbase.dll";
 #endif
     dynamic_link(numa_lib_name, LibnumaLinkTable,
                  sizeof(LibnumaLinkTable) / sizeof(dynamic_link_descriptor), /*handle*/nullptr,

--- a/src/tbb/numa_allocation.cpp
+++ b/src/tbb/numa_allocation.cpp
@@ -87,7 +87,7 @@ static std::atomic<do_once_state> interleaved_initialization_state;
 
 void interleaved_initialization_impl() {
 #if __linux__
-const char* numa_lib_name = "libnuma.so";
+const char* numa_lib_name = "libnuma.so.1";
 #elif _WIN32 || _WIN64
 const char* numa_lib_name = "kernelbase.dll";
 #endif


### PR DESCRIPTION
### Description 
Currently for NUMA support libtbb dynamically loads libnuma.so, but in major Linux distributions it's a symlink that added as part of a *dev package. More universal is to load libnuma.so.1, that that is part of basic libnuma package.

### Type of change

- [X] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
