### PR TITLE
Fix to avoid exceeding concurrency in resource_limited_node

### DIFF
--- a/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
+++ b/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
@@ -437,7 +437,9 @@ class resource_limited_body_leaf
 
 public:
     resource_limited_body_leaf(graph& g, std::tuple<ResourceProviders&...> resource_providers, const Body& body,
-                              resource_limited_input<Input, OutputPorts>* input_ptr)
+    resource_limited_body_leaf(graph& g, std::tuple<ResourceProviders&...> resource_providers,
+                               const Body& body,
+                               resource_limited_input<Input, OutputPorts>* input_ptr)
         : resource_limited_body_leaf(g, get_consumers_tuple(resource_providers), body, input_ptr)
     {}
 

--- a/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
+++ b/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
@@ -427,7 +427,7 @@ class resource_limited_body_leaf
 
     template <typename ConsumersTuple>
     resource_limited_body_leaf(graph& g, ConsumersTuple&& consumers_tuple, const Body& body,
-                              resource_limited_input<Input, OutputPorts>* input_ptr)
+                               resource_limited_input<Input, OutputPorts>* input_ptr)
         : resource_limited_body<Input, OutputPorts>(g)
         , m_consumers(std::forward<ConsumersTuple>(consumers_tuple))
         , m_body(body)

--- a/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
+++ b/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
@@ -436,11 +436,12 @@ class resource_limited_body_leaf
     {}
 
 public:
-    resource_limited_body_leaf(graph& g, std::tuple<ResourceProviders&...> resource_providers, const Body& body,
     resource_limited_body_leaf(graph& g, std::tuple<ResourceProviders&...> resource_providers,
                                const Body& body,
                                resource_limited_input<Input, OutputPorts>* input_ptr)
-        : resource_limited_body_leaf(g, get_consumers_tuple(resource_providers), body, input_ptr)
+        : resource_limited_body_leaf(g, get_consumers_tuple(resource_providers)
+        , body
+        , input_ptr)
     {}
 
     consumers_tuple_type get_consumers_tuple(std::tuple<ResourceProviders&...> resource_providers) {
@@ -508,13 +509,12 @@ public:
     } 
 
     void release_concurrency_and_spawn_next(const Input& input_msg) {
-        if (m_input_ptr) {
-            // Call back to the input layer to release concurrency slot and get next task
-            // Only do this if concurrency is limited (not unlimited)
-            graph_task* next_task = m_input_ptr->release_concurrency_slot(input_msg);
-            if (next_task && next_task != SUCCESSFULLY_ENQUEUED) {
-                spawn_in_graph_arena(this->graph_reference(), *next_task);
-            }
+        __TBB_ASSERT(m_input_ptr != nullptr, "m_input_ptr should never be nullptr when releasing concurrency slot");
+        // Call back to the input layer to release concurrency slot and get next task
+        // Only do this if concurrency is limited (not unlimited)
+        graph_task* next_task = m_input_ptr->release_concurrency_slot(input_msg);
+        if (next_task && next_task != SUCCESSFULLY_ENQUEUED) {
+            spawn_in_graph_arena(this->graph_reference(), *next_task);
         }
     }
 
@@ -594,16 +594,17 @@ public:
     using class_type = resource_limited_input<input_type, output_ports_type>;
     using base_type = function_input_base<input_type, queueing, cache_aligned_allocator<input_type>, class_type>;
     using input_queue_type = function_input_queue<input_type, cache_aligned_allocator<input_type>>;
+    template <typename Body, typename... ResourceProviders>
+    using body_leaf = resource_limited_body_leaf<input_type, output_ports_type,
+                                                 Body, ResourceProviders...>;
 
     template <typename Body, typename... ResourceProviders>
     resource_limited_input(graph& g, std::size_t max_concurrency,
                            std::tuple<ResourceProviders&...> resource_providers,
                            Body& body)
         : base_type(g, max_concurrency, no_priority, is_body_noexcept(body, resource_providers))
-        , m_body(new body_leaf<input_type, output_ports_type, Body, ResourceProviders...>
-            (g, resource_providers, body, this))
-        , m_init_body(new body_leaf<input_type, output_ports_type, Body, ResourceProviders...>
-            (g, resource_providers, body, this))
+        , m_body(new body_leaf<Body, ResourceProviders...>(g, resource_providers, body, this))
+        , m_init_body(new body_leaf<Body, ResourceProviders...>(g, resource_providers, body, this))
         , m_output_ports(init_output_ports<output_ports_type>::call(g, m_output_ports))
     {}
 

--- a/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
+++ b/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
@@ -600,8 +600,10 @@ public:
                            std::tuple<ResourceProviders&...> resource_providers,
                            Body& body)
         : base_type(g, max_concurrency, no_priority, is_body_noexcept(body, resource_providers))
-        , m_body(new resource_limited_body_leaf<input_type, output_ports_type, Body, ResourceProviders...>(g, resource_providers, body, this))
-        , m_init_body(new resource_limited_body_leaf<input_type, output_ports_type, Body, ResourceProviders...>(g, resource_providers, body, this))
+        , m_body(new body_leaf<input_type, output_ports_type, Body, ResourceProviders...>
+            (g, resource_providers, body, this))
+        , m_init_body(new body_leaf<input_type, output_ports_type, Body, ResourceProviders...>
+            (g, resource_providers, body, this))
         , m_output_ports(init_output_ports<output_ports_type>::call(g, m_output_ports))
     {}
 

--- a/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
+++ b/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
@@ -35,6 +35,9 @@ namespace d2 {
 template <typename ResourceHandle>
 class resource_consumer_base;
 
+template <typename Input, typename OutputPorts>
+class resource_limited_input;
+
 class request_id {
     std::uint64_t m_unique_integer;
 public:
@@ -217,6 +220,7 @@ public:
     virtual void                   notify(request_id id) = 0;
     virtual resource_limited_body* clone() = 0;
     virtual void*                  get_body_ptr() = 0;
+    virtual void                   update_input_ptr(resource_limited_input<Input, OutputPorts>* ptr) = 0;
     virtual ~resource_limited_body() = default;
 
     resource_limited_body(graph& g) : m_graph(g) {}
@@ -419,18 +423,22 @@ class resource_limited_body_leaf
     consumers_tuple_type m_consumers;
     Body                 m_body;
     std::uint64_t        m_counter;
+    resource_limited_input<Input, OutputPorts>* m_input_ptr;
 
     template <typename ConsumersTuple>
-    resource_limited_body_leaf(graph& g, ConsumersTuple&& consumers_tuple, const Body& body)
+    resource_limited_body_leaf(graph& g, ConsumersTuple&& consumers_tuple, const Body& body,
+                              resource_limited_input<Input, OutputPorts>* input_ptr)
         : resource_limited_body<Input, OutputPorts>(g)
         , m_consumers(std::forward<ConsumersTuple>(consumers_tuple))
         , m_body(body)
         , m_counter(0)
+        , m_input_ptr(input_ptr)
     {}
 
 public:
-    resource_limited_body_leaf(graph& g, std::tuple<ResourceProviders&...> resource_providers, const Body& body)
-        : resource_limited_body_leaf(g, get_consumers_tuple(resource_providers), body)
+    resource_limited_body_leaf(graph& g, std::tuple<ResourceProviders&...> resource_providers, const Body& body,
+                              resource_limited_input<Input, OutputPorts>* input_ptr)
+        : resource_limited_body_leaf(g, get_consumers_tuple(resource_providers), body, input_ptr)
     {}
 
     consumers_tuple_type get_consumers_tuple(std::tuple<ResourceProviders&...> resource_providers) {
@@ -490,8 +498,21 @@ public:
                 call_body(req_data.input_message, req_data.output_ports, req_data.handles);
             }).on_completion([&] {
                 release_resources(id, req_data);
+                // delay release of concurrency slot until after body completes
+                release_concurrency_and_spawn_next(req_data.input_message);
                 remove_request(id);
             });
+        }
+    } 
+
+    void release_concurrency_and_spawn_next(const Input& input_msg) {
+        if (m_input_ptr) {
+            // Call back to the input layer to release concurrency slot and get next task
+            // Only do this if concurrency is limited (not unlimited)
+            graph_task* next_task = m_input_ptr->release_concurrency_slot(input_msg);
+            if (next_task && next_task != SUCCESSFULLY_ENQUEUED) {
+                spawn_in_graph_arena(this->graph_reference(), *next_task);
+            }
         }
     }
 
