### PR TITLE
Backport of constrained nested arena slot index handling fix to 2021.13 ov

### DIFF
--- a/include/oneapi/tbb/version.h
+++ b/include/oneapi/tbb/version.h
@@ -32,7 +32,7 @@
 // Update version
 #define TBB_VERSION_MINOR 13
 // "Patch" version for custom releases
-#define TBB_VERSION_PATCH 2
+#define TBB_VERSION_PATCH 3
 // Suffix string
 #define __TBB_VERSION_SUFFIX ""
 // Full official version string

--- a/include/oneapi/tbb/version.h
+++ b/include/oneapi/tbb/version.h
@@ -45,7 +45,7 @@
 // OneAPI oneTBB specification version
 #define ONETBB_SPEC_VERSION "1.0"
 // Full interface version
-#define TBB_INTERFACE_VERSION 12132
+#define TBB_INTERFACE_VERSION 12133
 // Major interface version
 #define TBB_INTERFACE_VERSION_MAJOR (TBB_INTERFACE_VERSION/1000)
 // Minor interface version

--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -535,7 +536,8 @@ void __TBB_EXPORTED_FUNC enqueue(d1::task& t, d1::task_group_context& ctx, d1::t
 
 void task_arena_impl::initialize(d1::task_arena_base& ta) {
     // Enforce global market initialization to properly initialize soft limit
-    (void)governor::get_thread_data();
+    thread_data* td = governor::get_thread_data();
+    assert_pointer_valid(td, "thread_data pointer should not be null");
     d1::constraints arena_constraints;
 
 #if __TBB_ARENA_BINDING
@@ -557,9 +559,15 @@ void task_arena_impl::initialize(d1::task_arena_base& ta) {
     numa_binding_observer* observer = construct_binding_observer(
         static_cast<d1::task_arena*>(&ta), arena::num_arena_slots(ta.my_max_concurrency, ta.my_num_reserved_slots),
         ta.my_numa_id, ta.core_type(), ta.max_threads_per_core());
+    // Apply the constraints to this thread and make it appear as slot 0 during arena initialization.
+    const d1::slot_id current_slot = td->my_arena_index;
     if (observer) {
         // TODO: Consider lazy initialization for internal arena so
-        // the direct calls to observer might be omitted until actual initialization. 
+        // the direct calls to observer might be omitted until actual initialization.
+        // Early observer entry is used here to ensure that the thread allocating and initializing the arena
+        // has the same affinity as the future arena. While this violates the typical attach => notify protocol
+        // (see execute method), it may provide performance benefits (e.g., first-touch memory effects).
+        td->my_arena_index = 0;
         observer->on_scheduler_entry(true);
     }
 #endif /*__TBB_CPUBIND_PRESENT*/
@@ -572,9 +580,11 @@ void task_arena_impl::initialize(d1::task_arena_base& ta) {
     ta.my_arena.store(&a, std::memory_order_release);
 #if __TBB_CPUBIND_PRESENT
     a.my_numa_binding_observer = observer;
+    // Restore the constraints and the current slot index.
     if (observer) {
         observer->on_scheduler_exit(true);
         observer->observe(true);
+        td->my_arena_index = current_slot;
     }
 #endif /*__TBB_CPUBIND_PRESENT*/
 }

--- a/test/tbb/test_arena_constraints.cpp
+++ b/test/tbb/test_arena_constraints.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2019-2023 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -86,6 +87,44 @@ TEST_CASE("Test constraints propagation during arenas copy construction") {
 
         test_constraints_affinity_and_concurrency(constraints, copied_affinity);
     }
+}
+
+//! Test that initializing a constrained nested arena of smaller size does not cause out of range access in TBBBind
+//! \brief \ref regression
+TEST_CASE("Test constrained nested arena of smaller size") {
+    int n = tbb::this_task_arena::max_concurrency();
+    if (n <= 1) {
+        return; // Need the outer arena to be bigger than the nested arena.
+    }
+
+    using namespace tbb::info;
+    system_info::initialize();
+
+    tbb::task_arena::constraints c{numa_nodes().back()};
+    c.set_core_type(core_types().back());
+    c.set_max_threads_per_core(1);
+    c.set_max_concurrency(1); // Make the constrained arena smaller than the outer arena, which has n > 1 threads.
+
+    system_info::affinity_mask outer_affinity = system_info::allocate_current_affinity_mask();
+    utils::SpinBarrier barrier(n);
+
+    // parallel_for body runs in the implicit arena, which spans all available threads.
+    tbb::parallel_for(0, n, [&](int) {
+        // TBBBind changes thread affinity when entering the smaller constrained arena and restores it on exit.
+        // current_thread_index() exceeding the smaller arena size no longer causes out of range access in TBBBind.
+        tbb::task_arena{c}.execute([&] {
+            system_info::affinity_mask inner_affinity = system_info::allocate_current_affinity_mask();
+            REQUIRE_MESSAGE(hwloc_bitmap_isincluded(inner_affinity, outer_affinity),
+                "Nested constrained arena affinity mask is not a subset of the outer affinity mask.");
+
+            // Indirectly verify that TBBBind applied the affinity for this arena.
+            if (tbb::detail::r1::constraints_default_concurrency(c) < n) { // affinity mask should be smaller
+                REQUIRE_MESSAGE(!hwloc_bitmap_isequal(inner_affinity, outer_affinity),
+                    "TBBBind did not apply affinity: the nested arena mask was not narrowed.");
+            }
+        });
+        barrier.wait();
+    }, tbb::simple_partitioner{});
 }
 #endif /*__TBB_HWLOC_VALID_ENVIRONMENT && __HWLOC_CPUBIND_PRESENT */
 


### PR DESCRIPTION
### Description 
Backport of constrained nested arena slot index handling fix (from #2121):

Set thread slot index to 0 during constrained arena init and restore it after, preventing out-of-range access with TBBBind that could occur when a worker of a large outer arena constructed a smaller constrained arena (the worker's slot index can exceed the new arena size).

### Type of change
- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests
- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation
- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown