### PR TITLE
Add documentation about C++20 modules support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,8 +510,16 @@ jobs:
           - os: ubuntu-latest
             c_compiler: gcc
             cxx_compiler: g++
+            generator: "Unix Makefiles"
             std: 20
             build_type: relwithdebinfo
+          - os: ubuntu-latest
+            c_compiler: clang
+            cxx_compiler: clang++
+            generator: Ninja
+            std: 20
+            build_type: relwithdebinfo
+            cmake_extra: -DTBB_TEST_CXX20_MODULES=ON
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -519,12 +527,16 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo apt-get update && sudo apt-get install -y ninja
       - name: Test doc examples
         run: |
           mkdir build && cd build
-          cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} \
+          cmake -G "${{ matrix.generator }}" -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} \
-            -DTBB_TEST=OFF -DTBB_DOC_EXAMPLES=ON ..
+            ${{ matrix.cmake_extra }} -DTBB_TEST=OFF -DTBB_DOC_EXAMPLES=ON ..
           cmake --build . -v --parallel --target build-doc-examples
           ctest -C ${{ matrix.build_type }} --timeout ${env:TEST_TIMEOUT} --output-on-failure -L doc-examples
 
@@ -542,6 +554,13 @@ jobs:
             cxx_compiler: cl
             std: 20
             build_type: relwithdebinfo
+          - os: windows-2022
+            generator: Ninja
+            c_compiler: cl
+            cxx_compiler: cl
+            std: 20
+            build_type: relwithdebinfo
+            cmake_extra: -DTBB_TEST_CXX20_MODULES=ON
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -555,6 +574,6 @@ jobs:
           cd build
           cmake -G "${{ matrix.generator }}" -A x64 -DCMAKE_CXX_STANDARD=${{ matrix.std }} `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} `
-            -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DTBB_TEST=OFF -DTBB_DOC_EXAMPLES=ON ..
+            -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} ${{ matrix.cmake_extra }} -DTBB_TEST=OFF -DTBB_DOC_EXAMPLES=ON ..
           cmake --build . --config ${{ matrix.build_type }} -v --parallel --target build-doc-examples
           ctest -C ${{ matrix.build_type }} --timeout ${env:TEST_TIMEOUT} --output-on-failure -L doc-examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,7 +500,7 @@ jobs:
           cmake --build . -v --target light_test_examples
 
   linux-doc-examples-testing:
