### PR TITLE
[CI] Update Windows job windows-2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,13 +351,13 @@ jobs:
       matrix:
         include:
           - os: windows-2025
-            generator: Visual Studio 17 2022
+            generator: Visual Studio 18 2026
             c_compiler: cl
             cxx_compiler: cl
             std: 14
             build_type: relwithdebinfo
             preview: 'ON'
-            job_name: windows_cl2022_cxx14_relwithdebinfo_preview=ON
+            job_name: windows_cl2026_cxx14_relwithdebinfo_preview=ON
           - os: windows-11-arm
             generator: Visual Studio 17 2022
             c_compiler: cl


### PR DESCRIPTION
In accordance with [updated Windows images](https://github.com/actions/runner-images/blob/win25-vs2026/20260622.153/images/windows/Windows2025-VS2026-Readme.md), Visual Studio 17 2022 is no longer available, which caused [silent error in the CI](https://github.com/uxlfoundation/oneTBB/actions/runs/28233878282/job/83643931274?pr=2110#step:5:40).