### PR TITLE
[TCM] Move TCM internals to implementation side

### DIFF
--- a/thread_composability_manager/include/tcm/detail/_config.h
+++ b/thread_composability_manager/include/tcm/detail/_config.h
@@ -12,4 +12,17 @@
 #define TCM_USE_ASSERT TCM_DEBUG
 #endif
 
+#if _MSC_VER && !__INTEL_COMPILER
+#define __TCM_SUPPRESS_WARNING_PUSH __pragma(warning(push))
+#define __TCM_SUPPRESS_WARNING(w) __pragma(warning(disable : w))
+#define __TCM_SUPPRESS_WARNING_POP __pragma(warning(pop))
+#define __TCM_SUPPRESS_WARNING_WITH_PUSH(w)                             \
+    __TCM_SUPPRESS_WARNING_PUSH __TCM_SUPPRESS_WARNING(w)
+#else
+#define __TCM_SUPPRESS_WARNING_PUSH
+#define __TCM_SUPPRESS_WARNING(w)
+#define __TCM_SUPPRESS_WARNING_POP
+#define __TCM_SUPPRESS_WARNING_WITH_PUSH(w)
+#endif
+
 #endif  // __TCM_CONFIG_HEADER

--- a/thread_composability_manager/src/CMakeLists.txt
+++ b/thread_composability_manager/src/CMakeLists.txt
@@ -62,6 +62,8 @@ target_compile_definitions(tcm PRIVATE
 target_include_directories(tcm PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 
 # Prefer using target_link_options instead of target_link_libraries to specify link options because

--- a/thread_composability_manager/src/CMakeLists.txt
+++ b/thread_composability_manager/src/CMakeLists.txt
@@ -62,8 +62,6 @@ target_compile_definitions(tcm PRIVATE
 target_include_directories(tcm PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  PRIVATE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 
 # Prefer using target_link_options instead of target_link_libraries to specify link options because

--- a/thread_composability_manager/src/detail/_environment.h
+++ b/thread_composability_manager/src/detail/_environment.h
@@ -8,6 +8,7 @@
 #ifndef __TCM_ENVIRONMENT_HEADER
 #define __TCM_ENVIRONMENT_HEADER
 
+#include "tcm/detail/_config.h"
 #include "_tcm_assert.h"
 
 #include <cstdlib> // for std::atoi, std::atof

--- a/thread_composability_manager/src/detail/_tcm_assert.h
+++ b/thread_composability_manager/src/detail/_tcm_assert.h
@@ -8,7 +8,7 @@
 #ifndef __TCM_ASSERT_HEADER
 #define __TCM_ASSERT_HEADER
 
-#include "_config.h"
+#include "tcm/detail/_config.h"
 
 #include <atomic>
 #include <cstdio>
@@ -51,19 +51,6 @@ static void report_failed_assert(const char* location, int line, const char* con
 #define __TCM_ASSERT(condition, message) ((void)0)
 #define __TCM_ASSERT_EX(condition, message) tcm::internal::suppress_unused_warning(condition)
 #endif  // TCM_USE_ASSERT
-
-#if _MSC_VER && !__INTEL_COMPILER
-#define __TCM_SUPPRESS_WARNING_PUSH __pragma(warning(push))
-#define __TCM_SUPPRESS_WARNING(w) __pragma(warning(disable : w))
-#define __TCM_SUPPRESS_WARNING_POP __pragma(warning(pop))
-#define __TCM_SUPPRESS_WARNING_WITH_PUSH(w)                             \
-    __TCM_SUPPRESS_WARNING_PUSH __TCM_SUPPRESS_WARNING(w)
-#else
-#define __TCM_SUPPRESS_WARNING_PUSH
-#define __TCM_SUPPRESS_WARNING(w)
-#define __TCM_SUPPRESS_WARNING_POP
-#define __TCM_SUPPRESS_WARNING_WITH_PUSH(w)
-#endif
 
 } // namespace internal
 } // namespace tcm

--- a/thread_composability_manager/src/detail/hwloc_utils.h
+++ b/thread_composability_manager/src/detail/hwloc_utils.h
@@ -11,7 +11,7 @@
 #include <vector>
 #include <thread>               // std::this_thread::yield()
 
-#include "tcm/detail/_tcm_assert.h"
+#include "detail/_tcm_assert.h"
 
 #if _MSC_VER && !__INTEL_COMPILER && !__clang__
 #pragma warning( push )

--- a/thread_composability_manager/src/detail/hwloc_utils.h
+++ b/thread_composability_manager/src/detail/hwloc_utils.h
@@ -11,7 +11,7 @@
 #include <vector>
 #include <thread>               // std::this_thread::yield()
 
-#include "detail/_tcm_assert.h"
+#include "_tcm_assert.h"
 
 #if _MSC_VER && !__INTEL_COMPILER && !__clang__
 #pragma warning( push )

--- a/thread_composability_manager/src/linux/cgroup_info.h
+++ b/thread_composability_manager/src/linux/cgroup_info.h
@@ -8,7 +8,7 @@
 #ifndef __TCM_CGROUP_INFO_HEADER
 #define __TCM_CGROUP_INFO_HEADER
 
-#include "tcm/detail/_tcm_assert.h"
+#include "detail/_tcm_assert.h"
 
 #include <cstdint>
 #include <cstdio>

--- a/thread_composability_manager/src/linux/cgroup_info.h
+++ b/thread_composability_manager/src/linux/cgroup_info.h
@@ -8,7 +8,7 @@
 #ifndef __TCM_CGROUP_INFO_HEADER
 #define __TCM_CGROUP_INFO_HEADER
 
-#include "detail/_tcm_assert.h"
+#include "../detail/_tcm_assert.h"
 
 #include <cstdint>
 #include <cstdio>

--- a/thread_composability_manager/src/tcm.cpp
+++ b/thread_composability_manager/src/tcm.cpp
@@ -5,9 +5,9 @@
    SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 */
 
-#include "tcm/detail/_tcm_assert.h"
-#include "tcm/detail/hwloc_utils.h"
-#include "tcm/detail/_environment.h"
+#include "detail/_tcm_assert.h"
+#include "detail/hwloc_utils.h"
+#include "detail/_environment.h"
 #include "tcm.h"
 #include "tcm_permit_rep.h"
 

--- a/thread_composability_manager/src/utils.h
+++ b/thread_composability_manager/src/utils.h
@@ -16,7 +16,7 @@
 #include <map>
 
 #include "tcm/types.h"
-#include "tcm/detail/_tcm_assert.h"
+#include "detail/_tcm_assert.h"
 
 inline std::string to_string(void* ptr) {
     constexpr unsigned max_string_length = 32; // Sufficiently large size to hold 64-bit HEX pointer

--- a/thread_composability_manager/src/version.cpp
+++ b/thread_composability_manager/src/version.cpp
@@ -5,7 +5,7 @@
    SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 */
 
-#include "tcm/detail/_environment.h"
+#include "detail/_environment.h"
 #include "tcm/version.h"
 
 #if _WIN32

--- a/thread_composability_manager/test/basic_test_utils.h
+++ b/thread_composability_manager/test/basic_test_utils.h
@@ -13,8 +13,7 @@
  * and OS API
  **************************************************************************************************/
 
-#include "tcm/detail/_tcm_assert.h"
-
+#include "tcm/detail/_config.h"
 #include "tcm.h"
 
 #include "test_exceptions.h"
@@ -29,89 +28,36 @@
 #include <thread>
 #include <vector>
 
-// MSVC Warning: Args can be incorrect: this does not match function name specification
-__TCM_SUPPRESS_WARNING_WITH_PUSH(6387)
-inline int SetEnv( const char *envname, const char *envval ) {
-    __TCM_ASSERT( (envname && envval), "SetEnv requires two valid C strings" );
-#if !(_MSC_VER || __MINGW32__ || __MINGW64__)
-    // On POSIX systems use setenv
-    return setenv(envname, envval, /*overwrite=*/1);
-#elif __STDC_SECURE_LIB__>=200411
-    // this macro is set in VC & MinGW if secure API functions are present
-    return _putenv_s(envname, envval);
-#else
-    // If no secure API on Windows, use _putenv
-    size_t namelen = strlen(envname), valuelen = strlen(envval);
-    char* buf = new char[namelen+valuelen+2];
-    strncpy(buf, envname, namelen);
-    buf[namelen] = '=';
-    strncpy(buf+namelen+1, envval, valuelen);
-    buf[namelen+1+valuelen] = char(0);
-    int status = _putenv(buf);
-    delete[] buf;
-    return status;
-#endif
-}
-
-char* GetEnv(const char* envname) {
-    __TCM_ASSERT(envname, "GetEnv requires valid C string");
-    return std::getenv(envname);
-}
-__TCM_SUPPRESS_WARNING_POP
-
-
 /***************************************************************************************************
- * TCM-specific helpers
+ * Testing and reporting functions
  **************************************************************************************************/
+template <bool skip_out_stream = false, bool skip_err_stream = false>
+class tcm_test_logger_t {
+public:
+    tcm_test_logger_t() = default;
 
-tcm_permit_request_t make_request(int min_sw_threads = tcm_automatic,
-                                  int max_sw_threads = tcm_automatic,
-                                  tcm_cpu_constraints_t* constraints = nullptr, uint32_t size = 0,
-                                  tcm_request_priority_t priority = TCM_REQUEST_PRIORITY_NORMAL,
-                                  tcm_permit_flags_t flags = {})
-{
-    __TCM_ASSERT(!(!constraints ^ !size), "Inconsistent request.");
+    template <typename T> void log(T&& msg) const {
+        if constexpr (!skip_out_stream)
+            log_to(out_stream(), std::forward<T>(msg));
+    }
 
-    tcm_permit_request_t req = TCM_PERMIT_REQUEST_INITIALIZER;
+    template <typename T> void log_error(T&& msg) const {
+        if constexpr (!skip_err_stream)
+            log_to(err_stream(), std::forward<T>(msg));
+    }
 
-    req.min_sw_threads = min_sw_threads; req.max_sw_threads = max_sw_threads;
-    req.cpu_constraints = constraints; req.constraints_size = size;
-    req.priority = priority; req.flags = flags;
+    template <typename T> void log_to(std::ostream& os, T&& msg) const {
+        os << msg << std::endl;
+    }
+private:
+    static std::ostream& out_stream() { return std::cout; }
+    static std::ostream& err_stream() { return std::cerr; }
 
-    return req;
-}
+    tcm_test_logger_t(const tcm_test_logger_t&) = delete;
+    tcm_test_logger_t& operator=(const tcm_test_logger_t&) = delete;
+};
 
-tcm_permit_t make_permit(uint32_t* concurrencies, tcm_cpu_mask_t* cpu_masks = nullptr,
-                         uint32_t size = 1, tcm_permit_state_t state = TCM_PERMIT_STATE_VOID,
-                         tcm_permit_flags_t flags = {})
-{
-  __TCM_ASSERT(concurrencies, "Array of concurrencies cannot be nullptr.");
-  return tcm_permit_t{concurrencies, cpu_masks, size, state, flags};
-}
-
-tcm_permit_t make_void_permit(uint32_t* concurrencies, tcm_cpu_mask_t* cpu_masks = nullptr,
-                               uint32_t size = 1, tcm_permit_flags_t flags = {})
-{
-    return make_permit(concurrencies, cpu_masks, size, TCM_PERMIT_STATE_VOID, flags);
-}
-
-tcm_permit_t make_active_permit(uint32_t* concurrencies, tcm_cpu_mask_t* cpu_masks = nullptr,
-                                 uint32_t size = 1, tcm_permit_flags_t flags = {})
-{
-  return make_permit(concurrencies, cpu_masks, size, TCM_PERMIT_STATE_ACTIVE, flags);
-}
-
-tcm_permit_t make_inactive_permit(uint32_t* concurrencies, tcm_cpu_mask_t* cpu_masks = nullptr,
-                                  uint32_t size = 1, tcm_permit_flags_t flags = {})
-{
-  return make_permit(concurrencies, cpu_masks, size, TCM_PERMIT_STATE_INACTIVE, flags);
-}
-
-tcm_permit_t make_pending_permit(uint32_t* concurrencies, tcm_cpu_mask_t* cpu_masks = nullptr,
-                                  uint32_t size = 1, tcm_permit_flags_t flags = {})
-{
-  return make_permit(concurrencies, cpu_masks, size, TCM_PERMIT_STATE_PENDING, flags);
-}
+static tcm_test_logger_t</*skip_out_stream*/false, /*skip_err_stream*/false> logger;
 
 
 /***************************************************************************************************
@@ -157,37 +103,6 @@ private:
     std::vector<tcm_client_id_t> tcm_clients;
 };
 
-/***************************************************************************************************
- * Testing and reporting functions
- **************************************************************************************************/
-template <bool skip_out_stream = false, bool skip_err_stream = false>
-class tcm_test_logger_t {
-public:
-    tcm_test_logger_t() = default;
-
-    template <typename T> void log(T&& msg) const {
-        if constexpr (!skip_out_stream)
-            log_to(out_stream(), std::forward<T>(msg));
-    }
-
-    template <typename T> void log_error(T&& msg) const {
-        if constexpr (!skip_err_stream)
-            log_to(err_stream(), std::forward<T>(msg));
-    }
-
-    template <typename T> void log_to(std::ostream& os, T&& msg) const {
-        os << msg << std::endl;
-    }
-private:
-    static std::ostream& out_stream() { return std::cout; }
-    static std::ostream& err_stream() { return std::cerr; }
-
-    tcm_test_logger_t(const tcm_test_logger_t&) = delete;
-    tcm_test_logger_t& operator=(const tcm_test_logger_t&) = delete;
-};
-
-/* Global objects */
-static tcm_test_logger_t</*skip_out_stream*/false, /*skip_err_stream*/false> logger;
 static tcm_tests_data tcm_tests;
 
 #define TEST_PREFACE(name, filename, linenumber)                                                   \
@@ -202,6 +117,9 @@ static tcm_tests_data tcm_tests;
 #define TEST(name) TEST_AUX((name), __FILE__, __LINE__)
 
 
+/***************************************************************************************************
+ * Basic helpers for a test
+ ***************************************************************************************************/
 bool check(bool b, const std::string& msg, unsigned num_indents = 0,
            const std::string& report_msg = "")
 {
@@ -247,6 +165,97 @@ inline bool check_fail(tcm_result_t res, const std::string& msg = "",
 }
 
 /***************************************************************************************************
+ * Setting and getting value of an environment variable
+ ***************************************************************************************************/
+
+// MSVC Warning: Args can be incorrect: this does not match function name specification
+__TCM_SUPPRESS_WARNING_WITH_PUSH(6387)
+inline int SetEnv( const char *envname, const char *envval ) {
+    check( (envname && envval), /*msg*/"", /*num_indents*/0,
+           /*report_msg*/"SetEnv requires two valid C strings" );
+#if !(_MSC_VER || __MINGW32__ || __MINGW64__)
+    // On POSIX systems use setenv
+    return setenv(envname, envval, /*overwrite=*/1);
+#elif __STDC_SECURE_LIB__>=200411
+    // this macro is set in VC & MinGW if secure API functions are present
+    return _putenv_s(envname, envval);
+#else
+    // If no secure API on Windows, use _putenv
+    size_t namelen = strlen(envname), valuelen = strlen(envval);
+    char* buf = new char[namelen+valuelen+2];
+    strncpy(buf, envname, namelen);
+    buf[namelen] = '=';
+    strncpy(buf+namelen+1, envval, valuelen);
+    buf[namelen+1+valuelen] = char(0);
+    int status = _putenv(buf);
+    delete[] buf;
+    return status;
+#endif
+}
+
+char* GetEnv(const char* envname) {
+    check(envname, /*msg*/"", /*num_indents*/0, /*report_msg*/"GetEnv requires valid C string");
+    return std::getenv(envname);
+}
+__TCM_SUPPRESS_WARNING_POP
+
+
+/***************************************************************************************************
+ * TCM-specific helpers
+ **************************************************************************************************/
+
+tcm_permit_request_t make_request(int min_sw_threads = tcm_automatic,
+                                  int max_sw_threads = tcm_automatic,
+                                  tcm_cpu_constraints_t* constraints = nullptr, uint32_t size = 0,
+                                  tcm_request_priority_t priority = TCM_REQUEST_PRIORITY_NORMAL,
+                                  tcm_permit_flags_t flags = {})
+{
+    check(!(!constraints ^ !size), /*msg*/"", /*num_indents*/0,
+          /*report_msg*/"Inconsistent request.");
+
+    tcm_permit_request_t req = TCM_PERMIT_REQUEST_INITIALIZER;
+
+    req.min_sw_threads = min_sw_threads; req.max_sw_threads = max_sw_threads;
+    req.cpu_constraints = constraints; req.constraints_size = size;
+    req.priority = priority; req.flags = flags;
+
+    return req;
+}
+
+tcm_permit_t make_permit(uint32_t* concurrencies, tcm_cpu_mask_t* cpu_masks = nullptr,
+                         uint32_t size = 1, tcm_permit_state_t state = TCM_PERMIT_STATE_VOID,
+                         tcm_permit_flags_t flags = {})
+{
+  check(concurrencies, /*msg*/"", /*num_indents*/0,
+        /*report_msg*/"Array of concurrencies is nullptr.");
+  return tcm_permit_t{concurrencies, cpu_masks, size, state, flags};
+}
+
+tcm_permit_t make_void_permit(uint32_t* concurrencies, tcm_cpu_mask_t* cpu_masks = nullptr,
+                               uint32_t size = 1, tcm_permit_flags_t flags = {})
+{
+    return make_permit(concurrencies, cpu_masks, size, TCM_PERMIT_STATE_VOID, flags);
+}
+
+tcm_permit_t make_active_permit(uint32_t* concurrencies, tcm_cpu_mask_t* cpu_masks = nullptr,
+                                 uint32_t size = 1, tcm_permit_flags_t flags = {})
+{
+  return make_permit(concurrencies, cpu_masks, size, TCM_PERMIT_STATE_ACTIVE, flags);
+}
+
+tcm_permit_t make_inactive_permit(uint32_t* concurrencies, tcm_cpu_mask_t* cpu_masks = nullptr,
+                                  uint32_t size = 1, tcm_permit_flags_t flags = {})
+{
+  return make_permit(concurrencies, cpu_masks, size, TCM_PERMIT_STATE_INACTIVE, flags);
+}
+
+tcm_permit_t make_pending_permit(uint32_t* concurrencies, tcm_cpu_mask_t* cpu_masks = nullptr,
+                                  uint32_t size = 1, tcm_permit_flags_t flags = {})
+{
+  return make_permit(concurrencies, cpu_masks, size, TCM_PERMIT_STATE_PENDING, flags);
+}
+
+/***************************************************************************************************
  * Implementation of tcm_test_global_state's member functions
  **************************************************************************************************/
 inline void tcm_tests_data::add_client(tcm_client_id_t client_id) {
@@ -259,8 +268,10 @@ inline void tcm_tests_data::remove_client(tcm_client_id_t client_id) {
     std::vector<tcm_client_id_t>::iterator new_end =
         std::remove_if(tcm_clients.begin(), tcm_clients.end(),
                        [client_id](tcm_client_id_t const& cid) { return cid == client_id; });
-    __TCM_ASSERT(new_end != tcm_clients.end(), "Not all clients were added");
-    __TCM_ASSERT(tcm_clients.end() - new_end == 1, "More than one client with same ID removed");
+    check(new_end != tcm_clients.end(), /*msg*/"", /*num_indents*/0,
+          /*report_msg*/"Not all clients were added");
+    check(tcm_clients.end() - new_end == 1, /*msg*/"", /*num_indents*/0,
+          /*report_msg*/"More than one client with same ID removed");
     tcm_clients.erase(new_end, tcm_clients.end());
 }
 

--- a/thread_composability_manager/test/concurrency_utils.h
+++ b/thread_composability_manager/test/concurrency_utils.h
@@ -74,7 +74,8 @@ private:
             }
 
             path_start = std::strchr(path_start + 3, ':') + 1;
-            __TCM_ASSERT(path_start <= last_char, "Too long path?");
+            check(path_start <= last_char, /*msg*/"", /*num_indents*/0, /*report_msg*/"Buffer length"
+                  " seems to be too small to store the path of CPU controller.");
             break;
         }
         return path_start;
@@ -191,7 +192,8 @@ private:
             return num_cpus;
         }
 
-        __TCM_ASSERT(std::strncmp(mnt_type, "cgroup", 6) == 0, "Unexpected cgroup type");
+        check(std::strncmp(mnt_type, "cgroup", 6) == 0, /*msg*/"", /*num_indents*/0,
+              /*report_msg*/"Unexpected cgroup type");
 
         if (try_read_cgroup_v1_num_cpus_from(mnt_dir, num_cpus))
             return num_cpus; // Successfully read number of CPUs for cgroup v1

--- a/thread_composability_manager/test/hwloc_test_utils.h
+++ b/thread_composability_manager/test/hwloc_test_utils.h
@@ -11,8 +11,6 @@
 #include <vector>
 #include <thread>               // for std::thread::hardware_concurrency
 
-#include "tcm/detail/_tcm_assert.h"
-
 #if _MSC_VER && !__INTEL_COMPILER && !__clang__
 #pragma warning( push )
 #pragma warning( disable : 4100 )
@@ -123,7 +121,7 @@ private:
             process_node_affinity_mask = hwloc_bitmap_alloc();
 
             auto r = hwloc_get_cpubind(topology, process_cpu_affinity_mask, 0);
-            __TCM_ASSERT_EX(r >= 0, "HWLOC get CPU bind error.");
+            check(r >= 0, /*msg*/"", /*num_indents*/0, /*report_msg*/"HWLOC get CPU bind error.");
             hwloc_cpuset_to_nodeset(topology, process_cpu_affinity_mask, process_node_affinity_mask);
         }
 
@@ -167,7 +165,8 @@ private:
 
                 counter++;
             } hwloc_bitmap_foreach_end();
-            __TCM_ASSERT(max_numa_index >= 0, "Maximal NUMA index must not be negative");
+            check(max_numa_index >= 0, /*msg*/"", /*num_indents*/0,
+                  /*report_msg*/"Maximal NUMA index must not be negative");
 
             // Fill concurrency and affinity masks lists
             numa_affinity_masks_list.resize(max_numa_index + 1);
@@ -180,7 +179,8 @@ private:
                 current_mask = hwloc_bitmap_dup(node_buffer->cpuset);
 
                 hwloc_bitmap_and(current_mask, current_mask, process_cpu_affinity_mask);
-                __TCM_ASSERT(!hwloc_bitmap_iszero(current_mask), "hwloc detected unavailable NUMA node");
+                check(!hwloc_bitmap_iszero(current_mask), /*msg*/"", /*num_indents*/0,
+                      /*report_msg*/"HWLOC detected unavailable NUMA node");
             } hwloc_bitmap_foreach_end();
         }
     }