-    name: doc_examples_${{ matrix.os }}_${{ matrix.cxx_compiler }}_cxx${{ matrix.std }}_${{ matrix.build_type }}
+    name: doc_examples_${{ matrix.os }}_${{ matrix.cxx_compiler }}_cxx${{ matrix.std }}_${{ matrix.build_type }}_${{ matrix.cmake_extra }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 10
     strategy:
@@ -544,7 +544,7 @@ jobs:
           ctest -C ${{ matrix.build_type }} --timeout ${env:TEST_TIMEOUT} --output-on-failure -L doc-examples
 
   windows-doc-examples-testing:
-    name: doc_examples_${{ matrix.os }}_${{ matrix.cxx_compiler }}_cxx${{ matrix.std }}_${{ matrix.build_type }}
+    name: doc_examples_${{ matrix.os }}_${{ matrix.cxx_compiler }}_cxx${{ matrix.std }}_${{ matrix.build_type }}_${{ matrix.cmake_extra }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 10
     strategy:
@@ -553,6 +553,7 @@ jobs:
         include:
           - os: windows-2022
             generator: "Visual Studio 17 2022"
+            generator_arch: "-A x64"
             c_compiler: cl
             cxx_compiler: cl
             std: 20
@@ -575,7 +576,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -G "${{ matrix.generator }}" -A x64 -DCMAKE_CXX_STANDARD=${{ matrix.std }} `
+          cmake -G "${{ matrix.generator }}" "${{ matrix.generator_arch }}" -DCMAKE_CXX_STANDARD=${{ matrix.std }} `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} `
             -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} ${{ matrix.cmake_extra }} -DTBB_TEST=OFF -DTBB_DOC_EXAMPLES=ON ..
           cmake --build . --config ${{ matrix.build_type }} -v --parallel --target build-doc-examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,7 +530,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          sudo apt-get update && sudo apt-get install -y ninja
+          sudo apt-get update && sudo apt-get install -y ninja-build
       - name: Test doc examples
         run: |
           mkdir build && cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,6 +536,7 @@ jobs:
           fi
       - name: Test doc examples
         run: |
+          set -x
           mkdir build && cd build
           cmake -G "${{ matrix.generator }}" -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} \
@@ -553,13 +554,6 @@ jobs:
         include:
           - os: windows-2022
             generator: "Visual Studio 17 2022"
-            generator_arch: "-A x64"
-            c_compiler: cl
-            cxx_compiler: cl
-            std: 20
-            build_type: relwithdebinfo
-          - os: windows-2022
-            generator: Ninja
             c_compiler: cl
             cxx_compiler: cl
             std: 20
@@ -574,9 +568,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Test doc examples
         run: |
-          mkdir build
-          cd build
-          cmake -G "${{ matrix.generator }}" "${{ matrix.generator_arch }}" -DCMAKE_CXX_STANDARD=${{ matrix.std }} `
+          mkdir build && cd build
+          cmake -G "${{ matrix.generator }}" -A x64 -DCMAKE_CXX_STANDARD=${{ matrix.std }} `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} `
             -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} ${{ matrix.cmake_extra }} -DTBB_TEST=OFF -DTBB_DOC_EXAMPLES=ON ..
           cmake --build . --config ${{ matrix.build_type }} -v --parallel --target build-doc-examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,12 +508,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            c_compiler: gcc
-            cxx_compiler: g++
-            generator: "Unix Makefiles"
-            std: 20
-            build_type: relwithdebinfo
-          - os: ubuntu-latest
             c_compiler: clang
             cxx_compiler: clang++
             generator: Ninja

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,6 +531,9 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update && sudo apt-get install -y ninja-build
+          if [[ "${{ matrix.cxx_compiler }}" == "clang++" ]]; then
+            sudo apt-get install -y libomp-dev
+          fi
       - name: Test doc examples
         run: |
           mkdir build && cd build

--- a/doc/GSG/integrate.rst
+++ b/doc/GSG/integrate.rst
@@ -31,7 +31,8 @@ To add oneTBB to another project using CMake*, add the following commands to you
        find_package(TBB REQUIRED)
        target_link_libraries(my_executable TBB::tbb)
 
-Additionally, you can also enable experimental C++20 modules support for TBB using the following commands:
+Additionally, you can also enable experimental C++20 modules support for TBB using the following commands
+(see :ref:`cxx20_modules_support` for details):
 
 .. code-block:: cmake
 

--- a/doc/main/examples_testing/CMakeLists.txt
+++ b/doc/main/examples_testing/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2025 Intel Corporation
+# Copyright (c) 2026 UXL Foundation Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 project(doc_examples_testing LANGUAGES CXX)
 
 set(_reference_examples_path "${CMAKE_CURRENT_SOURCE_DIR}/../reference/examples")
 set(_userguide_examples_path "${CMAKE_CURRENT_SOURCE_DIR}/../tbb_userguide/examples")
+
+# Examples that require special handling and are excluded from the generic build
+set(_doc_examples_exclude_regex
+    "cxx20_module_example\\.cpp$"  # requires C++20 modules support
+)
 
 add_custom_target(build-doc-examples
     COMMENT "Build oneTBB documentation samples")
@@ -35,15 +41,30 @@ macro(add_doc_example _doc_example_path)
 endmacro()
 
 file(GLOB_RECURSE DOC_EXAMPLES_LIST "${_reference_examples_path}/*.cpp" "${_userguide_examples_path}/*.cpp")
+list(FILTER DOC_EXAMPLES_LIST EXCLUDE REGEX "${_doc_examples_exclude_regex}")
 
 foreach(_doc_example_path IN LISTS DOC_EXAMPLES_LIST)
     add_doc_example(${_doc_example_path})
 endforeach()
+
+if (TBB_TEST_CXX20_MODULES)
+    if (CMAKE_VERSION VERSION_LESS 3.28)
+        message(WARNING "CMake 3.28 or higher is required for C++20 modules, skipping cxx20_module_example")
+    else()
+        add_doc_example("${_userguide_examples_path}/cxx20_module_example.cpp")
+        target_sources(cxx20_module_example PRIVATE
+            FILE_SET CXX_MODULES
+            BASE_DIRS ${CMAKE_SOURCE_DIR}/include
+            FILES ${CMAKE_SOURCE_DIR}/include/oneapi/tbb.cppm
+        )
+        set_target_properties(cxx20_module_example PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON)
+    endif()
+endif()
 
 find_package(OpenMP)
 if (OpenMP_FOUND)
     target_compile_options(tbb_mixing_other_runtimes_example PRIVATE "${OpenMP_CXX_FLAGS}")
     target_link_options(tbb_mixing_other_runtimes_example PRIVATE "${OpenMP_CXX_FLAGS}")
 endif()
-
-

--- a/doc/main/examples_testing/CMakeLists.txt
+++ b/doc/main/examples_testing/CMakeLists.txt
@@ -57,9 +57,7 @@ if (TBB_TEST_CXX20_MODULES)
             BASE_DIRS ${CMAKE_SOURCE_DIR}/include
             FILES ${CMAKE_SOURCE_DIR}/include/oneapi/tbb.cppm
         )
-        set_target_properties(cxx20_module_example PROPERTIES
-            CXX_STANDARD 20
-            CXX_STANDARD_REQUIRED ON)
+        target_compile_features(cxx20_module_example PRIVATE cxx_std_20)
     endif()
 endif()
 

--- a/doc/main/reference/reference.rst
+++ b/doc/main/reference/reference.rst
@@ -57,3 +57,4 @@ The key properties of a preview feature are:
     parallel_phase_for_task_arena
     fg_resource_limiting
     core_type_selector
+    ../tbb_userguide/cxx20_modules_support

--- a/doc/main/tbb_userguide/cxx20_modules_support.rst
+++ b/doc/main/tbb_userguide/cxx20_modules_support.rst
@@ -3,13 +3,6 @@
 C++20 Modules Support
 =====================
 
-.. contents::
-    :local:
-    :depth: 2
-
-Description
-***********
-
 .. note::
     Support for C++20 modules is experimental and subject to change in future releases.
 
@@ -18,8 +11,8 @@ Description
 source file under ``<install-prefix>/include/oneapi/tbb.cppm`` and must be compiled as
 part of your own build target.
 
-CMake Integration
-*****************
+CMake* Integration
+******************
 
 To add the ``tbb`` module to your CMake target, locate ``tbb.cppm`` using the
 ``INTERFACE_INCLUDE_DIRECTORIES`` property of the ``TBB::tbb`` target and register it as
@@ -55,7 +48,7 @@ An then in your C++ source files, you can import the module:
     }
 
 Usage Of Predefined Macros
-******************************
+**************************
 
 C++20 modules do not export preprocessor macros. Macros defined in
 ``<oneapi/tbb/version.h>`` (such as ``TBB_VERSION`` or feature-test macros) are **not** available
@@ -77,7 +70,7 @@ As a workaround, include the version header alongside the module import.
     #endif
 
 Enabling Preview Features
-**************************
+*************************
 
 |short_name| preview features are gated by ``TBB_PREVIEW_*`` macros that are normally defined
 before including TBB headers. With modules, macros defined by the consumer before

--- a/doc/main/tbb_userguide/cxx20_modules_support.rst
+++ b/doc/main/tbb_userguide/cxx20_modules_support.rst
@@ -7,7 +7,7 @@ C++20 Modules Support
     Support for C++20 modules is experimental and subject to change in future releases.
 
 |short_name| provides a C++20 module interface unit, ``tbb.cppm``, that lets you use |short_name| via
