### PR TITLE
FIX: x86_64 flags in universal binary build (Xcode)

### DIFF
--- a/cmake/compilers/AppleClang.cmake
+++ b/cmake/compilers/AppleClang.cmake
@@ -38,7 +38,18 @@ else()
     set(_tbb_target_architectures "${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 if ("${_tbb_target_architectures}" MATCHES "(x86_64|amd64|AMD64)") # OSX systems are 64-bit only
-    set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -mrtm $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},12.0>>:-mwaitpkg>)
+    if(CMAKE_GENERATOR STREQUAL "Xcode")
+        # Note: Must be a string with whitespaces, because it gets passed to
+        # the .pbxproj file directly.
+        # These flags need to be set on a per-target basis (see the relevant
+        # CMakeLists.txt).
+        set(TBB_X86_XCODE_COMPILE_FLAGS "-mrtm $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},12.0>>:-mwaitpkg>")
+    else()
+        # Can be inserted directly, generators other than Xcode have a single
+        # compiler invocation and silently ignore flags that do not apply to
+        # the target architecture
+        set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -mrtm $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},12.0>>:-mwaitpkg>)
+    endif()
 endif()
 unset(_tbb_target_architectures)
 

--- a/cmake/compilers/Clang.cmake
+++ b/cmake/compilers/Clang.cmake
@@ -70,7 +70,18 @@ else()
     set(_tbb_target_architectures "${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 if ("${_tbb_target_architectures}" MATCHES "(AMD64|amd64|i.86|x86)" AND NOT EMSCRIPTEN)
-    set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -mrtm $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},12.0>>:-mwaitpkg>)
+    if(CMAKE_GENERATOR STREQUAL "Xcode")
+        # Note: Must be a string with whitespaces, because it gets passed to
+        # the .pbxproj file directly.
+        # These flags need to be set on a per-target basis (see the relevant
+        # CMakeLists.txt).
+        set(TBB_X86_XCODE_COMPILE_FLAGS "-mrtm $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},12.0>>:-mwaitpkg>")
+    else()
+        # Can be inserted directly, generators other than Xcode have a single
+        # compiler invocation and silently ignore flags that do not apply to
+        # the target architecture
+        set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -mrtm $<$<NOT:$<VERSION_LESS:${CMAKE_CXX_COMPILER_VERSION},12.0>>:-mwaitpkg>)
+    endif()
 endif()
 
 # Clang flags to prevent compiler from optimizing out security checks

--- a/src/tbb/CMakeLists.txt
+++ b/src/tbb/CMakeLists.txt
@@ -165,6 +165,17 @@ if(TBB_BUILD_APPLE_FRAMEWORKS)
         MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${TBB_BINARY_VERSION})
 endif()
 
+# On Xcode when building a universal binary, the x86_64-specific flags need to
+# be set as an Xcode attribute because of the way Xcode invokes the compiler
+# compared to all other generators.
+if(DEFINED TBB_X86_XCODE_COMPILE_FLAGS AND CMAKE_GENERATOR STREQUAL "Xcode")
+    # $(OTHER_CPLUSPLUSFLAGS) must be passed as a literal to also use all
+    # common compilation flags
+    set_target_properties(tbb PROPERTIES
+      XCODE_ATTRIBUTE_OTHER_CPLUSPLUSFLAGS[arch=x86_64] "\$(OTHER_CPLUSPLUSFLAGS) ${TBB_X86_XCODE_COMPILE_FLAGS}"
+    )
+endif()
+
 tbb_install_target(tbb)
 
 if (TBB_INSTALL)


### PR DESCRIPTION
### Description

Xcode compiler invocations are unlike the invocations of other CMake generators when building universal binaries:

- Xcode manually invokes the compiler two (2) times with different target flags
- All other generators do a single compiler invocation with both architectures specified in one invocation

This causes Xcode to currently pass x86_64 flags to an arm64-only compiler invocation, which causes a compiler error.

Xcode does allow setting flags specific to the architecture, which must be passed with a `CMAKE_XCODE_ATTRIBUTE_OTHER_CPLUSPLUSFLAGS for x86_64` manually.

Fixes issue #1772. See my comment in that thread for more info.

### Type of change

- [x] bug fix

### Tests

- [x] not needed

### Documentation

- [x] not needed

### Breaks backward compatibility

- [x] No

### Notify the following users

@isaevil that would be the follow-up PR we talked about :).