@@ -192,7 +192,8 @@ private:
             return;
         }
 #if __TCM_HWLOC_HYBRID_CPUS_INTERFACES_PRESENT
-        __TCM_ASSERT(hwloc_get_api_version() >= 0x20400, "Hybrid CPUs support interfaces required HWLOC >= 2.4");
+        check(hwloc_get_api_version() >= 0x20400, /*msg*/"", /*num_indents*/0,
+              /*report_msg*/"Hybrid CPUs support interfaces required HWLOC >= 2.4");
         // Parsing the hybrid CPU topology
         int core_types_number = hwloc_cpukinds_get_nr(topology, 0);
         bool core_types_parsing_broken = core_types_number <= 0;
@@ -212,7 +213,8 @@ private:
                     if (hwloc_bitmap_weight(current_mask) > 0) {
                         core_types_indexes_list.push_back(core_type);
                     }
-                    __TCM_ASSERT(hwloc_bitmap_weight(current_mask) >= 0, "Infinivitely filled core type mask");
+                    check(hwloc_bitmap_weight(current_mask) >= 0, /*msg*/"", /*num_indents*/0,
+                          /*report_msg*/"Infinitely filled core type mask");
                 } else {
                     core_types_parsing_broken = true;
                     break;
@@ -284,18 +286,20 @@ public:
     }
 
     static system_topology& instance() {
-        __TCM_ASSERT(instance_ptr != nullptr, "Getting instance of non-constructed topology");
+        check(instance_ptr != nullptr, /*msg*/"", /*num_indents*/0,
+              /*report_msg*/"Getting instance of non-constructed topology");
         return *instance_ptr;
     }
 
     static void destroy() {
-        __TCM_ASSERT(instance_ptr != nullptr, "Destroying non-constructed topology");
+        check(instance_ptr != nullptr, /*msg*/"", /*num_indents*/0,
+              /*report_msg*/"Destroying non-constructed topology");
         delete instance_ptr;
         instance_ptr = nullptr;
     }
 
     system_topology() = default;