-``import tbb;`` instead of ``#include <oneapi/tbb.h>``. The module is installed as a
+``import tbb;`` instead of regular library headers. The module is installed as a
 source file under ``<install-prefix>/include/oneapi/tbb.cppm`` and must be compiled as
 part of your own build target.
 
@@ -19,9 +19,9 @@ To add the ``tbb`` module to your CMake* target, locate ``tbb.cppm`` using the
 a ``CXX_MODULES`` file set:
 
 .. note::
-    To support C++20 modules, CMake 3.28 or later and a compiler and generator with C++20 modules
+    To support C++20 modules, CMake* 3.28 or later and a compiler and generator with C++20 modules
     support are required. Refer to the
-    `CMake documentation <https://cmake.org/cmake/help/latest/manual/cmake-cxxmodules.7.html>`_
+    `CMake* documentation <https://cmake.org/cmake/help/latest/manual/cmake-cxxmodules.7.html>`_
     for the list of supported compilers and generators.
 
 .. code:: cmake
@@ -63,10 +63,10 @@ Usage Of Predefined Macros
 **************************
 
 C++20 modules do not export preprocessor macros. Macros defined in
-``<oneapi/tbb/version.h>`` (such as version or feature-test macros) are **not** available
+|short_name| library headers (such as version or feature-test macros) are **not** available
 after ``import tbb;``.
 
-As a workaround, include the version header alongside the module import.
+As a workaround, include the `<oneapi/tbb/version.h>` header alongside the module import.
 
 .. code:: cpp
 

--- a/doc/main/tbb_userguide/cxx20_modules_support.rst
+++ b/doc/main/tbb_userguide/cxx20_modules_support.rst
@@ -63,7 +63,7 @@ Usage Of Predefined Macros
 **************************
 
 C++20 modules do not export preprocessor macros. Macros defined in
-``<oneapi/tbb/version.h>`` (such as ``TBB_VERSION`` or feature-test macros) are **not** available
+``<oneapi/tbb/version.h>`` (such as version or feature-test macros) are **not** available
 after ``import tbb;``.
 
 As a workaround, include the version header alongside the module import.

--- a/doc/main/tbb_userguide/cxx20_modules_support.rst
+++ b/doc/main/tbb_userguide/cxx20_modules_support.rst
@@ -105,7 +105,7 @@ To enable a preview feature, define the corresponding macro when **compiling**
         FILES ${_tbb_include_dir}/oneapi/tbb.cppm
     )
 
-    # Enable preview features when compiling the module
+    # Enable preview feature X when compiling the module
     target_compile_definitions(my_executable PRIVATE TBB_PREVIEW_FEATURE_X=1)
 
 After this, the preview API is included in the compiled module and available to all

--- a/doc/main/tbb_userguide/cxx20_modules_support.rst
+++ b/doc/main/tbb_userguide/cxx20_modules_support.rst
@@ -45,13 +45,11 @@ a ``CXX_MODULES`` file set:
 
 An then in your C++ source files, you can import the module:
 
-.. code:: cpp
-
-    import tbb;
-
-    int main() {
-        tbb::parallel_for(0, 100, [](int i) { /* ... */ });
-    }
+.. literalinclude:: ./examples/cxx20_module_example.cpp
+   :language: c++
+   :prepend: import tbb;
+   :start-after: /* begin_cxx20_modules_basic_example */
+   :end-before: /* end_cxx20_modules_basic_example */
 
 .. note::
     Translation units built with ``import tbb;`` are ABI-compatible with those built using
@@ -103,15 +101,7 @@ As a workaround, include the `<oneapi/tbb/version.h>` header alongside the modul
     In any other scenario, make sure to define the same preview macros both when compiling
     the module and in your source code to avoid a mismatch.
 
-.. code:: cpp
-
-    // It is assumed that the application is compiled with preview macros predefined
-    #include <oneapi/tbb/version.h>  // macros available here
-    import tbb;
-
-    static_assert(TBB_VERSION_MAJOR >= 2023, "Major version 2023 or later required");
-
-    // Feature-test macros are also available
-    #ifdef TBB_HAS_FEATURE_X
-    // use feature X
-    #endif
+.. literalinclude:: ./examples/cxx20_module_example.cpp
+   :language: c++
+   :start-after: /* begin_cxx20_modules_macro_example */
+   :end-before: /* end_cxx20_modules_macro_example */

