### PR TITLE
Move resource_limited_node RFC to experimental

### DIFF
--- a/rfcs/experimental/flow_graph_resource_limiting/resource_limited_node_api.md
+++ b/rfcs/experimental/flow_graph_resource_limiting/resource_limited_node_api.md
@@ -1,12 +1,12 @@
 # Resource-Limited Node API for the Flow Graph
 
-Note: This document is a sub-RFC for the [Resource-limited Nodes RFC](./README.md).
+Note: This document is a sub-RFC for the [Resource-limited Nodes RFC](../../proposed/flow_graph_serializers/README.md).
 
 ## Table of Contents
 
 * 1 [Feature Design](#feature-design)
   * 1.1 [Terminology](#terminology)
-  * 1.2 [Proposed Design](#proposed-design)
+  * 1.2 [Preview Feature High-level Design](#preview-feature-high-level-design)
   * 1.3 [API Details](#api-details)
   * 1.4 [API Specification](#api-specification)
     * 1.4.1 [`oneapi::tbb::flow::resource_limiter` Class](#oneapitbbflowresource_limiter-class)
@@ -20,7 +20,7 @@ Note: This document is a sub-RFC for the [Resource-limited Nodes RFC](./README.m
 
 ## Feature Design
 
-As described in the [parent RFC](./README.md),
+As described in the [parent RFC](../../proposed/flow_graph_serializers/README.md),
 the current Flow Graph functional nodes API provides only a mechanism for limiting the number of bodies executed in parallel.
 However, since limiting only the concurrency of a single node does not satisfy
 some use cases, the API should be extended to support limiting access to shared resources across several nodes in the graph.
@@ -35,10 +35,10 @@ some use cases, the API should be extended to support limiting access to shared 
 
 *Protocol* - a set of rules and actions that define the relationship between a consumer and a provider.
 
-### Proposed Design
+### Preview Feature High-level Design
 
-It is proposed to extend the current Flow Graph API with two entities representing a *Provider* and a *Consumer* of one or several
-*Resources* and to implement a *Protocol* with unspecified details.
+The preview feature extends the Flow Graph API with two entities representing a *Provider* and a *Consumer* of one or several
+*Resources* and is implementing a *Protocol* with unspecified details.
 
 ```cpp
 namespace oneapi {
@@ -338,8 +338,8 @@ auto node_body = [](input i, auto& ports, void* resource_handle_ptr1, void* reso
     * `rc_multifunction_node`
     * `resource_limited_multifunction_node`
     * `resource_consumer_multifunction_node`
-2. Should a Resource-Limited alternative for `function_node` be provided?
-3. Should the experimental version of `resource_limited_node` support node priorities?
+2. Should a Resource-Limited alternative for other node types be provided?
+3. How `resource_limited_node` should support node priorities?
 4. Should the `output_ports()` member function be provided by `resource_limited_node`?
 5. Should the `rejecting` alternative be provided for `resource_limited_node`?
 6. Instead of a separate node type, should `resource_limited` be considered as a policy for existing functional nodes?
@@ -351,7 +351,8 @@ auto node_body = [](input i, auto& ports, void* resource_handle_ptr1, void* reso
 
 ### ROOT, GENIE and DB Example
 
-Consider implementing the flow graph described in the [parent RFC](./README.md#implementation-experience).
+Consider implementing the flow graph described in the
+[parent RFC](../../proposed/flow_graph_serializers/README.md#implementation-experience).
 Below is an example of how to implement it using proposed API.
 
 ```cpp

--- a/rfcs/experimental/flow_graph_resource_limiting/resource_limited_node_api.md
+++ b/rfcs/experimental/flow_graph_resource_limiting/resource_limited_node_api.md
@@ -38,7 +38,7 @@ some use cases, the API should be extended to support limiting access to shared 
 ### Preview Feature High-level Design
 
 The preview feature extends the Flow Graph API with two entities representing a *Provider* and a *Consumer* of one or several
-*Resources* and is implementing a *Protocol* with unspecified details.
+*Resources* and implements a *Protocol* with unspecified details.
 
 ```cpp
 namespace oneapi {

--- a/rfcs/experimental/flow_graph_resource_limiting/resource_limited_node_api.md
+++ b/rfcs/experimental/flow_graph_resource_limiting/resource_limited_node_api.md
@@ -339,7 +339,7 @@ auto node_body = [](input i, auto& ports, void* resource_handle_ptr1, void* reso
     * `resource_limited_multifunction_node`
     * `resource_consumer_multifunction_node`
 2. Should a Resource-Limited alternative for other node types be provided?
-3. How `resource_limited_node` should support node priorities?
+3. Should ``resource_limited_node`` support node priorities, and if so, how?
 4. Should the `output_ports()` member function be provided by `resource_limited_node`?
 5. Should the `rejecting` alternative be provided for `resource_limited_node`?
 6. Instead of a separate node type, should `resource_limited` be considered as a policy for existing functional nodes?


### PR DESCRIPTION
### Description 
Partially move the implemented part of resource limiting proposal to experimental (`resource_limiter` and `resource_limited_node` class design and API)


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
