### PR TITLE
[TCM] Correct renegotiating for two requests w/o hyperthreading

### DIFF
--- a/thread_composability_manager/src/tcm.cpp
+++ b/thread_composability_manager/src/tcm.cpp
@@ -1549,7 +1549,7 @@ protected:
         std::unique_ptr<tcm_cpu_mask_t, cpu_mask_deleter_t> unique_result_mask(&per_constraint_union_mask);
         std::unique_ptr<tcm_cpu_mask_t, cpu_mask_deleter_t> unique_common_mask(&common_mask);
 
-        hwloc_bitmap_or(common_mask, common_mask, mask);
+        hwloc_bitmap_copy(common_mask, mask);
         uint32_t common_concurrency = 0;
 
         // min_required is the maximum among the amount of unavailable resources needed
@@ -1625,7 +1625,9 @@ protected:
                         hwloc_bitmap_or(per_constraint_union_mask, mask, cpu_mask);
                         const int mc = get_oversubscribed_mask_concurrency(per_constraint_union_mask);
                         __TCM_ASSERT(uint32_t(mc) >= granted, "Incorrectly granted permit detected.");
-                        const int available = mc - granted;
+                        // Avoid double counting of current grant of being satisfied permit when
+                        // caching available for immediate grant at the end
+                        const int available = mc - granted - int(current_concurrency);
                         available_min = std::min(available_min, available);
                         const auto fitting_result =
                             try_fit_concurrency(constraint_min, constraint_max, available);
@@ -1647,7 +1649,9 @@ protected:
                         common_concurrency += granted;
                         __TCM_ASSERT(uint32_t(mc) >= common_concurrency,
                                      "Incorrectly granted permit detected.");
-                        const int available = mc - common_concurrency;
+                        // Avoid double counting of current grant of being satisfied permit when
+                        // caching available for immediate grant at the end
+                        const int available = mc - common_concurrency - int(current_concurrency);
                         available_min = std::min(available_min, available);
                         const auto fitting_result =
                             try_fit_concurrency(constraint_min, constraint_max, available);
@@ -1698,7 +1702,9 @@ protected:
                     __TCM_ASSERT(uint32_t(mc) >= common_concurrency,
                                  "Incorrectly granted permit is detected.");
 
-                    const int available = mc - common_concurrency;
+                    // Avoid double counting of current grant of being satisfied permit when caching
+                    // available for immediate grant at the end
+                    const int available = mc - common_concurrency - int(current_concurrency);
                     available_min = std::min(available_min, available);
                     auto fitting_result = try_fit_concurrency(constraint_min, constraint_max, available);
                     if (!fitting_result.is_required_satisfied)

