### PR TITLE
[DOCTEST] Suppress MSVC warning about incorrect std::tuple specialization

### DIFF
--- a/test/common/doctest.h
+++ b/test/common/doctest.h
@@ -554,7 +554,9 @@ template <class charT, class traits>
 class basic_istream;
 typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
 template <class... Types>
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(5285) // Cannot declare a specialization for 'std::tuple'
 class tuple;
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
 // see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
 template <class Ty>


### PR DESCRIPTION
A more standard-compliant approach based on inclusion of standard headers caused warnings in standard headers about mismatched type comparison. See more info at: https://github.com/doctest/doctest/blob/master/doc/markdown/configuration.md#doctest_config_use_std_headers