-    system_topology(const system_topology&) = delete; 
+    system_topology(const system_topology&) = delete;
     system_topology& operator=(const system_topology&) = delete;
 
     ~system_topology() {
@@ -320,7 +324,8 @@ public:
     }
 
     const hwloc_topology_t& get_topology() {
-        __TCM_ASSERT(instance_ptr != nullptr, "Getting of non-constructed topology");
+        check(instance_ptr != nullptr, /*msg*/"", /*num_indents*/0,
+              /*report_msg*/"Getting of non-constructed topology");
         return topology;
     }
 
@@ -328,7 +333,8 @@ public:
         int& _numa_nodes_count, int*& _numa_indexes_list,
         int& _core_types_count, int*& _core_types_indexes_list
     ) {
-        __TCM_ASSERT(is_topology_parsed(), "Trying to get access to uninitialized system_topology");
+        check(is_topology_parsed(), /*msg*/"", /*num_indents*/0,
+              /*report_msg*/"Trying to get access to uninitialized system_topology");
         _numa_nodes_count = numa_nodes_count;
         _numa_indexes_list = numa_indexes_list.data();
 
@@ -339,10 +345,14 @@ public:
     void fill_constraints_affinity_mask(affinity_mask input_mask, int numa_node_index,
                                         int core_type_index, int max_threads_per_core)
     {
-        __TCM_ASSERT(is_topology_parsed(), "Trying to get access to uninitialized system_topology");
-        __TCM_ASSERT(numa_node_index < (int)numa_affinity_masks_list.size(), "Wrong NUMA node id");
-        __TCM_ASSERT(core_type_index < (int)core_types_affinity_masks_list.size(), "Wrong core type id");
-        __TCM_ASSERT(max_threads_per_core == -1 || max_threads_per_core > 0, "Wrong max_threads_per_core");
+        check(is_topology_parsed(), /*msg*/"", /*num_indents*/0,
+              /*report_msg*/ "Trying to get access to uninitialized system_topology");
+        check(numa_node_index < (int)numa_affinity_masks_list.size(), /*msg*/"", /*num_indents*/0,
+              /*report_msg*/ "Wrong NUMA node id");
+        check(core_type_index < (int)core_types_affinity_masks_list.size(), /*msg*/"", /*num_indents*/0,
+              /*report_msg*/ "Wrong core type id");
+        check(max_threads_per_core == -1 || max_threads_per_core > 0, /*msg*/"", /*num_indents*/0,
+              /*report_msg*/ "Wrong max_threads_per_core");
 
         hwloc_cpuset_t constraints_mask = hwloc_bitmap_alloc();
         hwloc_cpuset_t core_mask = hwloc_bitmap_alloc();
@@ -392,7 +402,8 @@ public:
     }
 
     int get_default_concurrency(int numa_node_index, int core_type_index, int max_threads_per_core) {
-        __TCM_ASSERT(is_topology_parsed(), "Trying to get access to uninitialized system_topology");
+        check(is_topology_parsed(), /*msg*/"", /*num_indents*/0,
+              /*report_msg*/"Trying to get access to uninitialized system_topology");
 
         hwloc_cpuset_t constraints_mask = hwloc_bitmap_alloc();
         fill_constraints_affinity_mask(constraints_mask, numa_node_index, core_type_index, max_threads_per_core);
@@ -403,7 +414,8 @@ public:
     }
 
     unsigned get_process_concurrency() const {
-        __TCM_ASSERT(is_topology_parsed(), "Trying to get access to uninitialized system_topology");
+        check(is_topology_parsed(), /*msg*/"", /*num_indents*/0,
+              /*report_msg*/"Trying to get access to uninitialized system_topology");
 
         int process_concurrency = hwloc_bitmap_weight(process_cpu_affinity_mask);
         if (process_concurrency <= 0) {
@@ -417,12 +429,14 @@ public:
     }
 
     const_affinity_mask process_affinity_mask() {
-        __TCM_ASSERT(is_topology_parsed(), "Trying to get access to uninitialized system_topology");
+        check(is_topology_parsed(), /*msg*/"", /*num_indents*/0,
+              /*report_msg*/"Trying to get access to uninitialized system_topology");
         return process_cpu_affinity_mask;
     }
 
     affinity_mask allocate_process_affinity_mask() {
-        __TCM_ASSERT(is_topology_parsed(), "Trying to get access to uninitialized system_topology");
+        check(is_topology_parsed(), /*msg*/"", /*num_indents*/0,
+              /*report_msg*/"Trying to get access to uninitialized system_topology");
         return hwloc_bitmap_dup(process_cpu_affinity_mask);
     }
 
@@ -432,17 +446,17 @@ public:
 
     void store_current_affinity_mask( affinity_mask current_mask ) {
         auto result = hwloc_get_cpubind(topology, current_mask, HWLOC_CPUBIND_THREAD);
-        __TCM_ASSERT_EX(result >= 0, "hwloc_get_cpubind failed.");
+        check(result >= 0, /*msg*/"", /*num_indents*/0, /*report_msg*/"hwloc_get_cpubind failed.");
 
         hwloc_bitmap_and(current_mask, current_mask, process_cpu_affinity_mask);
-        __TCM_ASSERT(!hwloc_bitmap_iszero(current_mask),
-            "Current affinity mask must intersects with process affinity mask");
+        check(!hwloc_bitmap_iszero(current_mask), /*msg*/"", /*num_indents*/0,
+              /*report_msg*/"Current affinity mask does not intersect with process affinity mask");
     }
 
     void set_affinity_mask( const_affinity_mask mask ) {
         if (hwloc_bitmap_weight(mask) > 0) {
           auto result = hwloc_set_cpubind(topology, mask, HWLOC_CPUBIND_THREAD);
-          __TCM_ASSERT_EX(result >= 0, "hwloc_set_cpubind failed.");
+          check(result >= 0, /*msg*/"", /*num_indents*/0, /*report_msg*/"hwloc_set_cpubind failed.");
         }
     }
 };

--- a/thread_composability_manager/test/test_constrained_requests.cpp
+++ b/thread_composability_manager/test/test_constrained_requests.cpp
@@ -5,7 +5,6 @@
    SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 */
 
-#include "tcm/detail/_tcm_assert.h"
 #include "common_tests.h"
 #include "hwloc_test_utils.h"
 #include "test_utils.h"
@@ -47,9 +46,11 @@ public:
       mask = obj->cpuset;
       weight = hardware_concurrency(mask);
     }
