### PR TITLE
[TCM] Add common paths to generated envars scripts

### DIFF
--- a/thread_composability_manager/integration/linux/vars/vars.sh.in
+++ b/thread_composability_manager/integration/linux/vars/vars.sh.in
@@ -157,6 +157,9 @@ if [ -e "$TCM_LIB_DIR" ]; then
   export TCMROOT
 
   LD_LIBRARY_PATH=$(prepend_path "${TCM_LIB_DIR}" "${LD_LIBRARY_PATH:-}") ; export LD_LIBRARY_PATH
+  LIBRARY_PATH=$(prepend_path "${TCM_LIB_DIR}" "${LIBRARY_PATH:-}") ; export LIBRARY_PATH
+  C_INCLUDE_PATH=$(prepend_path "${TCMROOT}/include" "${C_INCLUDE_PATH:-}"); export C_INCLUDE_PATH
+  CPLUS_INCLUDE_PATH=$(prepend_path "${TCMROOT}/include" "${CPLUS_INCLUDE_PATH:-}"); export CPLUS_INCLUDE_PATH
 else
   >&2 echo "ERROR: TCM library directory ${TCM_LIB_DIR} does not exist."
   return 255 2>/dev/null || exit 255

--- a/thread_composability_manager/integration/windows/vars/vars.bat.in
+++ b/thread_composability_manager/integration/windows/vars/vars.bat.in
@@ -36,6 +36,10 @@ if "%TCM_TARGET_ARCH%" == "ia32" (
 set "TCM_BIN_DIR=@BINARY_PATH_PLACEHOLDER@"
 
 if exist "%TCM_BIN_DIR%" (
+    set "INCLUDE=%TCMROOT%\include;%INCLUDE%"
+    set "C_INCLUDE_PATH=%TCMROOT%\include;%C_INCLUDE_PATH%"
+    set "CPLUS_INCLUDE_PATH=%TCMROOT%\include;%CPLUS_INCLUDE_PATH%"
+    set "LIB=@LIBRARY_PATH_PLACEHOLDER@;%LIB%"
     set "PATH=%TCM_BIN_DIR%;%PATH%"
 ) else (
     echo:
@@ -43,11 +47,6 @@ if exist "%TCM_BIN_DIR%" (
     echo:
     exit /b 255
 )
-
-set "INCLUDE=%TCMROOT%\include;%INCLUDE%"
-set "C_INCLUDE_PATH=%TCMROOT%\include;%C_INCLUDE_PATH%"
-set "CPLUS_INCLUDE_PATH=%TCMROOT%\include;%CPLUS_INCLUDE_PATH%"
-set "LIB=@LIBRARY_PATH_PLACEHOLDER@;%LIB%"
 
 :End
 exit /B 0

--- a/thread_composability_manager/integration/windows/vars/vars.bat.in
+++ b/thread_composability_manager/integration/windows/vars/vars.bat.in
@@ -44,5 +44,10 @@ if exist "%TCM_BIN_DIR%" (
     exit /b 255
 )
 
+set "INCLUDE=%TCMROOT%\include;%INCLUDE%"
+set "C_INCLUDE_PATH=%TCMROOT%\include;%C_INCLUDE_PATH%"
+set "CPLUS_INCLUDE_PATH=%TCMROOT%\include;%CPLUS_INCLUDE_PATH%"
+set "LIB=@LIBRARY_PATH_PLACEHOLDER@;%LIB%"
+
 :End
 exit /B 0


### PR DESCRIPTION
For development purposes having path to TCM binary only is usually not enough. This patch updates common environment paths that are used by compilers to find headers and lib files.