### PR TITLE
FIX: Universal builds on Apple with LLVM Clang

### DIFF
--- a/cmake/compilers/Clang.cmake
+++ b/cmake/compilers/Clang.cmake
@@ -64,7 +64,12 @@ if (NOT TBB_STRICT AND COMMAND tbb_remove_compile_flag)
 endif()
 
 # Enable Intel(R) Transactional Synchronization Extensions (-mrtm) and WAITPKG instructions support (-mwaitpkg) on relevant processors
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "(AMD64|amd64|i.86|x86)" AND NOT EMSCRIPTEN)
+if (APPLE AND CMAKE_OSX_ARCHITECTURES)
+    set(_tbb_target_architectures "${CMAKE_OSX_ARCHITECTURES}")
+else()
+    set(_tbb_target_architectures "${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+if ("${_tbb_target_architectures}" MATCHES "(AMD64|amd64|i.86|x86)" AND NOT EMSCRIPTEN)
     set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -mrtm $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},12.0>>:-mwaitpkg>)
 endif()
 


### PR DESCRIPTION
### Description 

Currently, when building a universal binary on Apple platforms with a supported compiler other than AppleClang (i.e., any other LLVM-derived Clang) this will cause the same error as in issue #1772.

This provides a small fix which checks if (1) architectures are cross-compiled on Apple or (2) a universal binary is compiled on Apple. Fall back to the regular CMAKE_SYSTEM_PROCESSOR for non-Apple targets, which used to be the default behavior. Essentially mimicks the AppleClang detection.

Partly fixes #1772 (should already be fixed for AppleClang).

### Type of change

- [x] bug fix and infrastructure - Fixes compilation error on LLVM Clang when compiling universal binaries

### Tests

- [x] not needed

### Documentation

- [x] not needed

### Breaks backward compatibility

- [x] No