### PR TITLE
[CI] Add checks for exit codes of executed commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,8 +382,17 @@ jobs:
           cmake -G "${{ matrix.generator }}" -A x64 -DCMAKE_CXX_STANDARD=${{ matrix.std }} ${{ matrix.cmake_static }} `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} `
             -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DTBB_TEST_PREVIEW=${{ matrix.preview }} ..
+          if (!$?) {
+              throw "CMake failed, exit code $LastExitCode"
+          }
           cmake --build . --config ${{ matrix.build_type }} -j -v
+          if (!$?) {
+              throw "CMake failed, exit code $LastExitCode"
+          }
           ctest -C ${{ matrix.build_type }} --timeout ${env:TEST_TIMEOUT} --output-on-failure
+          if (!$?) {
+              throw "CTest failed, exit code $LastExitCode"
+          }
 
   linux-examples-testing:
     name: examples_${{ matrix.os }}_${{ matrix.cxx_compiler }}_cxx${{ matrix.std }}_${{ matrix.build_type }}_preview=${{ matrix.preview }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,11 +390,11 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} `
             -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DTBB_TEST_PREVIEW=${{ matrix.preview }} ..
           if (!$?) {
-              throw "CMake failed, exit code $LastExitCode"
+              throw "CMake configuration step failed, exit code $LastExitCode"
           }
           cmake --build . --config ${{ matrix.build_type }} -j -v
           if (!$?) {
-              throw "CMake failed, exit code $LastExitCode"
+              throw "CMake build step failed, exit code $LastExitCode"
           }
           ctest -C ${{ matrix.build_type }} --timeout ${env:TEST_TIMEOUT} --output-on-failure
           if (!$?) {
@@ -514,11 +514,11 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} `
             -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DTBB_TEST_PREVIEW=${{ matrix.preview }} -DTBB_TEST=OFF -DTBB_EXAMPLES=ON ..
           if (!$?) {
-              throw "CMake failed, exit code $LastExitCode"
+              throw "CMake configuration step of examples failed, exit code $LastExitCode"
           }
           cmake --build . -v --target light_test_examples
           if (!$?) {
-              throw "CMake failed, exit code $LastExitCode"
+              throw "CMake build step of examples failed, exit code $LastExitCode"
           }
 
   linux-doc-examples-testing:
@@ -589,13 +589,13 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} `
             -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} ${{ matrix.cmake_extra }} -DTBB_TEST=OFF -DTBB_DOC_EXAMPLES=ON ..
           if (!$?) {
-              throw "CMake failed, exit code $LastExitCode"
+              throw "CMake configuration step of examples from documentation failed, exit code $LastExitCode"
           }
           cmake --build . --config ${{ matrix.build_type }} -v --parallel --target build-doc-examples
           if (!$?) {
-              throw "CMake failed, exit code $LastExitCode"
+              throw "CMake build step of examples from documentation failed, exit code $LastExitCode"
           }
           ctest -C ${{ matrix.build_type }} --timeout ${env:TEST_TIMEOUT} --output-on-failure -L doc-examples
           if (!$?) {
-              throw "CTest failed, exit code $LastExitCode"
+              throw "CTest of examples from documentation failed, exit code $LastExitCode"
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run scan
         run: |
+          set -e -x -o pipefail
           sudo apt update && sudo apt install -y codespell
           ${GITHUB_WORKSPACE}/.github/scripts/codespell.sh `pwd`
 
@@ -65,6 +66,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run scan
         run: |
+          set -e -x -o pipefail
           command -v clang-format
           cp -r examples examples_formatted
           find examples_formatted -regex '.*\.\(cpp\|hpp\)' -exec clang-format -style=file -i {} \;
@@ -85,6 +87,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install prerequisites
         run: |
+          set -e -x -o pipefail
           pip3 install -U Jinja2
           pip3 install git+https://github.com/executablebooks/sphinx-book-theme.git
           pip3 install sphinx_design
@@ -92,6 +95,7 @@ jobs:
           mkdir html
       - name: Build documentation
         run: |
+          set -e -x -o pipefail
           export BUILD_TYPE=${BUILD_TYPE} && sphinx-build doc html
           tar -czvf html.tar.gz html/
       - name: Save docs
@@ -127,6 +131,7 @@ jobs:
           name: oneTBB-html-docs-${{ env.GITHUB_SHA_SHORT }}
       - name: Publish to github pages
         run: |
+          set -e -x -o pipefail
           tar -xvf html.tar.gz
           cd gh-pages
           rm -rf *
@@ -153,6 +158,7 @@ jobs:
           fetch-depth: 0
       - name: Run check
         run: |
+          set -e -x -o pipefail
           base_sha=${{ github.event.pull_request.base.sha }}
           current_year=$(date +%Y)
           apache_copyright_line="Licensed under the Apache License"
@@ -226,6 +232,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run testing
         run: |
+          set -e -x -o pipefail
           mkdir build && cd build
           cmake -DTBB4PY_BUILD=ON -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc ..
           make VERBOSE=1 -j${BUILD_CONCURRENCY} python_build
@@ -284,7 +291,7 @@ jobs:
       - name: Run testing
         shell: bash
         run: |
-          set -x
+          set -e -x -o pipefail
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_static }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DTBB_TEST_PREVIEW=${{ matrix.preview }} ..
@@ -328,7 +335,7 @@ jobs:
       - name: Run testing
         shell: bash
         run: |
-          set -x
+          set -e -x -o pipefail
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_static }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DTBB_TEST_PREVIEW=${{ matrix.preview }} ..
@@ -430,7 +437,7 @@ jobs:
       - name: Run testing
         shell: bash
         run: |
-          set -x
+          set -e -x -o pipefail
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} \
@@ -461,7 +468,7 @@ jobs:
       - name: Run testing
         shell: bash
         run: |
-          set -x
+          set -e -x -o pipefail
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} \
@@ -506,7 +513,13 @@ jobs:
           cmake -G "${{ matrix.generator }}" -A x64 -DCMAKE_CXX_STANDARD=${{ matrix.std }} `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} `
             -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DTBB_TEST_PREVIEW=${{ matrix.preview }} -DTBB_TEST=OFF -DTBB_EXAMPLES=ON ..
+          if (!$?) {
+              throw "CMake failed, exit code $LastExitCode"
+          }
           cmake --build . -v --target light_test_examples
+          if (!$?) {
+              throw "CMake failed, exit code $LastExitCode"
+          }
 
   linux-doc-examples-testing:
     name: doc_examples_${{ matrix.os }}_${{ matrix.cxx_compiler }}_cxx${{ matrix.std }}_${{ matrix.build_type }}_${{ matrix.cmake_extra }}
@@ -539,7 +552,7 @@ jobs:
           fi
       - name: Test doc examples
         run: |
-          set -x
+          set -e -x -o pipefail
           mkdir build && cd build
           cmake -G "${{ matrix.generator }}" -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} \
@@ -575,5 +588,14 @@ jobs:
           cmake -G "${{ matrix.generator }}" -A x64 -DCMAKE_CXX_STANDARD=${{ matrix.std }} `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} `
             -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} ${{ matrix.cmake_extra }} -DTBB_TEST=OFF -DTBB_DOC_EXAMPLES=ON ..
+          if (!$?) {
+              throw "CMake failed, exit code $LastExitCode"
+          }
           cmake --build . --config ${{ matrix.build_type }} -v --parallel --target build-doc-examples
+          if (!$?) {
+              throw "CMake failed, exit code $LastExitCode"
+          }
           ctest -C ${{ matrix.build_type }} --timeout ${env:TEST_TIMEOUT} --output-on-failure -L doc-examples
+          if (!$?) {
+              throw "CTest failed, exit code $LastExitCode"
+          }


### PR DESCRIPTION
There were no checks for errors of the commands executed in CI. This patch adds those, which immediately allowed to catch the error in [this failing job](https://github.com/uxlfoundation/oneTBB/actions/runs/28362474698/job/84020183007?pr=2112). [Its recent runs](https://github.com/uxlfoundation/oneTBB/actions/runs/28233878282/job/83643931274?pr=2110#step:5:40) were misleadingly successful.