--- a/doc/main/tbb_userguide/cxx20_modules_support.rst
+++ b/doc/main/tbb_userguide/cxx20_modules_support.rst
@@ -52,8 +52,7 @@ An then in your C++ source files, you can import the module:
    :end-before: /* end_cxx20_modules_basic_example */
 
 .. note::
-    Translation units built with ``import tbb;`` are ABI-compatible with those built using
-    ``#include <oneapi/tbb.h>``.
+    Translation units that use ``import tbb;`` are ABI-compatible with those that use library headers.
 
 Enabling Preview Features
 *************************

--- a/doc/main/tbb_userguide/cxx20_modules_support.rst
+++ b/doc/main/tbb_userguide/cxx20_modules_support.rst
@@ -55,31 +55,7 @@ An then in your C++ source files, you can import the module:
 
 .. note::
     Translation units built with ``import tbb;`` are ABI-compatible with those built using
-    ``#include <oneapi/tbb.h>``. Because the exported API is attached to the global module
-    fragment, the module name does not participate in symbol mangling, and both can be linked
-    into the same program.
-
-Usage Of Predefined Macros
-**************************
-
-C++20 modules do not export preprocessor macros. Macros defined in
-|short_name| library headers (such as version or feature-test macros) are **not** available
-after ``import tbb;``.
-
-As a workaround, include the `<oneapi/tbb/version.h>` header alongside the module import.
-
-.. code:: cpp
-
-    #define TBB_PREVIEW_FEATURE_X 1
-    #include <oneapi/tbb/version.h>  // macros available here
-    import tbb;
-
-    static_assert(TBB_VERSION_MAJOR >= 2023, "Major version 2023 or later required");
-
-    // Feature-test macros are also available
-    #ifdef TBB_HAS_FEATURE_X
-    // use feature X
-    #endif
+    ``#include <oneapi/tbb.h>``.
 
 Enabling Preview Features
 *************************
@@ -105,8 +81,37 @@ To enable a preview feature, define the corresponding macro when **compiling**
         FILES ${_tbb_include_dir}/oneapi/tbb.cppm
     )
 
-    # Enable preview feature X when compiling the module
+    # Enable preview feature X when compiling the target that uses the module
     target_compile_definitions(my_executable PRIVATE TBB_PREVIEW_FEATURE_X=1)
 
 After this, the preview API is included in the compiled module and available to all
 translation units that use ``import tbb;``.
+
+Usage Of Predefined Macros
+**************************
+
+C++20 modules do not export preprocessor macros. Macros defined in
+|short_name| library headers (such as version or feature-test macros) are **not** available
+after ``import tbb;``.
+
+As a workaround, include the `<oneapi/tbb/version.h>` header alongside the module import.
+
+.. caution::
+    In typical usage with CMake* integration, ``tbb.cppm`` is compiled as part of your target,
+    so ``TBB_PREVIEW_*`` macros defined via ``target_compile_definitions`` are already applied
+    when the module is built. There is no need to redefine them in application source files.
+    In any other scenario, make sure to define the same preview macros both when compiling
+    the module and in your source code to avoid a mismatch.
+
+.. code:: cpp
+
+    // It is assumed that the application is compiled with preview macros predefined
+    #include <oneapi/tbb/version.h>  // macros available here
+    import tbb;
+
+    static_assert(TBB_VERSION_MAJOR >= 2023, "Major version 2023 or later required");
+
+    // Feature-test macros are also available
+    #ifdef TBB_HAS_FEATURE_X
+    // use feature X
+    #endif

--- a/doc/main/tbb_userguide/cxx20_modules_support.rst
+++ b/doc/main/tbb_userguide/cxx20_modules_support.rst
@@ -14,13 +14,19 @@ part of your own build target.
 CMake* Integration
 ******************
 
