### PR TITLE
Fix sporadic hangs in FG buffering node tests

### DIFF
--- a/test/common/graph_utils.h
+++ b/test/common/graph_utils.h
@@ -1028,9 +1028,12 @@ void spin_try_get(BufferingNode& node, T& value) {
 
             // This workaround assumes the calling thread is in the graph arena and all
             // task elements are submitted to the graph before calling spin_try_get.
-            CHECK_MESSAGE(oneapi::tbb::this_task_arena::current_thread_index() !=
-                          oneapi::tbb::task_arena::not_initialized,
-                          "Calling thread is expected to be within an arena");
+
+            // Usage of oneapi::tbb::task_arena::not_initialized directly in CHECK_MESSAGE
+            // results in ODR-use and undefined reference
+            bool is_current_thread_in_arena = oneapi::tbb::this_task_arena::current_thread_index() !=
+                                              oneapi::tbb::task_arena::not_initialized;
+            CHECK_MESSAGE(is_current_thread_in_arena, "Calling thread is not in arena");
             oneapi::tbb::this_task_arena::enqueue([] {});
         }
         ++count;

--- a/test/common/graph_utils.h
+++ b/test/common/graph_utils.h
@@ -1028,6 +1028,9 @@ void spin_try_get(BufferingNode& node, T& value) {
 
             // This workaround assumes the calling thread is in the graph arena and all
             // task elements are submitted to the graph before calling spin_try_get.
+            CHECK_MESSAGE(oneapi::tbb::this_task_arena::current_thread_index() !=
+                          oneapi::tbb::task_arena::not_initialized,
+                          "Calling thread is expected to be within an arena");
             oneapi::tbb::this_task_arena::enqueue([] {});
         }
         ++count;

--- a/test/common/graph_utils.h
+++ b/test/common/graph_utils.h
@@ -1012,4 +1012,26 @@ void assert_all_items_equal_to(const TupleLike& tuple_like, const Message& messa
     assert_all_items_equal_impl<std::tuple_size<TupleLike>::value>::compare(tuple_like, message);
 }
 
+template <typename BufferingNode, typename T>
+void spin_try_get(BufferingNode& node, T& value) {
+    std::size_t count = 0;
+
+    while (!node.try_get(value)) {
+        if (count == 1000000) {
+            // Tests that use spin_try_get first submit a set of values into the graph
+            // and then wait for outputs to arrive in buffers at the end of the graph.
+            // Because flow graph nodes spawn tasks in the graph arena and spin_try_get
+            // does not wait for graph completion, TBB does not strictly guarantee that
+            // a worker thread will wake up and execute the pending task.
+            // The workaround is to enqueue a task into the current graph arena,
+            // which is guaranteed to be executed at some point.
+
+            // This workaround assumes the calling thread is in the graph arena and all
+            // task elements are submitted to the graph before calling spin_try_get.
+            oneapi::tbb::this_task_arena::enqueue([] {});
+        }
+        ++count;
+    }
+}
+
 #endif  // __TBB_harness_graph_H

--- a/test/tbb/test_buffer_node.cpp
+++ b/test/tbb/test_buffer_node.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -31,11 +32,6 @@
 
 #define N 1000
 #define C 10
-
-template< typename T >
-void spin_try_get( tbb::flow::buffer_node<T> &b, T &value ) {
-    while ( b.try_get(value) != true ) {}
-}
 
 template< typename T >
 void check_item( T* count_value, T &value ) {

--- a/test/tbb/test_priority_queue_node.cpp
+++ b/test/tbb/test_priority_queue_node.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -38,11 +39,6 @@
 
 #define N 10
 #define C 10
-
-template< typename T >
-void spin_try_get( tbb::flow::priority_queue_node<T> &q, T &value ) {
-    while ( q.try_get(value) != true ) ;
-}
 
 template< typename T >
 void check_item( T* next_value, T &value ) {

--- a/test/tbb/test_queue_node.cpp
+++ b/test/tbb/test_queue_node.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -38,22 +39,6 @@
 
 #define N 1000
 #define C 10
-
-template< typename T >
-void spin_try_get( tbb::flow::queue_node<T> &q, T &value ) {
-    int count = 0;
-    while ( q.try_get(value) != true ) {
-        if (count < 1000000) {
-            ++count;
-        }
-        if (count == 1000000) {
-            // Perhaps, we observe the missed wakeup. Enqueue a task to wake up threads.
-            tbb::task_arena a(tbb::task_arena::attach{});
-            a.enqueue([]{});
-            ++count;
-        }
-    }
-}
 
 template< typename T >
 void check_item( T* next_value, T &value ) {

--- a/test/tbb/test_sequencer_node.cpp
+++ b/test/tbb/test_sequencer_node.cpp
@@ -25,6 +25,7 @@
 #include "common/utils_assert.h"
 #include "common/test_follows_and_precedes_api.h"
 #include "common/concepts_common.h"
+#include "common/graph_utils.h"
 
 #include <cstdio>
 #include <atomic>

--- a/test/tbb/test_sequencer_node.cpp
+++ b/test/tbb/test_sequencer_node.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -46,11 +47,6 @@ template< typename T >
 bool wait_try_get( tbb::flow::graph &g, tbb::flow::sequencer_node<T> &q, T &value ) {
     g.wait_for_all();
     return q.try_get(value);
-}
-
-template< typename T >
-void spin_try_get( tbb::flow::queue_node<T> &q, T &value ) {
-    while ( q.try_get(value) != true ) ;
 }
 
 template< typename T >


### PR DESCRIPTION
### Description 
Adopt workaround from test_queue_node for other buffering node types.

The existing tests are a bit incorrect to assume TBB worker will come and pick up some internal tasks that are spawned, which is not guaranteed by TBB scheduler.
After a huge amount of checks in spin_try_get, enqueue a task that is guaranteed to execute


Fixes #1467

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
