### PR TITLE
Support interleaved allocations of objects > 2MB with non-default bytes_per_chunk

### DIFF
--- a/src/tbb/numa_allocation.cpp
+++ b/src/tbb/numa_allocation.cpp
@@ -196,7 +196,7 @@ void *__TBB_EXPORTED_FUNC allocate_interleaved(size_t bytes,
     // If /sys/kernel/mm/transparent_hugepage/enabled is set to "always", allocations of objects
     // > 2MB with non-default bytes_per_chunk (say, 8K) fail, because move_pages() can't fulfill
     // the request. MADV_NOHUGEPAGE prevents this. Cover smaller sizes as well, because several
-    // allocations with smaller sizes can be potentially joined by THP.
+    // allocations with smaller sizes can be potentially joined by Transparent Huge Pages (THP).
     int r = madvise(base_addr, align_to_greater_or_equal(bytes, governor::default_page_size()),
                     MADV_NOHUGEPAGE);
     if (r != 0)

--- a/src/tbb/numa_allocation.cpp
+++ b/src/tbb/numa_allocation.cpp
@@ -197,8 +197,8 @@ void *__TBB_EXPORTED_FUNC allocate_interleaved(size_t bytes,
     // > 2MB with non-default bytes_per_chunk (say, 8K) fail, because move_pages() can't fulfill
     // the request. MADV_NOHUGEPAGE prevents this. Cover smaller sizes as well, because several
     // allocations with smaller sizes can be potentially joined by Transparent Huge Pages (THP).
-    int r = madvise(base_addr, align_to_greater_or_equal(bytes, governor::default_page_size()),
-                    MADV_NOHUGEPAGE);
+    // Expecting that madvise() is aligning bytes to page size.
+    int r = madvise(base_addr, bytes, MADV_NOHUGEPAGE);
     if (r != 0)
         return nullptr;
 

--- a/src/tbb/numa_allocation.cpp
+++ b/src/tbb/numa_allocation.cpp
@@ -27,6 +27,7 @@
 
 #include <algorithm> // for std::any_of
 #include <sys/mman.h>
+#include <stdio.h>
 
 // TBB build must be done without numaif.h, but we need signatures of those functions
 // for dynamic loading, so declare it here.
@@ -193,6 +194,15 @@ void *__TBB_EXPORTED_FUNC allocate_interleaved(size_t bytes,
         }
     }
     // process non-standard chunk size or repeated nodes
+
+    // If /sys/kernel/mm/transparent_hugepage/enabled is set to "always", allocations of objects
+    // > 2MB with non-default bytes_per_chunk (say, 8K) fail, because move_pages() can't fulfill
+    // the request. MADV_NOHUGEPAGE prevents this. Cover smaller sizes as well, because several
+    // allocations with smaller sizes can be potentially joined by THP.
+    int r = madvise(base_addr, align_to_greater_or_equal(bytes, governor::default_page_size()),
+                    MADV_NOHUGEPAGE);
+    if (r != 0)
+        return nullptr;
 
     // touch each page, otherwise move_pages() will fail with EFAULT
     for (size_t i = 0; i < bytes; i += governor::default_page_size())

--- a/src/tbb/numa_allocation.cpp
+++ b/src/tbb/numa_allocation.cpp
@@ -27,8 +27,6 @@
 
 #include <algorithm> // for std::any_of
 #include <sys/mman.h>
-#include <stdio.h>
-
 // TBB build must be done without numaif.h, but we need signatures of those functions
 // for dynamic loading, so declare it here.
 extern "C" {

--- a/test/tbb/test_numa_allocation.cpp
+++ b/test/tbb/test_numa_allocation.cpp
@@ -122,7 +122,8 @@ TEST_CASE("invalid parameters") {
 
 void VerifySizeAndNodes(char *ptr, size_t bytes, const std::vector<tbb::numa_node_id>& nodes,
                         size_t bytes_per_chunk, bool check_ownership) {
-    REQUIRE_MESSAGE(ptr != nullptr, "Failed to allocate NUMA interleaved memory for size " << bytes);
+    REQUIRE_MESSAGE(ptr != nullptr, "Failed to allocate NUMA interleaved memory for size "
+                                    << bytes << " and bytes_per_chunk " << bytes_per_chunk);
     REQUIRE_EQ(utils::NonZero(ptr, bytes), 0);
     if (!check_ownership)
         return;
@@ -199,7 +200,7 @@ TEST_CASE("test basics") {
     bool lib = tbb::info::numa_nodes().size() > 1;
 #endif
 
-    for (size_t obj_size = 8; obj_size <= 1024 * 1024LLU; obj_size *= 2)
+    for (size_t obj_size = 8; obj_size <= 10 * 1024 * 1024LLU; obj_size *= 2)
     {
         {
             std::vector<tbb::numa_node_id> numa_nodes = tbb::info::numa_nodes();


### PR DESCRIPTION
### Description 
There is an issue: tbb::allocate_numa_interleaved(2*1024*1024, 8*1024) is not working when /sys/kernel/mm/transparent_hugepage/enabled is set to "always".

### Type of change

- [X] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [X] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
