### PR TITLE
Check that OS return non-zero system page size

### DIFF
--- a/src/tbb/misc.cpp
+++ b/src/tbb/misc.cpp
@@ -69,7 +69,7 @@ size_t DefaultSystemPageSize() {
 #else
     long page_size = sysconf(_SC_PAGESIZE);
     __TBB_ASSERT_RELEASE(page_size > 0, "Failed to get system page size");
-    return page_size;
+    return static_cast<size_t>(page_size);
 #endif
 }
 

--- a/src/tbb/misc.cpp
+++ b/src/tbb/misc.cpp
@@ -64,9 +64,12 @@ size_t DefaultSystemPageSize() {
 #if _WIN32
     SYSTEM_INFO si;
     GetSystemInfo(&si);
+    __TBB_ASSERT_RELEASE(si.dwPageSize > 0, "Failed to get system page size");
     return si.dwPageSize;
 #else
-    return sysconf(_SC_PAGESIZE);
+    long page_size = sysconf(_SC_PAGESIZE);
+    __TBB_ASSERT_RELEASE(page_size > 0, "Failed to get system page size");
+    return page_size;
 #endif
 }
 


### PR DESCRIPTION
### Description 

System page size is acquired from OS, it's reasonable to check that it's valid.