-To add the ``tbb`` module to your CMake target, locate ``tbb.cppm`` using the
+To add the ``tbb`` module to your CMake* target, locate ``tbb.cppm`` using the
 ``INTERFACE_INCLUDE_DIRECTORIES`` property of the ``TBB::tbb`` target and register it as
 a ``CXX_MODULES`` file set:
 
+.. note::
+    To support C++20 modules, CMake 3.28 or later and a compiler and generator with C++20 modules
+    support are required. Refer to the
+    `CMake documentation <https://cmake.org/cmake/help/latest/manual/cmake-cxxmodules.7.html>`_
+    for the list of supported compilers and generators.
+
 .. code:: cmake
 
-    cmake_minimum_required(VERSION 3.28)  # CMake 3.28+ required for CXX_MODULES file sets
+    cmake_minimum_required(VERSION 3.28)
     project(myapp CXX)
 
     set(CMAKE_CXX_STANDARD 20)
@@ -46,6 +52,12 @@ An then in your C++ source files, you can import the module:
     int main() {
         tbb::parallel_for(0, 100, [](int i) { /* ... */ });
     }
+
+.. note::
+    Translation units built with ``import tbb;`` are ABI-compatible with those built using
+    ``#include <oneapi/tbb.h>``. Because the exported API is attached to the global module
+    fragment, the module name does not participate in symbol mangling, and both can be linked
+    into the same program.
 
 Usage Of Predefined Macros
 **************************
@@ -77,7 +89,7 @@ before including TBB headers. With modules, macros defined by the consumer befor
 ``import tbb;`` **cannot** affect the module's already-compiled interface.
 
 To enable a preview feature, define the corresponding macro when **compiling**
-``tbb.cppm`` itself. In CMake, use ``target_compile_definitions``:
+``tbb.cppm`` itself. In CMake*, use ``target_compile_definitions``:
 
 .. code:: cmake
 

--- a/doc/main/tbb_userguide/cxx20_modules_support.rst
+++ b/doc/main/tbb_userguide/cxx20_modules_support.rst
@@ -1,0 +1,107 @@
+.. _cxx20_modules_support:
+
+C++20 Modules Support
+=====================
+
+.. contents::
+    :local:
+    :depth: 2
+
+Description
+***********
+
+.. note::
+    Support for C++20 modules is experimental and subject to change in future releases.
+
+|short_name| provides a C++20 module interface unit, ``tbb.cppm``, that lets you use |short_name| via
+``import tbb;`` instead of ``#include <oneapi/tbb.h>``. The module is installed as a
+source file under ``<install-prefix>/include/oneapi/tbb.cppm`` and must be compiled as
+part of your own build target.
+
+CMake Integration
+*****************
+
+To add the ``tbb`` module to your CMake target, locate ``tbb.cppm`` using the
+``INTERFACE_INCLUDE_DIRECTORIES`` property of the ``TBB::tbb`` target and register it as
+a ``CXX_MODULES`` file set:
+
+.. code:: cmake
+
+    cmake_minimum_required(VERSION 3.28)  # CMake 3.28+ required for CXX_MODULES file sets
+    project(myapp CXX)
+
+    set(CMAKE_CXX_STANDARD 20)
+
+    find_package(TBB REQUIRED)
+
+    add_executable(my_executable main.cpp)
+    target_link_libraries(my_executable PRIVATE TBB::tbb)
+
+    get_target_property(_tbb_include_dir TBB::tbb INTERFACE_INCLUDE_DIRECTORIES)
+    target_sources(my_executable PRIVATE
+        FILE_SET cxx_modules TYPE CXX_MODULES
+        BASE_DIRS ${_tbb_include_dir}
+        FILES ${_tbb_include_dir}/oneapi/tbb.cppm
+    )
+
+An then in your C++ source files, you can import the module:
+
+.. code:: cpp
+
+    import tbb;
+
+    int main() {
+        tbb::parallel_for(0, 100, [](int i) { /* ... */ });
+    }
+
+Usage Of Predefined Macros
+******************************
+
+C++20 modules do not export preprocessor macros. Macros defined in
+``<oneapi/tbb/version.h>`` (such as ``TBB_VERSION`` or feature-test macros) are **not** available
+after ``import tbb;``.
+
+As a workaround, include the version header alongside the module import.
+
+.. code:: cpp
+
+    #define TBB_PREVIEW_FEATURE_X 1
+    #include <oneapi/tbb/version.h>  // macros available here
+    import tbb;
+
+    static_assert(TBB_VERSION_MAJOR >= 2023, "Major version 2023 or later required");
+
+    // Feature-test macros are also available
+    #ifdef TBB_HAS_FEATURE_X
+    // use feature X
+    #endif
+
+Enabling Preview Features
+**************************
+
+|short_name| preview features are gated by ``TBB_PREVIEW_*`` macros that are normally defined
+before including TBB headers. With modules, macros defined by the consumer before
+``import tbb;`` **cannot** affect the module's already-compiled interface.
+
+To enable a preview feature, define the corresponding macro when **compiling**
+``tbb.cppm`` itself. In CMake, use ``target_compile_definitions``:
+
+.. code:: cmake
+
+    find_package(TBB REQUIRED)
+
+    add_executable(my_executable main.cpp)
+    target_link_libraries(my_executable PRIVATE TBB::tbb)
+
+    get_target_property(_tbb_include_dir TBB::tbb INTERFACE_INCLUDE_DIRECTORIES)
+    target_sources(my_executable PRIVATE
+        FILE_SET cxx_modules TYPE CXX_MODULES
+        BASE_DIRS ${_tbb_include_dir}
+        FILES ${_tbb_include_dir}/oneapi/tbb.cppm
+    )
+
+    # Enable preview features when compiling the module
+    target_compile_definitions(my_executable PRIVATE TBB_PREVIEW_FEATURE_X=1)
+
+After this, the preview API is included in the compiled module and available to all
+translation units that use ``import tbb;``.