-    __TCM_ASSERT(obj, "Failed to get the HWLOC object representing the first core. "
-                 "Has test been run on HW subset?");
-    __TCM_ASSERT(weight > 0, "Invalid mask of the first core. Has test been run on a HW subset?");
+    check(obj, /*msg*/"", /*num_indents*/0,
+          /*report_msg*/"Failed to get the HWLOC object representing the first core. "
+          "Has test been run on HW subset?");
+    check(weight > 0, /*msg*/"", /*num_indents*/0,
+          /*report_msg*/"Invalid mask of the first core. Has test been run on a HW subset?");
   }
 
   tcm_cpu_mask_t operator()() const {

--- a/thread_composability_manager/test/test_thread_pool.h
+++ b/thread_composability_manager/test/test_thread_pool.h
@@ -10,7 +10,6 @@
 
 #include "common_tests.h"
 
-#include "tcm/detail/_tcm_assert.h"
 #include "tcm.h"
 
 #include <atomic>

--- a/thread_composability_manager/test/test_utils.h
+++ b/thread_composability_manager/test/test_utils.h
@@ -14,7 +14,6 @@
 
 #include "hwloc_test_utils.h"
 #include "../src/utils.h"
-#include "tcm/detail/_tcm_assert.h"
 #include "tcm.h"
 
 #include <algorithm>
@@ -40,7 +39,7 @@ inline std::string to_string(const tcm_const_cpu_mask_t mask) {
 
 inline tcm_cpu_mask_t allocate_cpu_mask() { return hwloc_bitmap_alloc(); }
 inline void free_cpu_mask(tcm_cpu_mask_t mask) {
-  __TCM_ASSERT(mask, "CPU mask should not be nullptr");
+  check(mask, /*msg*/"", /*num_indents*/0, /*report_msg*/"CPU mask should not be nullptr");
   hwloc_bitmap_free(mask);
 }
 
@@ -51,7 +50,8 @@ struct mask_deleter {
 struct masks_guard_t {
   masks_guard_t(uint32_t size) : m_size(size) {}
   void operator()(tcm_cpu_mask_t* cpu_masks) const {
-    __TCM_ASSERT(cpu_masks, "Array of CPU masks cannot be nullptr");
+    check(cpu_masks, /*msg*/"", /*num_indents*/0,
+          /*report_msg*/"Array of CPU masks cannot be nullptr");
     for (uint32_t i = 0; i < m_size; ++i) {
       free_cpu_mask(cpu_masks[i]);
     }
@@ -62,33 +62,33 @@ private:
 };
 
 inline bool is_equal(tcm_const_cpu_mask_t mask_1, tcm_const_cpu_mask_t mask_2) {
-  __TCM_ASSERT(mask_1, "CPU mask should not be nullptr");
-  __TCM_ASSERT(mask_2, "CPU mask should not be nullptr");
+  check(mask_1, /*msg*/"", /*num_indents*/0, /*report_msg*/"CPU mask 1 should not be nullptr");
+  check(mask_2, /*msg*/"", /*num_indents*/0, /*report_msg*/"CPU mask 2 should not be nullptr");
   return hwloc_bitmap_compare(mask_1, mask_2) == 0;
 }
 
 inline bool is_intersect(tcm_const_cpu_mask_t mask_1, tcm_const_cpu_mask_t mask_2) {
-  __TCM_ASSERT(mask_1, "CPU mask should not be nullptr");
-  __TCM_ASSERT(mask_2, "CPU mask should not be nullptr");
+  check(mask_1, /*msg*/"", /*num_indents*/0, /*report_msg*/"CPU mask 1 should not be nullptr");
+  check(mask_2, /*msg*/"", /*num_indents*/0, /*report_msg*/"CPU mask 2 should not be nullptr");
   return hwloc_bitmap_intersects(mask_1, mask_2);
 }
 
 inline void copy(tcm_cpu_mask_t dst, tcm_const_cpu_mask_t src) {
-  __TCM_ASSERT(dst, "Destination CPU mask should not be nullptr");
-  __TCM_ASSERT(src, "Source CPU mask should not be nullptr");
-  int result = hwloc_bitmap_copy(dst, src);
-  __TCM_ASSERT_EX(0 == result, "Unable to copy the CPU mask");
+  check(dst, /*msg*/"", /*num_indents*/0, /*report_msg*/"Destination mask should not be nullptr");
+  check(src, /*msg*/"", /*num_indents*/0, /*report_msg*/"Source mask should not be nullptr");
+  const int result = hwloc_bitmap_copy(dst, src);
+  check(0 == result, /*msg*/"", /*num_indents*/0, /*report_msg*/"Unable to copy the CPU mask");
 }
 
 inline int32_t hardware_concurrency(tcm_const_cpu_mask_t mask) {
-  __TCM_ASSERT(mask, "CPU mask should not be nullptr");
+  check(mask, /*msg*/"", /*num_indents*/0, /*report_msg*/"CPU mask should not be nullptr");
   return int32_t(hwloc_bitmap_weight(mask));
 }
 
 constexpr float tcm_oversubscription_factor = 1.0f;
 
 inline int32_t tcm_concurrency(tcm_const_cpu_mask_t mask) {
-  __TCM_ASSERT(mask, "CPU mask should not be nullptr");
+  check(mask, /*msg*/"", /*num_indents*/0, /*report_msg*/"CPU mask should not be nullptr");
   return int32_t(tcm_oversubscription_factor * hardware_concurrency(mask));
 }
 
@@ -124,8 +124,10 @@ inline int32_t platform_tcm_concurrency() {
 inline void extract_first_n_bits_from_process_affinity_mask(tcm_cpu_mask_t result, int n_threads,
                                                             tcm_const_cpu_mask_t hint = nullptr)
 {
-  __TCM_ASSERT(result, "Result CPU mask should be pre-allocated on the caller side");
-  __TCM_ASSERT(hwloc_bitmap_iszero(result), "Result CPU mask should be empty");
+  check(result, /*msg*/"", /*num_indents*/0,
+        /*report_msg*/"Result CPU mask should be pre-allocated on the caller side");
+  check(hwloc_bitmap_iszero(result), /*msg*/"", /*num_indents*/0,
+        /*report_msg*/"Result CPU mask should be empty");
 
   int start_id = -1;
   if (hint)
@@ -368,7 +370,7 @@ inline bool check_permit(const tcm_permit_t& expected, tcm_permit_handle_t ph,
     msg = "check permit_handle=" + to_string(ph) + " is not nullptr";
   check(ph, msg, num_indents);
 
-  __TCM_ASSERT(expected.size > 0, "Permit size cannot be zero.");
+  check(expected.size > 0, /*msg*/"", /*num_indents*/0, /*report_msg*/"Permit size cannot be zero.");
   std::vector<uint32_t> concurrencies(expected.size, 0);
   std::unique_ptr<tcm_cpu_mask_t[], masks_guard_t> cpu_masks(nullptr, masks_guard_t(expected.size));
   if (expected.cpu_masks) {
@@ -589,7 +591,8 @@ public:
         if (allocate_mask)
             for (uint32_t i = 0; i < size; ++i) {
                 cpu_masks[i] = allocate_cpu_mask();
-                __TCM_ASSERT(cpu_masks[i], "Failed allocating CPU mask");
+                check(cpu_masks[i], /*msg*/"", /*num_indents*/0,
+                      /*report_msg*/"Failed allocating CPU mask");
             }
     }
 
@@ -598,7 +601,7 @@ public:
     uint32_t concurrency() { return get_permit_concurrency(permit); }
 
     tcm_const_cpu_mask_t cpu_mask(size_t idx = 0) {
-      __TCM_ASSERT(idx < size, "Index is out of range");
+      check(idx < size, /*msg*/"", /*num_indents*/0, /*report_msg*/"Index is out of range");
       return cpu_masks ? cpu_masks[idx] : nullptr;
     }
 private:
@@ -646,8 +649,9 @@ inline permit_t<size> make_active_permit(uint32_t expected_concurrency,
   permit.concurrencies[0] = expected_concurrency;
   if (allocate_mask) {
       for (int i = 0; i < size; ++i) {
-          __TCM_ASSERT(permit.cpu_masks[i], "Nothing to copy into");
-          __TCM_ASSERT(cpu_masks[i], "Nothing to copy from");
+          check(permit.cpu_masks[i], /*msg*/"", /*num_indents*/0,
+                /*report_msg*/"Nothing to copy into");
+          check(cpu_masks[i], /*msg*/"", /*num_indents*/0, /*report_msg*/"Nothing to copy from");
           hwloc_bitmap_copy(permit.cpu_masks[i], cpu_masks[i]);
       }
   }


### PR DESCRIPTION
### Description 
TCM asserts, work with HWLOC and environment are implementation details. They should not be visible
outside of the library. This also helps to make CMake packaging more straightforward.

During the move, some of the details were found used in the tests, which required replacing those
with alternatives available in the test framework. That is replacing all the `__TCM_ASSERT` macros
onto calls to `check` function, which will report only in case if its boolean expression turned out
`false`.