--- a/thread_composability_manager/test/test_constrained_requests.cpp
+++ b/thread_composability_manager/test/test_constrained_requests.cpp
@@ -451,8 +451,6 @@ TEST("Two constrained requests oversubscribing first core") {
 void test_two_requests_not_oversubscribe_after_renegotiation(tcm_cpu_constraints_t constraints,
                                                              const int32_t constraints_capacity)
 {
-  one_thread_per_core_mask region{};
-
   tcm_client_id_t clidA = connect_new_client();
 
   // A takes the whole shared region.

--- a/thread_composability_manager/test/test_constrained_requests.cpp
+++ b/thread_composability_manager/test/test_constrained_requests.cpp
@@ -451,23 +451,23 @@ TEST("Two constrained requests oversubscribing first core") {
 void test_two_requests_not_oversubscribe_after_renegotiation(tcm_cpu_constraints_t constraints,
                                                              const int32_t constraints_capacity)
 {
-  tcm_client_id_t clidA = connect_new_client();
+  tcm_client_id_t client_id = connect_new_client();
 
   // A takes the whole shared region.
   tcm_permit_handle_t phA = request_permit(
-      clidA, make_request(tcm_automatic, constraints_capacity, &constraints, 1));
+      client_id, make_request(tcm_automatic, constraints_capacity, &constraints, 1));
   check(get_permit_data(phA).concurrency() == uint32_t(constraints_capacity),
         "Permit A occupies the whole shared region");
 
   // B requests the same region; A is negotiated down so that A and B together fit the region.
   tcm_permit_handle_t phB = request_permit(
-      clidA, make_request(tcm_automatic, constraints_capacity, &constraints, 1));
+      client_id, make_request(tcm_automatic, constraints_capacity, &constraints, 1));
   check(get_permit_data(phA).concurrency() + get_permit_data(phB).concurrency() ==
         uint32_t(constraints_capacity),
         "Permits A and B together fully but exactly subscribe the shared region");
 
   // C occupies the resources outside the shared region (the sibling hardware threads).
-  tcm_permit_handle_t phC = request_permit(clidA, make_request(1, platform_tcm_concurrency()));
+  tcm_permit_handle_t phC = request_permit(client_id, make_request(1, platform_tcm_concurrency()));
   check(get_permit_data(phC).concurrency() ==
         uint32_t(platform_tcm_concurrency() - constraints_capacity),
         "Permit C occupies the rest of resources, outside the region");
@@ -481,12 +481,12 @@ void test_two_requests_not_oversubscribe_after_renegotiation(tcm_cpu_constraints
   check(grantA + grantB <= uint32_t(constraints_capacity),
         "Shared region is not oversubscribed after renegotiation", /*num_indents*/0,
         /*report_msg*/"A grant=" + std::to_string(grantA) + ", B grant=" + std::to_string(grantB) +
-                      ", region capacity=" + std::to_string(constraints_capacity));
+        ", region capacity=" + std::to_string(constraints_capacity));
 
   release_permit(phA);
   release_permit(phB);
 
-  disconnect_client(clidA);
+  disconnect_client(client_id);
 }
 
 TEST("Two constrained requests do not oversubscribe a shared region after renegotiation") {

--- a/thread_composability_manager/test/test_constrained_requests.cpp
+++ b/thread_composability_manager/test/test_constrained_requests.cpp
@@ -96,6 +96,28 @@ public:
   int32_t id() { return numa_id; }
 };
 
+class one_thread_per_core_mask {
+  int32_t weight;
+  tcm_cpu_mask_t cpu_mask;
+
+public:
+  one_thread_per_core_mask() : weight(0), cpu_mask(allocate_cpu_mask()) {
+    auto& topology = tcm_test::system_topology::instance();
+    topology.fill_constraints_affinity_mask(cpu_mask,
+                                            /*numa_id*/tcm_automatic,
+                                            /*core_type_id*/tcm_automatic,
+                                            /*max_threads_per_core*/1);
+    weight = tcm_concurrency(cpu_mask);
+  }
+  ~one_thread_per_core_mask() { free_cpu_mask(cpu_mask); }
+
+  one_thread_per_core_mask(const one_thread_per_core_mask&) = delete;
+  one_thread_per_core_mask& operator=(const one_thread_per_core_mask&) = delete;
+
+  tcm_cpu_mask_t mask() const { return cpu_mask;}
+  int32_t capacity() const { return weight; }
+};
+
 TEST("test_allow_mask_omitting_during_permit_copy") {
     tcm_client_id_t client_id = connect_new_client();
 
@@ -424,6 +446,83 @@ TEST("Two constrained requests oversubscribing first core") {
   test_config.new_stateB = TCM_PERMIT_STATE_ACTIVE;
 
   test_two_requests<first_core_mask, first_core_mask>{test_config}();
+}
+
+void test_two_requests_not_oversubscribe_after_renegotiation(tcm_cpu_constraints_t constraints,
+                                                             const int32_t constraints_capacity)
+{
+  one_thread_per_core_mask region{};
+
+  tcm_client_id_t clidA = connect_new_client();
+
+  // A takes the whole shared region.
+  tcm_permit_handle_t phA = request_permit(
+      clidA, make_request(tcm_automatic, constraints_capacity, &constraints, 1));
+  check(get_permit_data(phA).concurrency() == uint32_t(constraints_capacity),
+        "Permit A occupies the whole shared region");
+
+  // B requests the same region; A is negotiated down so that A and B together fit the region.
+  tcm_permit_handle_t phB = request_permit(
+      clidA, make_request(tcm_automatic, constraints_capacity, &constraints, 1));
+  check(get_permit_data(phA).concurrency() + get_permit_data(phB).concurrency() ==
+        uint32_t(constraints_capacity),
+        "Permits A and B together fully but exactly subscribe the shared region");
+
+  // C occupies the resources outside the shared region (the sibling hardware threads).
+  tcm_permit_handle_t phC = request_permit(clidA, make_request(1, platform_tcm_concurrency()));
+  check(get_permit_data(phC).concurrency() ==
+        uint32_t(platform_tcm_concurrency() - constraints_capacity),
+        "Permit C occupies the rest of resources, outside the region");
+
+  // Releasing C frees resources and triggers renegotiation of the still-active A and B. The freed
+  // resources are outside the shared region, so they must not be granted inside the full region.
+  release_permit(phC);
+
+  const uint32_t grantA = get_permit_data(phA).concurrency();
+  const uint32_t grantB = get_permit_data(phB).concurrency();
+  check(grantA + grantB <= uint32_t(constraints_capacity),
+        "Shared region is not oversubscribed after renegotiation", /*num_indents*/0,
+        /*report_msg*/"A grant=" + std::to_string(grantA) + ", B grant=" + std::to_string(grantB) +
+                      ", region capacity=" + std::to_string(constraints_capacity));
+
+  release_permit(phA);
+  release_permit(phB);
+
+  disconnect_client(clidA);
+}
+
+TEST("Two constrained requests do not oversubscribe a shared region after renegotiation") {
+    one_thread_per_core_mask region{};
+
+    // The over-subscription can only manifest when the shared region has room for more than one
+    // resource (so that two permits can co-exist in it) and there are sibling threads outside of it
+    // (so that a third, unrelated permit can hold resources whose release triggers renegotiation).
+    const int32_t region_capacity = region.capacity();
+    if (region_capacity < 2 || platform_tcm_concurrency() <= region_capacity) {
+        test_log("Skipping: the platform lacks an SMT-enabled multi-core region required by this test "
+                 "(region capacity=" + std::to_string(region_capacity) +
+                 ", process concurrency=" + std::to_string(platform_tcm_concurrency()) + ").");
+        return;
+    }
+
+    {
+        test_log("\nSUBCASE START: Using low level constraints");
+        tcm_cpu_constraints_t low_level_constraints = TCM_PERMIT_REQUEST_CONSTRAINTS_INITIALIZER;
+        low_level_constraints.mask = region.mask();
+        low_level_constraints.min_concurrency = 1;
+        test_two_requests_not_oversubscribe_after_renegotiation(low_level_constraints,
+                                                                region_capacity);
+        test_log("SUBCASE END: Using low level constraints\n");
+    }
+    {
+        test_log("\nSUBCASE START: Using high level constraints");
+        tcm_cpu_constraints_t high_level_constraints = TCM_PERMIT_REQUEST_CONSTRAINTS_INITIALIZER;
+        high_level_constraints.threads_per_core = 1;
+        high_level_constraints.min_concurrency = 1;
+        test_two_requests_not_oversubscribe_after_renegotiation(high_level_constraints,
+                                                                region_capacity);
+        test_log("SUBCASE END: Using high level constraints\n");
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
Fix and a regression test for over-subscription of a constrained CPU region during renegotiation.

Two active permits (A and B) share the same constrained region - the "one hardware thread per core" mask. That region has a capacity equal to the number of cores, while the process still owns the sibling hardware threads outside of it.

The bug: while computing how much can be granted to a permit that already owns some resources in
the shared region, try_satisfy() treated the region capacity minus the *competitors'* grants as
immediately available, and then added the permit's *own* current grant on top - double counting
the slots the permit already occupies. As a result a renegotiation triggered by freeing an
unrelated resource would grant one of the permits more than the region can hold, ending up with
(A_grant + B_grant) > region capacity. That later trips the "Incorrectly granted permit detected"
assertion in try_satisfy() when the over-subscribed region is scanned again.

The scenario in the test deterministically reconstructs that state:
  1. A requests the shared region and is granted the whole of it.
  2. B requests the same region; TCM negotiates A down so that A + B == capacity.
  3. C grabs the free sibling threads (the resources outside the region).
  4. Releasing C triggers renegotiate_permits(), whose active-permit saturation loop tries to
     grow A or B back towards its desired concurrency. With the bug this over-grants inside the
     already-full region.
The invariant checked is that the grants of the two permits sharing the region never exceed the
region capacity.
