### PR TITLE
Make task_arena constants constexpr

### DIFF
--- a/doc/main/specification/source/task_scheduler/task_arena/task_arena_cls.rst
+++ b/doc/main/specification/source/task_scheduler/task_arena/task_arena_cls.rst
@@ -19,8 +19,8 @@ A class that represents an explicit, user-managed task scheduler arena.
 
             class task_arena {
             public:
-                static const int automatic = /* unspecified */;
-                static const int not_initialized = /* unspecified */;
+                static constexpr int automatic = /* unspecified */;
+                static constexpr int not_initialized = /* unspecified */;
                 enum class priority : /* unspecified type */ {
                     low = /* unspecified */,
                     normal = /* unspecified */,

--- a/include/oneapi/tbb/task_arena.h
+++ b/include/oneapi/tbb/task_arena.h
@@ -244,12 +244,12 @@ protected:
 
 public:
     //! Typedef for number of threads that is automatic.
-    static const int automatic = -1;
+    static constexpr int automatic = -1;
     //! Typedef for current thread index in an uninitialized arena.
-    static const int not_initialized = -2;
+    static constexpr int not_initialized = -2;
 #if __TBB_PREVIEW_TASK_ARENA_CORE_TYPE_SELECTOR
     //! Typedef for core type(s) to be specified by the provided selector.
-    static const int selectable = -2;
+    static constexpr int selectable = -2;
 #endif
 };
 

--- a/test/common/utils.h
+++ b/test/common/utils.h
@@ -508,6 +508,12 @@ inline size_t NonZero(void *ptr, size_t size)
     return 0;
 }
 
+template <typename T>
+T force_constant_odr_use(const T& value) {
+    volatile const T* addr = &value;
+    return *addr;
+}
+
 } // namespace utils
 
 #endif // __TBB_test_common_utils_H

--- a/test/tbb/test_arena_constraints.cpp
+++ b/test/tbb/test_arena_constraints.cpp
@@ -265,3 +265,13 @@ TEST_CASE("Using custom assertion handler to test failure on invalid constraints
         tbb::info::default_concurrency(tbb::task_arena::constraints{}.set_max_threads_per_core(0)),
         "Wrong max_threads_per_core constraints field value.");
 }
+
+#if __TBB_CPP17_PRESENT
+//! \brief \ref regression
+TEST_CASE("ODR-use task_arena::selectable") {
+    CHECK(utils::force_constant_odr_use(tbb::task_arena::selectable) == tbb::task_arena::selectable);
+
+    auto task_arena_ptr = std::make_unique<tbb::task_arena>(tbb::task_arena::automatic);
+    CHECK(task_arena_ptr != nullptr);
+}
+#endif // __TBB_CPP17_PRESENT

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -2244,3 +2244,22 @@ TEST_CASE("Test enqueue guarantees when task_arena is combined with task_group")
 }
 
 #endif // TBB_USE_EXCEPTIONS
+
+#if __TBB_CPP17_PRESENT
+int force_constant_odr_use(const int& value) {
+    volatile const int* addr = &value;
+    return *addr;
+}
+
+//! \brief \ref regression
+TEST_CASE("ODR-use task_arena constants") {
+    CHECK(force_constant_odr_use(tbb::task_arena::automatic) == tbb::task_arena::automatic);
+    CHECK(force_constant_odr_use(tbb::task_arena::not_initialized) == tbb::task_arena::not_initialized);
+#if __TBB_PREVIEW_TASK_ARENA_CORE_TYPE_SELECTOR
+    CHECK(force_constant_odr_use(tbb::task_arena::selectable) == tbb::task_arena::selectable);
+#endif
+
+    auto task_arena_ptr = std::make_unique<tbb::task_arena>(tbb::task_arena::automatic);
+    CHECK(task_arena_ptr != nullptr);
+}
+#endif // __TBB_CPP17_PRESENT

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -42,6 +42,7 @@
 #include <stdexcept>
 #include <thread>
 #include <vector>
+#include <memory>
 
 //#include "harness_fp.h"
 

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -2247,18 +2247,10 @@ TEST_CASE("Test enqueue guarantees when task_arena is combined with task_group")
 #endif // TBB_USE_EXCEPTIONS
 
 #if __TBB_CPP17_PRESENT
-int force_constant_odr_use(const int& value) {
-    volatile const int* addr = &value;
-    return *addr;
-}
-
 //! \brief \ref regression
 TEST_CASE("ODR-use task_arena constants") {
-    CHECK(force_constant_odr_use(tbb::task_arena::automatic) == tbb::task_arena::automatic);
-    CHECK(force_constant_odr_use(tbb::task_arena::not_initialized) == tbb::task_arena::not_initialized);
-#if __TBB_PREVIEW_TASK_ARENA_CORE_TYPE_SELECTOR
-    CHECK(force_constant_odr_use(tbb::task_arena::selectable) == tbb::task_arena::selectable);
-#endif
+    CHECK(utils::force_constant_odr_use(tbb::task_arena::automatic) == tbb::task_arena::automatic);
+    CHECK(utils::force_constant_odr_use(tbb::task_arena::not_initialized) == tbb::task_arena::not_initialized);
 
     auto task_arena_ptr = std::make_unique<tbb::task_arena>(tbb::task_arena::automatic);
     CHECK(task_arena_ptr != nullptr);


### PR DESCRIPTION
### Description 
Make `task_arena::automatic`, `not_initialized` and `selectable` constexpr to allow their ODR use in scenarios like `std::make_unique<tbb::task_arena>(tbb::task_arena::automatic)` from C++17.


Fixes #529 

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