@@ -531,12 +552,16 @@ public:
     }
 
     resource_limited_body_leaf* clone() override {
-        resource_limited_body_leaf* new_body = new resource_limited_body_leaf(this->graph_reference(), m_consumers, this->m_body);
+        resource_limited_body_leaf* new_body = new resource_limited_body_leaf(this->graph_reference(), m_consumers, this->m_body, m_input_ptr);
         set_body_ptr_helper<sizeof...(ResourceProviders)>::run(new_body->m_consumers, new_body);
         return new_body;
     }
 
     void* get_body_ptr() override { return &m_body; }
+
+    void update_input_ptr(resource_limited_input<Input, OutputPorts>* ptr) override {
+        m_input_ptr = ptr;
+    }
 
     template <typename ResourceHandlesTuple>
     void call_body(const Input& input, OutputPorts& ports, ResourceHandlesTuple& tuple) {
@@ -570,8 +595,8 @@ public:
                            std::tuple<ResourceProviders&...> resource_providers,
                            Body& body)
         : base_type(g, max_concurrency, no_priority, is_body_noexcept(body, resource_providers))
-        , m_body(new resource_limited_body_leaf<input_type, output_ports_type, Body, ResourceProviders...>(g, resource_providers, body))
-        , m_init_body(new resource_limited_body_leaf<input_type, output_ports_type, Body, ResourceProviders...>(g, resource_providers, body))
+        , m_body(new resource_limited_body_leaf<input_type, output_ports_type, Body, ResourceProviders...>(g, resource_providers, body, this))
+        , m_init_body(new resource_limited_body_leaf<input_type, output_ports_type, Body, ResourceProviders...>(g, resource_providers, body, this))
         , m_output_ports(init_output_ports<output_ports_type>::call(g, m_output_ports))
     {}
 
@@ -580,7 +605,10 @@ public:
         , m_body(other.m_init_body->clone())
         , m_init_body(other.m_init_body->clone())
         , m_output_ports(init_output_ports<output_ports_type>::call(this->graph_reference(), m_output_ports))
-    {}
+    {
+        m_body->update_input_ptr(this);
+        m_init_body->update_input_ptr(this);
+    }
 
     ~resource_limited_input() {
         delete m_body;
@@ -590,12 +618,24 @@ public:
     graph_task* apply_body_impl_bypass(const input_type& i
                                        __TBB_FLOW_GRAPH_METAINFO_ARG(const message_metainfo&))
     {
+        // Call the body to initiate resource acquisition
+        // NOTE: function_input_base has already acquired a concurrency slot for us
+        // We must NOT release it until the body actually completes execution
         (*m_body)(i, m_output_ports);
-        graph_task* ttask = nullptr;
+
+        // DO NOT call try_get_postponed_task() here!
+        // The slot will be released after async body execution completes
+        return SUCCESSFULLY_ENQUEUED;
+    }
+
+    // Called by body_leaf after body execution completes to release concurrency slot
+    graph_task* release_concurrency_slot(const input_type& i) {
+        // Only release concurrency if limiting is enabled (not unlimited)
         if (base_type::my_max_concurrency != 0) {
-            ttask = base_type::try_get_postponed_task(i);
+            // Delegate to base class method which releases slot and dequeues next message
+            return base_type::try_get_postponed_task(i);
         }
-        return ttask ? ttask : SUCCESSFULLY_ENQUEUED;
+        return nullptr;
     }
 
     output_ports_type& output_ports() { return m_output_ports; }

--- a/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
+++ b/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
@@ -554,7 +554,10 @@ public:
     }
 
     resource_limited_body_leaf* clone() override {
-        resource_limited_body_leaf* new_body = new resource_limited_body_leaf(this->graph_reference(), m_consumers, this->m_body, m_input_ptr);
+        resource_limited_body_leaf* new_body = new resource_limited_body_leaf(this->graph_reference(),
+                                                                              m_consumers,
+                                                                              this->m_body,
+                                                                              m_input_ptr);
         set_body_ptr_helper<sizeof...(ResourceProviders)>::run(new_body->m_consumers, new_body);
         return new_body;
     }