--- a/doc/main/tbb_userguide/examples/cxx20_module_example.cpp
+++ b/doc/main/tbb_userguide/examples/cxx20_module_example.cpp
@@ -1,0 +1,35 @@
+/*
+    Copyright (c) 2026 UXL Foundation Contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/* begin_cxx20_modules_macro_example */
+// It is assumed that the application is compiled with preview macros predefined
+#include <oneapi/tbb/version.h>  // macros available here
+import tbb;
+
+static_assert(TBB_VERSION_MAJOR >= 2023, "Major version 2023 or later is required");
+
+// Feature-test macros are also available
+#ifdef TBB_HAS_FEATURE_X
+// use feature X
+#endif
+/* end_cxx20_modules_macro_example */
+
+/* begin_cxx20_modules_basic_example */
+
+int main() {
+    tbb::parallel_for(0, 100, [](int i) { /* ... */ });
+}
+/* end_cxx20_modules_basic_example */

--- a/doc/main/tbb_userguide/examples/cxx20_module_example.cpp
+++ b/doc/main/tbb_userguide/examples/cxx20_module_example.cpp
@@ -28,7 +28,6 @@ static_assert(TBB_VERSION_MAJOR >= 2023, "Major version 2023 or later is require
 /* end_cxx20_modules_macro_example */
 
 /* begin_cxx20_modules_basic_example */
-
 int main() {
     tbb::parallel_for(0, 100, [](int i) { /* ... */ });
 }

--- a/doc/main/tbb_userguide/title.rst
+++ b/doc/main/tbb_userguide/title.rst
@@ -25,6 +25,7 @@
    ../tbb_userguide/Migration_Guide
    ../tbb_userguide/Constraints
    ../tbb_userguide/std_invoke
+   ../tbb_userguide/cxx20_modules_support
    ../tbb_userguide/appendix_A
    ../tbb_userguide/appendix_B
    ../tbb_userguide/References


### PR DESCRIPTION
### Description 
New page in user guide focuses primarily on integration and suggesting workarounds to use `tbb` module with its predefined macros and preview features support.

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_