--- a/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
+++ b/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
@@ -509,7 +509,7 @@ public:
     } 
 
     void release_concurrency_and_spawn_next(const Input& input_msg) {
-        __TBB_ASSERT(m_input_ptr != nullptr, "m_input_ptr should never be nullptr when releasing concurrency slot");
+        __TBB_ASSERT(m_input_ptr, "m_input_ptr shouldn't be 0 when releasing concurrency slot");
         // Call back to the input layer to release concurrency slot and get next task
         // Only do this if concurrency is limited (not unlimited)
         graph_task* next_task = m_input_ptr->release_concurrency_slot(input_msg);

--- a/test/tbb/test_resource_limited_node.cpp
+++ b/test/tbb/test_resource_limited_node.cpp
@@ -564,8 +564,7 @@ TEST_CASE("concurrency limit with multiple resources") {
                  "Concurrency limit was violated: max_observed=" << max_observed.load()
                  << " > max_concurrency=" << max_concurrency);
 
-    // We should have observed some concurrency (at least 2 concurrent executions)
-    CHECK_MESSAGE(max_observed.load() >= 2,
+    CHECK_MESSAGE((max_observed.load() >= 2 || tbb::this_task_arena::max_concurrency() < 2),
                  "Expected to observe concurrent execution but max_observed=" << max_observed.load());
 }
 

--- a/test/tbb/test_resource_limited_node.cpp
+++ b/test/tbb/test_resource_limited_node.cpp
@@ -516,3 +516,56 @@ TEST_CASE("resource_limited_node cancellation with active requests") {
     test_cancellation_with_active_requests(/*same_graph = */true, /*exception =*/true);
 #endif
 }
+
+//! \brief \ref requirement
+TEST_CASE("concurrency limit with multiple resources") {
+    using namespace oneapi::tbb::flow;
+
+    // Number of resources exceeds concurrency limit
+    resource_limiter<int> limiter{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+    using node_type = resource_limited_node<int, std::tuple<>>;
+    using ports_type = typename node_type::output_ports_type;
+
+    const std::size_t max_concurrency = 2;
+    std::atomic<std::size_t> concurrent_count{0};
+    std::atomic<std::size_t> max_observed{0};
+
+    auto node_body = [&](int /*input*/, ports_type&, int /*resource*/) {
+        std::size_t current = ++concurrent_count;
+        std::size_t prev_max = max_observed.load(std::memory_order_relaxed);
+        while (current > prev_max &&
+               !max_observed.compare_exchange_weak(prev_max, current,
+                                                   std::memory_order_release,
+                                                   std::memory_order_relaxed));
+
+        // Busy wait for a bit
+        for (std::size_t i = 0; i < 10000; ++i) {
+            std::size_t count = concurrent_count.load(std::memory_order_relaxed);
+            CHECK_MESSAGE(count <= max_concurrency,
+                         "Too many concurrent executions: " << count << " > " << max_concurrency);
+        }
+
+        --concurrent_count;
+    };
+
+    graph g;
+    node_type node(g, max_concurrency, std::tie(limiter), node_body);
+
+    const int num_messages = 50;
+    for (int i = 0; i < num_messages; ++i) {
+        node.try_put(i);
+    }
+
+    g.wait_for_all();
+
+    CHECK_MESSAGE(concurrent_count.load() == 0, "Final concurrent count should be zero");
+    CHECK_MESSAGE(max_observed.load() <= max_concurrency,
+                 "Concurrency limit was violated: max_observed=" << max_observed.load()
+                 << " > max_concurrency=" << max_concurrency);
+
+    // We should have observed some concurrency (at least 2 concurrent executions)
+    CHECK_MESSAGE(max_observed.load() >= 2,
+                 "Expected to observe concurrent execution but max_observed=" << max_observed.load());
+}
+


### PR DESCRIPTION
### Description

The max concurrency of a node is not controlled by its concurrency parameter but by the number of resources it can acquire. The execution of resource_limited_body_leaf was limited but that body only starts the async process to by calling request on the various providers and then returns. So the previous implementation guards the request logic not the body execution.

This PR releases the takes the concurrency slot in the body_leaf but only releases it when the body completes.

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [X] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [X] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
